### PR TITLE
Fix Claude Code plugin marketplace manifest + add install smoke test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "quoin",
+  "owner": {
+    "name": "Agent IX"
+  },
+  "metadata": {
+    "description": "Spec authoring, review, matrix, and planning skills + workflows for Agent IX."
+  },
+  "plugins": [
+    {
+      "name": "quoin",
+      "source": "./",
+      "description": "Spec authoring, review, matrix, and planning skills for Agent IX."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,7 @@
   "name": "quoin",
   "version": "0.1.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
-  "skills": "./skills"
+  "author": {
+    "name": "Agent IX"
+  }
 }

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,27 @@
+name: install-smoke
+
+# Clean-room check that a brand-new community user can install quoin from public
+# npm and load its Claude Code plugin (skills/workflows). Uses PLUGIN_SOURCE=local
+# so it validates THIS revision's plugin manifest rather than whatever is already
+# on the default branch. No secrets required: plugin install is pure git, so the
+# "skills present" assertions run without auth (the live plugin-load check is
+# skipped when no subscription credential is present).
+
+on:
+  pull_request:
+  push:
+    tags: ["*.*.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clean-room install + plugin smoke (local plugin source)
+        env:
+          PLUGIN_SOURCE: local
+        run: ./smoke/run.sh

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,13 @@ evals:
 evals-all:
 	node evals/run.mjs --all --model $(MODEL) --repeats $(REPEATS)
 
+# Community install smoke test (clean-room Docker: public npm + Claude plugin).
+# Verifies an outside developer can `npm i -g @agent-ix/quoin` and load the
+# plugin (skills/workflows) into Claude Code. See smoke/README.md.
+.PHONY: install-smoke
+install-smoke:
+	./smoke/run.sh
+
 .PHONY: lint
 lint:
 	pnpm run lint

--- a/README.md
+++ b/README.md
@@ -66,12 +66,28 @@ Multi-agent workflows that fan out, run lenses in parallel, and synthesize resul
 
 ## Install
 
-Install `quoin` with `ix-flow` so the spec tooling and workflow lifecycle commands are
-both available:
+Installing quoin into Claude is **two steps**: the CLI (from public npm) and the plugin
+that adds the [skills](#skills) and [workflows](#workflows) to Claude Code. No Anthropic API
+key is required — your Claude subscription is used.
+
+**1. Install the CLIs** (`quoin` plus `ix-flow`, which runs the workflow lifecycle commands):
 
 ```bash
 npm install -g @agent-ix/quoin@latest @agent-ix/ix-flow@latest
 ```
+
+**2. Add the plugin to Claude Code** (run these inside Claude Code):
+
+```text
+/plugin marketplace add agent-ix/quoin
+/plugin install quoin@quoin
+```
+
+That registers quoin's spec-authoring skills and workflows so you can drive them by asking
+the agent. (To also get the `/ix-flow` runner skills, repeat step 2 for `agent-ix/ix-flow`.)
+
+> A clean-room, repeatable check of this exact install path lives in [`smoke/`](./smoke) —
+> run `make install-smoke`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 `quoin` is a bundle of **Quire modules**, **agent skills**, and **workflows** for
 authoring [ISO/IEC/IEEE 29148](https://www.iso.org/standard/72089.html)-aligned software specifications and other technical
-documents. It packages the spec vocabulary, the authoring/review/planning contracts,
-and the catalog/plugin tooling agents need to write and validate specs directly as Markdown.
+documents. It includes prepackaged modules for the spec vocabulary and ideation/authoring/review/planning
+workflows agents need to write and validate specs directly as Markdown.
 
 `quoin` is built on the [Quire](https://github.com/agent-ix/quire-rs) document standard and validation engine by Agent-IX.
 
@@ -29,7 +29,7 @@ The default module set defines the spec archetypes and domain-object vocabulary.
 | [spec-artifacts-app](https://github.com/agent-ix/spec-artifacts-app)         | `ApplicationSpec`, `MasterRequirements`                              |
 | [spec-artifacts-process](https://github.com/agent-ix/spec-artifacts-process) | `ADR`, `Plan`, `Task`, `Review`, `Finding`, `TestMatrix`, `Standard` |
 
-**Domain objects** — the entities you reference inside specs:
+**Domain objects** — the objects you reference inside specs:
 
 | Module                                                                             | Objects                                                                                                                                                                                                                                |
 | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "default-modules.yaml",
     "skills/",
     "bin/",
-    "plugin.json",
+    ".claude-plugin/",
     "LICENSE",
     "README.md"
   ],

--- a/smoke/Dockerfile
+++ b/smoke/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+#
+# Clean-room "community install" smoke image for @agent-ix/quoin.
+#
+# The build context is THIS directory (smoke/), which deliberately contains no
+# .npmrc and no @agent-ix scope override — so the container resolves packages
+# exactly like an outside developer on a fresh machine would.
+#
+# The package + Claude Code plugin are installed at RUNTIME (entrypoint), not at
+# build time, so bumping PKG_VERSION needs no rebuild.
+FROM node:24-bookworm-slim
+
+ARG CLAUDE_VERSION=latest
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git jq ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
+
+# Per-package identity consumed by the generic entrypoint/assert scripts.
+ENV PKG=@agent-ix/quoin \
+    BIN=quoin \
+    PLUGIN=quoin \
+    MARKETPLACE=quoin \
+    REPO=agent-ix/quoin \
+    HOME=/root
+
+COPY . /smoke
+RUN chmod +x /smoke/entrypoint.sh /smoke/assert.sh /smoke/run.sh
+
+ENTRYPOINT ["/smoke/entrypoint.sh"]

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -1,0 +1,48 @@
+# Community install smoke test
+
+A clean-room, repeatable check that a brand-new developer can install `quoin`
+from **public npm** and use it **inside Claude Code** with no Agent-IX internal
+config and no Anthropic API key.
+
+```bash
+make install-smoke                       # from the repo root (real community path)
+PLUGIN_SOURCE=local ./smoke/run.sh       # validate the working tree (what CI runs)
+PKG_VERSION=0.2.1 ./smoke/run.sh         # pin for byte-for-byte reproducibility
+```
+
+## Plugin source
+
+- `PLUGIN_SOURCE=github` (default) installs the plugin from `agent-ix/quoin` on
+  GitHub's default branch — the exact path a community user follows.
+- `PLUGIN_SOURCE=local` installs the plugin from the mounted checkout — validates
+  the manifest in *this* revision before it reaches the default branch. CI uses
+  this (see `.github/workflows/install-smoke.yml`) so a PR's own changes are
+  tested. No credentials needed; the live-load check is simply skipped.
+
+## What it does
+
+A fresh `node:24` container with **no `.npmrc` and no `@agent-ix` scope
+override** (exactly an outside user's machine):
+
+1. **Stage 1 — public npm.** `npm install -g @agent-ix/quoin` from
+   `registry.npmjs.org` and runs the `quoin` bin. Proves the published CLI and
+   its full dependency tree resolve from public npm with zero auth.
+2. **Stage 2 — Claude plugin.** Configures the `/plugin marketplace add
+   agent-ix/quoin` + `/plugin install quoin@quoin` flow non-interactively (via
+   `~/.claude/settings.json` + `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1`) and lets
+   Claude Code clone + install the plugin from the public GitHub repo.
+3. **Assert.** Verifies the plugin cloned and every skill/workflow in
+   [`expected.txt`](./expected.txt) is present (14 skills + 3 workflows). If the
+   host's Claude subscription credential is available it also confirms the live
+   session loaded the plugin.
+
+## Auth
+
+`run.sh` bind-mounts `~/.claude/.credentials.json` **read-only**; the token is
+never read or extracted, so the live load-check runs on your subscription with
+no API key. Marketplace cloning is plain git on a public repo, so the
+"skills present" assertions pass even without credentials — only the bonus
+live-load confirmation needs them.
+
+This complements the `agent-pty` evals (`make evals`), which measure a real
+agent's token/tool/latency behavior; this harness only verifies installability.

--- a/smoke/assert.sh
+++ b/smoke/assert.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Deterministic assertions. Reads expected.txt (lines: "plugin <name>",
+# "skill <slug>", "workflow <name>") and verifies each artifact landed after the
+# marketplace install. Two evidence sources:
+#   * filesystem — the cloned plugin under ~/.claude/plugins (always available;
+#     auth-independent, since marketplace cloning is plain git on a public repo)
+#   * live session — the `system/init` event from a real `claude -p` turn, which
+#     lists loaded plugins[], plugin_errors, and skills as slash_commands
+#     (available only when host subscription creds were mounted)
+# Exit non-zero on any miss.
+set -uo pipefail
+
+STREAM="${1:-/dev/null}"
+SMOKE_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXPECTED="$SMOKE_DIR/expected.txt"
+export HOME="${HOME:-/root}"
+CACHE="$HOME/.claude/plugins"
+fail=0
+
+PLUGIN_NAME="$(awk '/^plugin /{print $2; exit}' "$EXPECTED")"
+
+# The live session init event (only present when auth succeeded).
+INIT=""
+if [ -s "$STREAM" ]; then
+  INIT="$(jq -c 'select(.type=="system" and .subtype=="init")' "$STREAM" 2>/dev/null | head -1)"
+fi
+
+echo
+echo "## Assertions  (cache: $CACHE)"
+if [ ! -d "$CACHE" ]; then
+  echo "   FAIL  no plugin cache at $CACHE — marketplace install did not run"
+  sed 's/^/         /' /tmp/claude.err 2>/dev/null | head -20
+  exit 1
+fi
+
+# Is <skill> loaded as a Claude slash command (e.g. "quoin:specify")?
+live_has_skill() {
+  [ -n "$INIT" ] || return 2
+  echo "$INIT" | jq -e --arg s "$1" '(.slash_commands // []) | any(endswith(":"+$s) or . == $s)' >/dev/null 2>&1
+}
+
+while read -r kind name _; do
+  [ -z "${kind:-}" ] && continue
+  case "$kind" in
+    \#*) continue ;;
+    plugin)
+      fs="$(find "$CACHE" -type d -name "$name" 2>/dev/null | head -1)"
+      if [ -n "$fs" ]; then echo "   PASS  plugin cloned: $name"
+      else echo "   FAIL  plugin not cloned: $name"; fail=1; fi
+      if [ -n "$INIT" ]; then
+        if echo "$INIT" | jq -e --arg n "$name" '(.plugins // []) | any(.name==$n)' >/dev/null 2>&1; then
+          echo "   PASS  plugin loaded in live Claude session: $name"
+        else
+          echo "   FAIL  plugin NOT loaded in live Claude session: $name"; fail=1
+        fi
+        errs="$(echo "$INIT" | jq -c '.plugin_errors // empty' 2>/dev/null)"
+        if [ -n "$errs" ] && [ "$errs" != "null" ] && [ "$errs" != "[]" ]; then
+          echo "   FAIL  plugin_errors reported by Claude: $errs"; fail=1
+        fi
+      fi
+      ;;
+    skill)
+      hit="$(find "$CACHE" -path "*/skills/$name/SKILL.md" 2>/dev/null | head -1)"
+      if [ -n "$hit" ]; then echo "   PASS  skill present: $name"
+      else echo "   FAIL  skill MISSING: $name"; fail=1; fi
+      live_has_skill "$name" && echo "         · loaded as a Claude command"
+      ;;
+    workflow)
+      hit="$(find "$CACHE" -path "*/workflows/$name/def.yaml" 2>/dev/null | head -1)"
+      if [ -n "$hit" ]; then echo "   PASS  workflow present: $name"
+      else echo "   FAIL  workflow MISSING: $name"; fail=1; fi
+      ;;
+  esac
+done < "$EXPECTED"
+
+echo
+[ -z "$INIT" ] && echo "   note: no live Claude session captured (no/invalid creds) — live-load checks skipped"
+if [ "$fail" -eq 0 ]; then
+  echo "## RESULT: PASS — $PLUGIN_NAME installs from public npm and its skills/workflows are present"
+else
+  echo "## RESULT: FAIL — see misses above"
+fi
+exit "$fail"

--- a/smoke/entrypoint.sh
+++ b/smoke/entrypoint.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Runs inside the clean-room container. Two stages, then assertions:
+#   Stage 1  install the published CLI from PUBLIC npm (no auth, no .npmrc)
+#   Stage 2  install the Claude Code plugin and its skills/workflows
+#   assert   the CLI bin runs, the plugin installed, its skills/workflows exist
+#
+# PLUGIN_SOURCE selects where the plugin comes from:
+#   github (default)  /plugin marketplace add agent-ix/<repo>  — the real
+#                     community path, validating what's live on GitHub's default
+#                     branch. Used by `make install-smoke`.
+#   local             marketplace add /repo (the mounted checkout) — validates
+#                     THIS revision's plugin manifest. Used by CI on PRs, where
+#                     the fix may not have reached the default branch yet.
+#
+# Subscription auth (host ~/.claude/.credentials.json mounted at /seed) is
+# OPTIONAL: plugin marketplace add/install are pure git + local cache and need
+# no Anthropic auth, so the "skills present" checks are deterministic with or
+# without creds. Creds only enable the bonus "Claude actually loaded the plugin
+# and exposes its skills as commands" confirmation from a live session.
+set -uo pipefail
+
+: "${PKG:?PKG not set}"
+: "${BIN:?BIN not set}"
+: "${REPO:?REPO not set}"
+: "${PLUGIN:?PLUGIN not set}"
+: "${MARKETPLACE:?MARKETPLACE not set}"
+PKG_VERSION="${PKG_VERSION:-latest}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-github}"
+PUBLIC_REGISTRY="https://registry.npmjs.org/"
+export HOME="${HOME:-/root}"
+
+mkdir -p "$HOME/.claude"
+
+echo "=================================================================="
+echo " Community install smoke test: $PKG  (plugin source: $PLUGIN_SOURCE)"
+echo " clean room: $(node -v) / npm $(npm -v) / claude $(claude --version 2>/dev/null || echo '?')"
+echo "=================================================================="
+
+if [ -f "$HOME/.npmrc" ] || [ -f /etc/npmrc ]; then
+  echo "WARN: an .npmrc exists in the image — clean-room assumption weakened"
+fi
+
+# --- Auth (optional): seed the mounted host subscription credential ---
+LIVE=0
+if [ -f /seed/.credentials.json ]; then
+  cp /seed/.credentials.json "$HOME/.claude/.credentials.json"
+  chmod 600 "$HOME/.claude/.credentials.json"
+  [ -f /seed/.claude.json ] && cp /seed/.claude.json "$HOME/.claude.json" || echo '{}' > "$HOME/.claude.json"
+  LIVE=1
+  echo "auth: seeded host subscription credential (live plugin-load check enabled)"
+else
+  echo '{}' > "$HOME/.claude.json"
+  echo "auth: no credential mounted (filesystem-only checks; live load check skipped)"
+fi
+
+# ======================================================================
+echo
+echo "## Stage 1 — install published CLI from PUBLIC npm"
+echo "   npm install -g $PKG@$PKG_VERSION  (registry: $PUBLIC_REGISTRY)"
+if ! npm install -g "$PKG@$PKG_VERSION" --registry="$PUBLIC_REGISTRY"; then
+  echo "FAIL: public npm install of $PKG failed"
+  exit 1
+fi
+RESOLVED="$(npm ls -g "$PKG" --depth=0 2>/dev/null | grep -oE "${PKG}@[0-9][^ ]*" | head -1)"
+echo "   resolved: ${RESOLVED:-unknown}"
+if "$BIN" --help >/dev/null 2>&1; then
+  echo "   PASS  '$BIN --help' runs"
+else
+  echo "   FAIL  '$BIN --help' did not run:"; "$BIN" --help || true
+  exit 1
+fi
+
+# ======================================================================
+echo
+echo "## Stage 2 — install Claude Code plugin"
+case "$PLUGIN_SOURCE" in
+  local)
+    MARKET_SRC=/repo
+    if [ ! -f /repo/.claude-plugin/marketplace.json ]; then
+      echo "   FAIL  PLUGIN_SOURCE=local but /repo/.claude-plugin/marketplace.json is missing"
+      echo "         (mount the repo checkout at /repo, or this repo lacks a marketplace manifest)"
+      exit 1
+    fi
+    ;;
+  github) MARKET_SRC="$REPO" ;;
+  *) echo "   FAIL  unknown PLUGIN_SOURCE=$PLUGIN_SOURCE"; exit 2 ;;
+esac
+echo "   claude plugin marketplace add $MARKET_SRC"
+claude plugin marketplace add "$MARKET_SRC" || echo "   (marketplace add reported non-zero — see assertions)"
+echo "   claude plugin install $PLUGIN@$MARKETPLACE"
+claude plugin install "$PLUGIN@$MARKETPLACE" || echo "   (plugin install reported non-zero — see assertions)"
+
+# Optional live session: capture the system/init event for the load check.
+STREAM=/tmp/init.stream.jsonl
+: > "$STREAM"
+if [ "$LIVE" = 1 ]; then
+  timeout 180 claude -p "Reply with the single word: ok" \
+    --output-format stream-json --verbose \
+    </dev/null >"$STREAM" 2>/tmp/claude.err \
+    || echo "   note: claude print-turn exited non-zero (plugin install already ran above)"
+fi
+
+# ======================================================================
+/smoke/assert.sh "$STREAM"

--- a/smoke/expected.txt
+++ b/smoke/expected.txt
@@ -1,0 +1,20 @@
+# Artifacts a fresh community user must get after installing the quoin plugin.
+# Format: "<kind> <name>"   kind ∈ {plugin, skill, workflow}
+plugin quoin
+skill specify
+skill spec-review
+skill spec-matrix
+skill spec-to-plan
+skill spec-ideation
+skill spec-integrity-analysis
+skill spec-dependency-analysis
+skill spec-evidence-analysis
+skill spec-failure-domain-analysis
+skill spec-scope-boundary-analysis
+skill spec-risk-complexity-analysis
+skill spec-security-analysis
+skill spec-app-review
+skill spec-object-review
+workflow review
+workflow matrix
+workflow to-plan

--- a/smoke/run.sh
+++ b/smoke/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Host-side driver: build the clean-room image and run the smoke test.
+#
+# Mounts the host's Claude subscription credential read-only when present (never
+# read/extracted — only the file is bind-mounted, so the live "plugin loaded"
+# check uses your subscription with no API key). Without it, the test still runs
+# filesystem-only checks.
+#
+# Env knobs:
+#   PKG_VERSION     published version to install from npm (default: latest)
+#   CLAUDE_VERSION  Claude Code version in the image (default: latest)
+#   PLUGIN_SOURCE   github (default; real community path) | local (this checkout)
+#
+# Examples:
+#   make install-smoke
+#   PLUGIN_SOURCE=local ./smoke/run.sh          # validate the working tree (CI)
+#   PKG_VERSION=0.2.1 ./smoke/run.sh            # pin for reproducibility
+set -euo pipefail
+
+SMOKE_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SMOKE_DIR/.." && pwd)"
+IMAGE="quoin-install-smoke"
+PKG_VERSION="${PKG_VERSION:-latest}"
+CLAUDE_VERSION="${CLAUDE_VERSION:-latest}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-github}"
+
+echo ">> build $IMAGE (CLAUDE_VERSION=$CLAUDE_VERSION)"
+docker build -t "$IMAGE" --build-arg CLAUDE_VERSION="$CLAUDE_VERSION" "$SMOKE_DIR"
+
+args=(--rm -e PKG_VERSION="$PKG_VERSION" -e PLUGIN_SOURCE="$PLUGIN_SOURCE")
+
+if [ "$PLUGIN_SOURCE" = "local" ]; then
+  args+=(-v "$REPO_ROOT:/repo:ro")
+  echo ">> plugin source: local checkout ($REPO_ROOT)"
+else
+  echo ">> plugin source: github:agent-ix (real community path)"
+fi
+
+creds="$HOME/.claude/.credentials.json"
+if [ -f "$creds" ]; then
+  args+=(-v "$creds:/seed/.credentials.json:ro")
+  [ -f "$HOME/.claude.json" ] && args+=(-v "$HOME/.claude.json:/seed/.claude.json:ro")
+  echo ">> mounting host subscription credential (live plugin-load check enabled)"
+else
+  echo ">> no host credential found — filesystem-only checks"
+fi
+
+echo ">> run smoke (PKG_VERSION=$PKG_VERSION)"
+docker run "${args[@]}" "$IMAGE"


### PR DESCRIPTION
## The bug this caught

quoin shipped only a root `plugin.json` and **no `.claude-plugin/marketplace.json`**. So `/plugin marketplace add agent-ix/quoin` found nothing, and a brand-new community user had **no working way to load quoin's 14 skills + 3 workflows into Claude Code** — even though the README implied `npm install` was enough.

This was surfaced by the new clean-room smoke test (also in this PR): Stage 1 (public npm install) passed, Stage 2 (Claude plugin) failed with "plugin not cloned".

## The fix (mirrors ix-flow's working structure)

- add **`.claude-plugin/marketplace.json`** (the missing manifest; `claude plugin validate` passes clean)
- move the stale root `plugin.json` → `.claude-plugin/plugin.json` (canonical location; nothing read the root copy except `package.json` `files`)
- ship `.claude-plugin/` in the npm `files` list
- **README**: document the real two-part install — `npm i -g …` **and** `/plugin marketplace add agent-ix/quoin` + `/plugin install quoin@quoin`. No Anthropic API key; your subscription is used.

Verified locally: a plugin install now loads all **14 skills + 3 workflows** as Claude commands.

## The smoke test

`smoke/` + `make install-smoke`: a fresh `node:24` container with **no `.npmrc`/scope override** installs `@agent-ix/quoin` from public npm and the plugin from the marketplace, then asserts every skill/workflow in [`smoke/expected.txt`](smoke/expected.txt) is present (and, with a mounted host subscription credential, that a live Claude session loaded them).

## CI

`.github/workflows/install-smoke.yml` runs on PRs + release tags with `PLUGIN_SOURCE=local`, so the PR validates **its own** manifest (not whatever is on `main`). Secret-free — plugin install is pure git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)