### PR TITLE
smoke: hard-gate that skills are usable as slash commands

### DIFF
--- a/smoke/README.md
+++ b/smoke/README.md
@@ -17,7 +17,7 @@ PKG_VERSION=0.2.1 ./smoke/run.sh         # pin for byte-for-byte reproducibility
 - `PLUGIN_SOURCE=local` installs the plugin from the mounted checkout — validates
   the manifest in *this* revision before it reaches the default branch. CI uses
   this (see `.github/workflows/install-smoke.yml`) so a PR's own changes are
-  tested. No credentials needed; the live-load check is simply skipped.
+  tested.
 
 ## What it does
 
@@ -27,22 +27,27 @@ override** (exactly an outside user's machine):
 1. **Stage 1 — public npm.** `npm install -g @agent-ix/quoin` from
    `registry.npmjs.org` and runs the `quoin` bin. Proves the published CLI and
    its full dependency tree resolve from public npm with zero auth.
-2. **Stage 2 — Claude plugin.** Configures the `/plugin marketplace add
-   agent-ix/quoin` + `/plugin install quoin@quoin` flow non-interactively (via
-   `~/.claude/settings.json` + `CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1`) and lets
-   Claude Code clone + install the plugin from the public GitHub repo.
-3. **Assert.** Verifies the plugin cloned and every skill/workflow in
-   [`expected.txt`](./expected.txt) is present (14 skills + 3 workflows). If the
-   host's Claude subscription credential is available it also confirms the live
-   session loaded the plugin.
+2. **Stage 2 — Claude plugin.** `claude plugin marketplace add` + `plugin
+   install` (the CLI form of the README's `/plugin` steps) clone and install the
+   plugin.
+3. **Assert.** For every skill/workflow in [`expected.txt`](./expected.txt) (14
+   skills + 3 workflows): the file is present in the plugin cache **and** — the
+   part that matters to a user — the skill is exposed as a usable `/command`.
+   That comes from Claude's `system/init` event (loaded `plugins[]`,
+   `plugin_errors`, and skills as `slash_commands`), which Claude emits **before
+   authentication**, so the whole test is deterministic and needs **no
+   credentials**. A skill present on disk but missing from the command list is a
+   FAIL — the "installed but I don't see it in Claude" failure mode.
 
 ## Auth
 
-`run.sh` bind-mounts `~/.claude/.credentials.json` **read-only**; the token is
-never read or extracted, so the live load-check runs on your subscription with
-no API key. Marketplace cloning is plain git on a public repo, so the
-"skills present" assertions pass even without credentials — only the bonus
-live-load confirmation needs them.
+None required. The plugin install is plain git and the slash-command check reads
+the pre-auth init event, so everything runs without an Anthropic API key or a
+subscription token — which is what makes it CI-friendly.
+
+(`run.sh` will bind-mount `~/.claude/.credentials.json` read-only if present, so
+the `claude -p` probe can also complete a real turn on your subscription; the
+token is never read or extracted. It is optional and changes no assertions.)
 
 This complements the `agent-pty` evals (`make evals`), which measure a real
 agent's token/tool/latency behavior; this harness only verifies installability.

--- a/smoke/assert.sh
+++ b/smoke/assert.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 #
 # Deterministic assertions. Reads expected.txt (lines: "plugin <name>",
-# "skill <slug>", "workflow <name>") and verifies each artifact landed after the
-# marketplace install. Two evidence sources:
-#   * filesystem — the cloned plugin under ~/.claude/plugins (always available;
-#     auth-independent, since marketplace cloning is plain git on a public repo)
-#   * live session — the `system/init` event from a real `claude -p` turn, which
-#     lists loaded plugins[], plugin_errors, and skills as slash_commands
-#     (available only when host subscription creds were mounted)
+# "skill <slug>", "workflow <name>") and verifies, after the marketplace
+# install, that each artifact is present AND usable. Evidence:
+#   * filesystem — the cloned plugin under ~/.claude/plugins (skill/workflow files)
+#   * session init — the `system/init` event from `claude -p`, listing loaded
+#     plugins[], plugin_errors, and skills as slash_commands. init is emitted
+#     before auth, so these checks are deterministic and need no credentials.
+#
+# A skill that exists on disk but is NOT exposed as a /command is a FAIL — that
+# is the "installed but I don't see it in Claude" failure mode this guards.
 # Exit non-zero on any miss.
 set -uo pipefail
 
@@ -20,11 +22,8 @@ fail=0
 
 PLUGIN_NAME="$(awk '/^plugin /{print $2; exit}' "$EXPECTED")"
 
-# The live session init event (only present when auth succeeded).
 INIT=""
-if [ -s "$STREAM" ]; then
-  INIT="$(jq -c 'select(.type=="system" and .subtype=="init")' "$STREAM" 2>/dev/null | head -1)"
-fi
+[ -s "$STREAM" ] && INIT="$(jq -c 'select(.type=="system" and .subtype=="init")' "$STREAM" 2>/dev/null | head -1)"
 
 echo
 echo "## Assertions  (cache: $CACHE)"
@@ -33,10 +32,16 @@ if [ ! -d "$CACHE" ]; then
   sed 's/^/         /' /tmp/claude.err 2>/dev/null | head -20
   exit 1
 fi
+if [ -z "$INIT" ]; then
+  echo "   FAIL  no Claude session init captured — cannot confirm the plugin loaded"
+  echo "         (claude -p must emit a system/init event; claude stderr:)"
+  sed 's/^/         /' /tmp/claude.err 2>/dev/null | head -20
+  fail=1
+fi
 
-# Is <skill> loaded as a Claude slash command (e.g. "quoin:specify")?
-live_has_skill() {
-  [ -n "$INIT" ] || return 2
+# Is <skill> exposed as a usable slash command (e.g. "ix-flow:ix-flow")?
+slash_has() {
+  [ -n "$INIT" ] || return 1
   echo "$INIT" | jq -e --arg s "$1" '(.slash_commands // []) | any(endswith(":"+$s) or . == $s)' >/dev/null 2>&1
 }
 
@@ -45,39 +50,36 @@ while read -r kind name _; do
   case "$kind" in
     \#*) continue ;;
     plugin)
-      fs="$(find "$CACHE" -type d -name "$name" 2>/dev/null | head -1)"
-      if [ -n "$fs" ]; then echo "   PASS  plugin cloned: $name"
+      if [ -n "$(find "$CACHE" -type d -name "$name" 2>/dev/null | head -1)" ]; then
+        echo "   PASS  plugin cloned: $name"
       else echo "   FAIL  plugin not cloned: $name"; fail=1; fi
       if [ -n "$INIT" ]; then
         if echo "$INIT" | jq -e --arg n "$name" '(.plugins // []) | any(.name==$n)' >/dev/null 2>&1; then
-          echo "   PASS  plugin loaded in live Claude session: $name"
-        else
-          echo "   FAIL  plugin NOT loaded in live Claude session: $name"; fail=1
-        fi
-        errs="$(echo "$INIT" | jq -c '.plugin_errors // empty' 2>/dev/null)"
-        if [ -n "$errs" ] && [ "$errs" != "null" ] && [ "$errs" != "[]" ]; then
-          echo "   FAIL  plugin_errors reported by Claude: $errs"; fail=1
-        fi
+          echo "   PASS  plugin loaded in Claude session: $name"
+        else echo "   FAIL  plugin NOT loaded in Claude session: $name"; fail=1; fi
+        errs="$(echo "$INIT" | jq -c '(.plugin_errors // []) | select(length>0)' 2>/dev/null)"
+        [ -n "$errs" ] && { echo "   FAIL  plugin_errors reported by Claude: $errs"; fail=1; }
       fi
       ;;
     skill)
-      hit="$(find "$CACHE" -path "*/skills/$name/SKILL.md" 2>/dev/null | head -1)"
-      if [ -n "$hit" ]; then echo "   PASS  skill present: $name"
-      else echo "   FAIL  skill MISSING: $name"; fail=1; fi
-      live_has_skill "$name" && echo "         · loaded as a Claude command"
+      if [ -n "$(find "$CACHE" -path "*/skills/$name/SKILL.md" 2>/dev/null | head -1)" ]; then
+        echo "   PASS  skill file present: $name"
+      else echo "   FAIL  skill file MISSING: $name"; fail=1; fi
+      if slash_has "$name"; then
+        echo "   PASS  skill usable as /command: $name"
+      else echo "   FAIL  skill NOT usable as a /command: $name"; fail=1; fi
       ;;
     workflow)
-      hit="$(find "$CACHE" -path "*/workflows/$name/def.yaml" 2>/dev/null | head -1)"
-      if [ -n "$hit" ]; then echo "   PASS  workflow present: $name"
+      if [ -n "$(find "$CACHE" -path "*/workflows/$name/def.yaml" 2>/dev/null | head -1)" ]; then
+        echo "   PASS  workflow present: $name"
       else echo "   FAIL  workflow MISSING: $name"; fail=1; fi
       ;;
   esac
 done < "$EXPECTED"
 
 echo
-[ -z "$INIT" ] && echo "   note: no live Claude session captured (no/invalid creds) — live-load checks skipped"
 if [ "$fail" -eq 0 ]; then
-  echo "## RESULT: PASS — $PLUGIN_NAME installs from public npm and its skills/workflows are present"
+  echo "## RESULT: PASS — $PLUGIN_NAME installs from public npm; skills present and usable as /commands"
 else
   echo "## RESULT: FAIL — see misses above"
 fi

--- a/smoke/entrypoint.sh
+++ b/smoke/entrypoint.sh
@@ -91,15 +91,17 @@ claude plugin marketplace add "$MARKET_SRC" || echo "   (marketplace add reporte
 echo "   claude plugin install $PLUGIN@$MARKETPLACE"
 claude plugin install "$PLUGIN@$MARKETPLACE" || echo "   (plugin install reported non-zero — see assertions)"
 
-# Optional live session: capture the system/init event for the load check.
+# Capture the session init event. It lists loaded plugins[], plugin_errors, and
+# every skill exposed as a slash command (e.g. "ix-flow:ix-flow") — the
+# user-visible "installed AND usable" surface. init is emitted before
+# authentication, so this works WITHOUT credentials and gives CI the same
+# deterministic signal (the turn itself may then fail auth; we only need init).
 STREAM=/tmp/init.stream.jsonl
 : > "$STREAM"
-if [ "$LIVE" = 1 ]; then
-  timeout 180 claude -p "Reply with the single word: ok" \
-    --output-format stream-json --verbose \
-    </dev/null >"$STREAM" 2>/tmp/claude.err \
-    || echo "   note: claude print-turn exited non-zero (plugin install already ran above)"
-fi
+timeout 180 claude -p "Reply with the single word: ok" \
+  --output-format stream-json --verbose \
+  </dev/null >"$STREAM" 2>/tmp/claude.err \
+  || echo "   note: claude print-turn exited non-zero (init event still captured for assertions)"
 
 # ======================================================================
 /smoke/assert.sh "$STREAM"


### PR DESCRIPTION
## Why

The smoke test asserted skill **files** were present, but the user-visible outcome — a skill showing up as a usable `/command` in Claude — was only a *soft* check, and only ran when host credentials were mounted. So a skill could install on disk yet never register as a command (the "I installed it but I do not see the commands" failure) and the test would still pass.

## What

- Capture the `claude -p` `system/init` event **unconditionally**. It lists loaded `plugins[]`, `plugin_errors`, and every skill as a `slash_commands` entry (`<plugin>:<skill>`), and Claude emits it **before authentication** — so it works with **no credentials**.
- Make **"skill usable as /command"** a **hard, always-on** assertion (plus `plugin loaded` and empty `plugin_errors`). A skill present on disk but absent from the command list now FAILs.
- Because it needs no secret, CI enforces it too. Docs updated.

Verified locally in the exact CI config (local source, no creds): every skill passes both `skill file present` and `skill usable as /command`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)