### PR TITLE
porting spec from prototype

### DIFF
--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -24,10 +24,8 @@ Coverage is mapped requirement → test as `file :: "test name"`:
 
 > Coverage gate: `vite.config.ts` declares 100% v8 thresholds
 > (branches/functions/lines/statements). `make test` (`vitest run`) passes all
-> 97 tests; `pnpm run test:coverage` currently **fails the gate** at 99.61%
-> lines / 98.24% funcs — the only gap is the `(p) => p.name` mapping in
-> `cli.ts:322` (`plugin ensure-defaults`), exercised only when the registry is
-> non-empty (see Backsync Notes).
+> 99 tests and `pnpm run test:coverage` passes the gate at **100%**
+> (branches/functions/lines/statements).
 
 ## Functional Requirements
 
@@ -49,7 +47,7 @@ Coverage is mapped requirement → test as `file :: "test name"`:
 | FR-014      | ✅ Covered | `write.test.ts` :: "renders an authoring pack as text"; :: "renders an authoring pack as JSON with --json"; :: "renders skeleton+schema, manifest-only, and object contracts"; :: "does not emit a manifest-only line when a contract has artifacts"                                                                                                                                                                            |
 | FR-015      | ✅ Covered | `write.test.ts` :: "builds a pack with contracts and a non-quoted clean repo path"; :: "quotes a repo path containing a space (shellQuote quoting branch)"; `index.test.ts` :: validation.command asserts `quire validate --scope`                                                                                                                                                                                              |
 | FR-016      | ✅ Covered | `index.test.ts` :: "ships the committed default module set" (asserts `default-modules.yaml` validates as a marketplace manifest with the expected entries)                                                                                                                                                                                                                                                                      |
-| FR-017      | ✅ Covered | `index.test.ts` :: "lazily installs the default module set, then loads its artifacts and objects"; `cli.test.ts` :: "ensure-defaults runs the installer and reports the registry"                                                                                                                                                                                                                                               |
+| FR-017      | ✅ Covered | `index.test.ts` :: "lazily installs the default module set, then loads its artifacts and objects"; `cli.test.ts` :: "ensure-defaults runs the installer and reports the registry"; :: "ensure-defaults reports installed plugin names from a non-empty registry"                                                                                                                                                                |
 | FR-018      | ✅ Covered | `plugins.test.ts` :: "path: prefix"; :: "github: with @ref"; :: "github: without ref leaves ref undefined"; :: "github: with //subdir maps to a git-subdir source (with ref)"; :: "github: with //subdir and no ref leaves ref undefined"; :: "package: npm with @version"; :: "package: npm without version"; :: "scoped package: npm keeps the scope @, splits on the last @"; :: "bare argument falls back to a path source" |
 | FR-019      | ✅ Covered | `plugins.test.ts` :: "install adds a plugin from a path source"; :: "installs, lists, then removes a plugin and its target dir + registry entry"; readModuleName suite ("reads the name from a top-level manifest.yaml"…); `cli.test.ts` :: "install without a source throws"; :: "remove without a name throws"; :: "remove deletes a plugin and prints confirmation"                                                          |
 | FR-020      | ✅ Covered | `flows.test.ts` :: "lists the bundled spec flows"; :: "throws for an unknown flow name"; `flows-notfound.test.ts` :: "throws when no candidate root contains the skill"                                                                                                                                                                                                                                                         |
@@ -66,7 +64,7 @@ Coverage is mapped requirement → test as `file :: "test name"`:
 | NFR-005     | ⚠️ Review  | Workflow launchers reference catalog modules via `flows.ts` and the bundled skills; no automated assertion. Verified by review.                                                                                                                                              |
 | NFR-006     | ⚠️ Review  | The agent-pty harness (`evals/run.mjs`) records latency, tokens, tool calls, validation attempts, and context fetches from the Claude Code transcript; defined in `spec/evals.md`, implemented in `evals/`.                                                                  |
 | NFR-007     | ✅ Covered | `flows.test.ts` :: "rejects when ix-flow cannot be spawned (PATH has no ix-flow)"; :: "sets process.exitCode when ix-flow exits non-zero"; `write.test.ts` validation-command tests confirm `quire` is emitted, not executed. (Version pinning is an accepted gap — Review.) |
-| NFR-008     | ⚠️ Review  | `catalog.test.ts` :: "skips candidates that do not resolve to a module root" covers the missing-manifest skip. The strict-abort path on a present-but-unparseable `manifest.yaml` has **no dedicated test** (see Backsync Notes).                                            |
+| NFR-008     | ✅ Covered | `catalog.test.ts` :: "skips candidates that do not resolve to a module root" (missing-manifest skip); :: "aborts (strict) on a present but unparseable manifest.yaml" (strict-abort path).                                                                                   |
 
 ## Use Case Coverage
 
@@ -98,12 +96,9 @@ the Claude Code transcript. This unit-test matrix does not duplicate that table.
   scenarios live in `spec/evals.md`.
 - US trace targets were re-pointed to the new FR IDs and US-006 (duplicate
   detection) was added to cover `catalog validate`.
-- **Untested strict-abort (NFR-008):** the loader skips a candidate with no
-  `manifest.yaml` (tested) but throws on a present-but-unparseable
-  `manifest.yaml` (untested). A fixture with a corrupt `manifest.yaml` asserting
-  the abort would close this.
-- **Open coverage gap (FR-017):** `cli.test.ts` :: "ensure-defaults runs the
-  installer and reports the registry" runs against an empty registry, so the
-  `(p) => p.name` mapping at `cli.ts:322` is never executed and the 100%
-  coverage gate fails. Closing it needs an `ensure-defaults` case where
-  `listPlugins()` returns ≥1 plugin (assert the reported `plugins` array).
+- **Strict-abort (NFR-008) — RESOLVED:** `catalog.test.ts` :: "aborts (strict)
+  on a present but unparseable manifest.yaml" now covers the corrupt-manifest
+  path alongside the missing-manifest skip.
+- **Coverage gate (FR-017) — RESOLVED:** `cli.test.ts` :: "ensure-defaults
+  reports installed plugin names from a non-empty registry" exercises the
+  `(p) => p.name` mapping; `pnpm run test:coverage` now passes at 100%.

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -6,61 +6,104 @@ type: TestMatrix
 
 # quoin Phase 0 Matrix
 
-Tests live in `tests/` and run under vitest (`make test` → `vitest run`):
-`index.test.ts` covers the catalog/install/write library surface;
-`cli.test.ts` and `cli-version-missing.test.ts` cover the full `main()`
-dispatch; `flows.test.ts` and `flows-notfound.test.ts` cover the workflow
-launchers; `write.test.ts`, `catalog.test.ts`, and `plugins.test.ts` cover those
-modules; `scripts.test.ts` covers the CLI help/version surface.
+Tests live in `tests/` and run under vitest (`make test` → `vitest run`).
+Coverage is mapped requirement → test as `file :: "test name"`:
+
+- `cli.test.ts` / `cli-version-missing.test.ts` — `main()` dispatch, arg
+  grammar, version, help, config root, `runCatalog`/`runPlugin`/`runWrite`.
+- `catalog.test.ts` — `defaultModuleRoots`, `loadCatalog`, `findCatalogEntry`,
+  `findDuplicates`, module-root location.
+- `write.test.ts` — `parseTypeList`, `createAuthoringPack`,
+  `formatAuthoringPack`, `shellQuote`.
+- `plugins.test.ts` — `parseSourceArg`, install/list/remove, `readModuleName`.
+- `modules` coverage via `index.test.ts` (default-set reconcile + manifest).
+- `flows.test.ts` / `flows-notfound.test.ts` — workflow launchers and the real
+  fake `ix-flow` binary (exit 0 / non-zero / signal / spawn-error).
+- `scripts.test.ts` — built CLI help/version surface.
+- `index.test.ts` — the public library surface end to end.
 
 > Coverage gate: `vite.config.ts` declares 100% v8 thresholds
-> (branches/functions/lines/statements). `pnpm run test:coverage` now **passes
-> at 100%** — the previously-uncovered `flows.ts` and the
-> `runCatalog`/`runPlugin`/`runWrite` dispatch paths are now fully tested.
+> (branches/functions/lines/statements). `make test` (`vitest run`) passes all
+> 97 tests; `pnpm run test:coverage` currently **fails the gate** at 99.61%
+> lines / 98.24% funcs — the only gap is the `(p) => p.name` mapping in
+> `cli.ts:322` (`plugin ensure-defaults`), exercised only when the registry is
+> non-empty (see Backsync Notes).
 
-| Requirement | Coverage   | Test (file :: name)                                                                                                                                                                                                                                                                                                                      |
-| ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FR-001      | ✅ Covered | `index.test.ts` :: "lazily installs the default module set, then loads its artifacts and objects"; `cli.test.ts` :: "ensure-defaults runs the installer and reports the registry" (explicit `quoin plugin ensure-defaults` entry point)                                                                                                  |
-| FR-002      | ✅ Covered | `index.test.ts` :: "installs, lists, and removes a plugin from a local path source" (registry + `~/.ix/filament/modules`)                                                                                                                                                                                                                |
-| FR-003      | ✅ Covered | `cli.test.ts` `runCatalog` suite — list/undefined/`--json`/show/show-missing/show-not-found/validate-ok/`--json`/duplicates→exit 1/unknown-subcommand; `catalog.test.ts` exercises `loadCatalog`/`findCatalogEntry`.                                                                                                                     |
-| FR-004      | ✅ Covered | `index.test.ts` :: "creates authoring packs for case-insensitive artifact and object types"                                                                                                                                                                                                                                              |
-| FR-005      | ✅ Covered | `index.test.ts` :: "creates authoring packs…" (asserts `["fr","DOMAIN"]` → `["FR","domain"]`)                                                                                                                                                                                                                                            |
-| FR-006      | ✅ Covered | `flows.test.ts` exercises `specFlowNames`/`startSpecFlow`/`resolveSkillPath`/`runIxFlow` (real fake `ix-flow` binary: exit 0 / non-zero / signal / spawn-error, `workflow-assets` layout); `cli.test.ts` covers spec-flow dispatch through `main`.                                                                                       |
-| FR-007      | ✅ Covered | `index.test.ts` :: "creates authoring packs…" (asserts `validation.command` contains `quire validate --scope`)                                                                                                                                                                                                                           |
-| FR-008      | ✅ Covered | `spec/evals.md` (Matrix-002) maps EV-001…EV-015 to US-001…US-005                                                                                                                                                                                                                                                                         |
-| FR-009      | ✅ Covered | `index.test.ts` :: "ships the committed default module set" (asserts `default-modules.yaml` has 8 entries incl. `spec-objects-business`)                                                                                                                                                                                                 |
-| FR-010      | ✅ Covered | `plugins.test.ts` :: "parseSourceArg" covers `path:`/`github:`(±`@ref`)/`package:`→npm/bare-path; `cli.test.ts` covers `plugin install` dispatch. The npm-unsupported-at-resolve error is owned + tested by ts-plugin-kit.                                                                                                               |
-| FR-011      | ✅ Covered | `catalog.test.ts` :: `defaultModuleRoots` asserts the `QUOIN_MODULE_PATHS`-first ordering + the `~/.ix/filament/modules` installed dir. The quire-rs shared-store contract is cross-repo (asserted in quire-rs).                                                                                                                         |
-| NFR-001     | ⚠️ Review  | Workflow launchers reference catalog modules via `flows.ts`; no automated assertion. Verified by review.                                                                                                                                                                                                                                 |
-| NFR-002     | ✅ Covered | The agent-pty-driven harness (`evals/run.mjs`) drives the real agent and records the metrics (latency, tokens, tool calls, validation attempts, context fetches) **for real** from the Claude Code transcript; defined in `spec/evals.md`, implemented in `evals/`. Canaries EV-001/EV-008 verified live; full set via `make evals-all`. |
-| NFR-003     | ✅ Covered | `index.test.ts` :: "lazily installs the default module set…" runs `ensureDefaultModules` against path-source fixtures (no network); reconcile is `mode: "lazy"`. Re-run idempotence is exercised indirectly across tests sharing fixtures; a dedicated double-call assertion is not present (see findings).                              |
+## Functional Requirements
+
+| Requirement | Coverage   | Test (file :: name)                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-001      | ✅ Covered | `cli.test.ts` :: "long flag with = and following-value form both work"; :: "boolean long flag (no value) is honored"; :: "subcommand is only captured for catalog/plugin; others become positionals"                                                                                                                                                                                                                            |
+| FR-002      | ✅ Covered | `cli.test.ts` :: "--version, -v, and the version command all print the package version"; :: "returns a non-empty version string"; `cli-version-missing.test.ts` :: "throws when package.json has no string version"                                                                                                                                                                                                             |
+| FR-003      | ✅ Covered | `cli.test.ts` :: "no command prints the top-level usage"; :: "--help and -h print command help"; :: "--help on an unrecognized command falls back to the top-level usage"; :: "help for a spec-flow command prints the workflow usage"                                                                                                                                                                                          |
+| FR-004      | ✅ Covered | `cli.test.ts` :: "falls back to IX_HOME when --config-root is omitted, and prints 'unknown' for a versionless module"; :: "--no-project-config short-circuits project config root"                                                                                                                                                                                                                                              |
+| FR-005      | ✅ Covered | `cli.test.ts` :: "throws on an unknown command"; :: "unknown catalog subcommand throws"; :: "unknown plugin subcommand throws"                                                                                                                                                                                                                                                                                                  |
+| FR-006      | ✅ Covered | `catalog.test.ts` :: "discovers a manifest one level deep under a candidate dir"; :: "skips a candidate that is a file, not a directory"; :: "skips a non-manifest child while scanning one level deep, then finds the manifest sibling"; :: "skips candidates that do not resolve to a module root"                                                                                                                            |
+| FR-007      | ✅ Covered | `catalog.test.ts` :: "includes QUOIN_MODULE_PATHS entries and installed module dirs"; :: "omits installed dirs when none have been installed"                                                                                                                                                                                                                                                                                   |
+| FR-008      | ✅ Covered | `catalog.test.ts` :: "deduplicates repeated module roots and module names"                                                                                                                                                                                                                                                                                                                                                      |
+| FR-009      | ✅ Covered | `catalog.test.ts` :: "falls back to the directory basename when manifest has no name"; :: "handles modules with and without a version and artifacts with/without schemaRef"; :: "ignores non-array and malformed type entries"                                                                                                                                                                                                  |
+| FR-010      | ✅ Covered | `index.test.ts` :: "creates authoring packs for case-insensitive artifact and object types" (asserts `["fr","DOMAIN"]` → `["FR","domain"]`)                                                                                                                                                                                                                                                                                     |
+| FR-011      | ✅ Covered | `cli.test.ts` :: "list (explicit) prints one line per module"; :: "list --json prints the whole catalog as JSON"; :: "undefined subcommand behaves like list"; :: "show prints a single entry (text)"; :: "show --json prints the entry as JSON"; :: "show of a missing type throws"; :: "show without a type throws"                                                                                                           |
+| FR-012      | ✅ Covered | `catalog.test.ts` :: "reports a type declared by two modules"; :: "reports no duplicates when type names are unique"; `cli.test.ts` :: "validate reports duplicates on stderr and sets exit code 1"; :: "validate succeeds with no duplicates (text)"; :: "validate --json succeeds with no duplicates"                                                                                                                         |
+| FR-013      | ✅ Covered | `write.test.ts` :: "throws when no type names are given"; :: "throws when repo_dir is not a directory"; :: "throws when repo_dir is a file (exists but not a directory)"; :: "throws with available type list when a type is not found"; `cli.test.ts` :: "missing repo_dir throws"; `write.test.ts` parseTypeList suite                                                                                                        |
+| FR-014      | ✅ Covered | `write.test.ts` :: "renders an authoring pack as text"; :: "renders an authoring pack as JSON with --json"; :: "renders skeleton+schema, manifest-only, and object contracts"; :: "does not emit a manifest-only line when a contract has artifacts"                                                                                                                                                                            |
+| FR-015      | ✅ Covered | `write.test.ts` :: "builds a pack with contracts and a non-quoted clean repo path"; :: "quotes a repo path containing a space (shellQuote quoting branch)"; `index.test.ts` :: validation.command asserts `quire validate --scope`                                                                                                                                                                                              |
+| FR-016      | ✅ Covered | `index.test.ts` :: "ships the committed default module set" (asserts `default-modules.yaml` validates as a marketplace manifest with the expected entries)                                                                                                                                                                                                                                                                      |
+| FR-017      | ✅ Covered | `index.test.ts` :: "lazily installs the default module set, then loads its artifacts and objects"; `cli.test.ts` :: "ensure-defaults runs the installer and reports the registry"                                                                                                                                                                                                                                               |
+| FR-018      | ✅ Covered | `plugins.test.ts` :: "path: prefix"; :: "github: with @ref"; :: "github: without ref leaves ref undefined"; :: "github: with //subdir maps to a git-subdir source (with ref)"; :: "github: with //subdir and no ref leaves ref undefined"; :: "package: npm with @version"; :: "package: npm without version"; :: "scoped package: npm keeps the scope @, splits on the last @"; :: "bare argument falls back to a path source" |
+| FR-019      | ✅ Covered | `plugins.test.ts` :: "install adds a plugin from a path source"; :: "installs, lists, then removes a plugin and its target dir + registry entry"; readModuleName suite ("reads the name from a top-level manifest.yaml"…); `cli.test.ts` :: "install without a source throws"; :: "remove without a name throws"; :: "remove deletes a plugin and prints confirmation"                                                          |
+| FR-020      | ✅ Covered | `flows.test.ts` :: "lists the bundled spec flows"; :: "throws for an unknown flow name"; `flows-notfound.test.ts` :: "throws when no candidate root contains the skill"                                                                                                                                                                                                                                                         |
+| FR-021      | ✅ Covered | `flows.test.ts` :: "resolves when ix-flow exits 0; builds id/json/target args"; :: "matrix runs the flow and propagates a non-zero exit code"; :: "defaults exit code to 1 when ix-flow is killed by a signal (null code)"; :: "rejects when ix-flow cannot be spawned (PATH has no ix-flow)"; `cli.test.ts` :: "review with --target/--json/--id runs the flow (ix-flow exit 0)"                                               |
+
+## Non-Functional Requirements
+
+| Requirement | Coverage   | Test / Evidence                                                                                                                                                                                                                                                              |
+| ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NFR-001     | ✅ Covered | `index.test.ts` :: "lazily installs the default module set…" runs `ensureDefaultModules` against path-source fixtures with `mode: "lazy"` and no network/git.                                                                                                                |
+| NFR-002     | ✅ Covered | `catalog.test.ts` :: "deduplicates repeated module roots and module names"; :: "reports a type declared by two modules" (duplicate module lists are sorted, ordering is first-wins).                                                                                         |
+| NFR-003     | ✅ Covered | `write.test.ts` :: "throws with available type list when a type is not found"; `cli.test.ts` :: "throws on an unknown command"; `plugins.test.ts` :: "throws when no manifest.yaml exists"                                                                                   |
+| NFR-004     | ⚠️ Review  | Standalone-dependency claim verified by inspecting `package.json` runtime deps (`ix-cli-core`, `ts-plugin-kit`, `yaml`); `ix-flow`/`quire` are spawned, not imported. No automated assertion.                                                                                |
+| NFR-005     | ⚠️ Review  | Workflow launchers reference catalog modules via `flows.ts` and the bundled skills; no automated assertion. Verified by review.                                                                                                                                              |
+| NFR-006     | ⚠️ Review  | The agent-pty harness (`evals/run.mjs`) records latency, tokens, tool calls, validation attempts, and context fetches from the Claude Code transcript; defined in `spec/evals.md`, implemented in `evals/`.                                                                  |
+| NFR-007     | ✅ Covered | `flows.test.ts` :: "rejects when ix-flow cannot be spawned (PATH has no ix-flow)"; :: "sets process.exitCode when ix-flow exits non-zero"; `write.test.ts` validation-command tests confirm `quire` is emitted, not executed. (Version pinning is an accepted gap — Review.) |
+| NFR-008     | ⚠️ Review  | `catalog.test.ts` :: "skips candidates that do not resolve to a module root" covers the missing-manifest skip. The strict-abort path on a present-but-unparseable `manifest.yaml` has **no dedicated test** (see Backsync Notes).                                            |
 
 ## Use Case Coverage
 
-| Use Case | Coverage   | Test / Evidence                                                                                                                                                                                         |
-| -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| US-001   | ✅ Covered | `index.test.ts` authoring-pack test; EV-001/EV-006/EV-014 in `spec/evals.md`                                                                                                                            |
-| US-002   | ✅ Covered | `scripts.test.ts` catalog/write help; `index.test.ts` case-insensitive lookup; EV-002/EV-007/EV-011                                                                                                     |
-| US-003   | ⚠️ Partial | `index.test.ts` plugin install/list/remove (path source only). GitHub/package install is not unit-tested (network-hermetic fixtures use `path:` only); EV-003/EV-009/EV-010 cover it at the eval layer. |
-| US-004   | ✅ Covered | `index.test.ts` validation-command assertion; EV-004/EV-008/EV-012                                                                                                                                      |
-| US-005   | ✅ Covered | `flows.test.ts` exercises the workflow launchers end-to-end (fake `ix-flow`); `cli.test.ts` covers `review`/`matrix` dispatch via `main`. EV-005/EV-013 add eval coverage.                              |
+| Use Case | Coverage   | Test / Evidence                                                                                                                                                      |
+| -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| US-001   | ✅ Covered | `index.test.ts` authoring-pack test; `write.test.ts` `formatAuthoringPack` suite; EV-001/EV-006/EV-014 in `spec/evals.md`                                            |
+| US-002   | ✅ Covered | `cli.test.ts` `runCatalog` show suite; `scripts.test.ts` catalog/write help; `index.test.ts` case-insensitive lookup; EV-002/EV-007                                  |
+| US-003   | ⚠️ Partial | `plugins.test.ts` + `index.test.ts` install/list/remove (path source only). GitHub/subdir install is exercised only at the eval layer (EV-003/EV-009/EV-010/EV-020). |
+| US-004   | ✅ Covered | `write.test.ts` validation-command assertions; `index.test.ts` `validation.command`; EV-004/EV-008/EV-012                                                            |
+| US-005   | ✅ Covered | `flows.test.ts` launchers end-to-end (real fake `ix-flow`); `cli.test.ts` `review`/`matrix` dispatch; EV-005/EV-013                                                  |
+| US-006   | ✅ Covered | `catalog.test.ts` :: "reports a type declared by two modules"; `cli.test.ts` :: "validate reports duplicates on stderr and sets exit code 1"                         |
 
 ## Eval Coverage
 
-The agent-facing eval set (EV-001…EV-015) is defined in `spec/evals.md`
-(Matrix-002) and implemented by the agent-pty-driven harness in `evals/` (run with
-`make evals` for the canaries or `make evals-all` for the full set). The harness
-drives the real agent through this CLI + the `/spec-*` skills and records real
-metrics from the Claude Code transcript. This unit-test matrix does not duplicate
-that table.
+The agent-facing eval set (EV-001…EV-020) is defined in `spec/evals.md`
+(Matrix-002) and implemented by the agent-pty-driven harness in `evals/`
+(`make evals` for canaries, `make evals-all` for the full set). It drives the
+real agent through this CLI + the `/spec-*` skills and records real metrics from
+the Claude Code transcript. This unit-test matrix does not duplicate that table.
 
 ## Backsync Notes
 
-- FR-001/FR-002 were rewritten from the old "discover bundled modules" /
-  "install records under `~/.ix`" wording to match the current lazy-install +
-  `~/.ix/filament/{modules,registry.json}` + ts-plugin-kit delegation model.
-- FR-009/FR-010/FR-011 and NFR-003 are new and trace to existing tests.
-- FR-006 and US-005 are now unit-covered: `flows.test.ts` tests the launchers
-  (incl. a real fake `ix-flow` binary for the exit-code / signal / spawn-error
-  paths), closing the prior eval-only gap. The repo now passes
-  `pnpm run test:coverage` at 100% (branches/functions/lines/statements).
+- Requirements were renumbered and expanded in the Phase 0 overhaul to be a
+  faithful, atomic backport of `src/` (`cli`, `catalog`, `write`, `plugins`,
+  `modules`, `flows`). The prior coarse FR-001…FR-011 set is superseded by the
+  capability-grouped FR-001…FR-021 / NFR-001…NFR-006 set in `spec.md`.
+- The previous meta-requirement "the spec SHALL define eval scenarios" was
+  dropped from the functional set; eval metric capture is now NFR-006 and the
+  scenarios live in `spec/evals.md`.
+- US trace targets were re-pointed to the new FR IDs and US-006 (duplicate
+  detection) was added to cover `catalog validate`.
+- **Untested strict-abort (NFR-008):** the loader skips a candidate with no
+  `manifest.yaml` (tested) but throws on a present-but-unparseable
+  `manifest.yaml` (untested). A fixture with a corrupt `manifest.yaml` asserting
+  the abort would close this.
+- **Open coverage gap (FR-017):** `cli.test.ts` :: "ensure-defaults runs the
+  installer and reports the registry" runs against an empty registry, so the
+  `(p) => p.name` mapping at `cli.ts:322` is never executed and the 100%
+  coverage gate fails. Closing it needs an `ensure-defaults` case where
+  `listPlugins()` returns ≥1 plugin (assert the reported `plugins` array).

--- a/spec/review.md
+++ b/spec/review.md
@@ -11,8 +11,9 @@ type: Review
 Review of the Phase 0 spec **overhaul** — a complete, code-faithful backport of
 `src/` (`cli`, `catalog`, `write`, `plugins`, `modules`, `flows`). The prior
 coarse FR-001…FR-011 set was superseded by a capability-grouped FR-001…FR-021 /
-NFR-001…NFR-006 set; user stories were re-traced and US-006 (duplicate
-detection) was added; the test matrix was regenerated against `tests/`.
+NFR-001…NFR-008 set (NFR-007/008 added during this review); user stories were
+re-traced and US-006 (duplicate detection) was added; the test matrix was
+regenerated against `tests/`.
 
 ## Automated Checks
 
@@ -22,7 +23,8 @@ detection) was added; the test matrix was regenerated against `tests/`.
 - **Link integrity:** every `US → FR` `traces_to` target (FR-010/011/012/013/
   014/015/017/018/019/020/021) resolves to a declared FR.
 - **Quire validation:** `quire validate --scope . "spec/**/*.md"` exits 0.
-- **Test suite:** `make test` → 97 passed (9 files).
+- **Test suite:** `make test` → 99 passed (9 files); `pnpm run test:coverage`
+  passes the 100% gate.
 
 ## Checklist Results
 
@@ -43,13 +45,10 @@ detection) was added; the test matrix was regenerated against `tests/`.
 
 ## Findings
 
-1. **Open coverage gap (FR-017) — action item.** `pnpm run test:coverage`
-   fails the declared 100% gate at 99.61% lines / 98.24% funcs. The sole gap is
-   the `(p) => p.name` mapping at `cli.ts:322` in `plugin ensure-defaults`,
-   reached only when the registry is non-empty; the existing test runs against
-   an empty registry. **Action:** add an `ensure-defaults` test that seeds ≥1
-   plugin and asserts the reported `plugins` array. (`make test` itself is
-   green; only the coverage script is red.)
+1. **Coverage gap (FR-017) — RESOLVED.** `cli.test.ts` :: "ensure-defaults
+   reports installed plugin names from a non-empty registry" now exercises the
+   `(p) => p.name` mapping at `cli.ts:322`. `pnpm run test:coverage` passes at
+   100% (branches/functions/lines/statements), 99 tests.
 
 2. **Framework FRs are intentionally not US-traced.** FR-001…FR-009 and FR-016
    describe CLI-framework and catalog-assembly mechanics (arg grammar, version,
@@ -112,25 +111,99 @@ Both lenses from the `spec-review` process were run against `spec.md` + `src/`:
 
 ## Findings (analysis)
 
-6. **NFR-008 strict-abort is untested — action item.** The skip-on-missing path
-   is tested; the abort-on-malformed-manifest path is not. Add a corrupt-manifest
-   fixture asserting the throw.
+6. **NFR-008 strict-abort — RESOLVED.** `catalog.test.ts` :: "aborts (strict)
+   on a present but unparseable manifest.yaml" now asserts the throw, alongside
+   the existing missing-manifest skip test.
 7. **External-tool versions unpinned (NFR-007) — known limitation.** `ix-flow`
    and `quire` are resolved from `PATH` with no minimum-version check. Acceptable
    for Phase 0; revisit when either tool's CLI contract changes.
 
+## Analysis Lenses (dependency / evidence / risk / scope)
+
+The remaining four lenses from the `spec-review` process were also run. Kept
+inline here (the dependency skill permits inline analysis) rather than as
+separate `spec/analysis/*.md` files, since no `analysis` archetype exists and
+loose files would not validate under Quire.
+
+### Dependency & Ordering — no cycles
+
+Logical implementation order (enablement → feature):
+
+1. **Root enablement:** FR-001 (arg parsing), FR-004 (config root / runtime
+   context).
+2. **Catalog enablement:** FR-006 (module-root location) → FR-007 (assembly
+   order) → FR-008 (dedup) / FR-009 (manifest parse) / FR-010 (lookup).
+3. **Module-store enablement:** FR-016 (committed default set), FR-018 (source
+   grammar).
+4. **Features:** FR-002/003/005 (version/help/errors), FR-011/012 (list/show/
+   validate), FR-013/014/015 (write), FR-017/019 (reconcile / plugin lifecycle),
+   FR-020/021 (workflow launch).
+
+No cyclic prerequisites. (Retrospective DAG — the code already exists; this
+orders a re-implementation and feeds `spec-to-plan`.)
+
+### Verification & Evidence — no open gaps
+
+Every FR is `test` with a named case in `spec/matrix.md`. Non-test methods:
+NFR-004 = inspection (`package.json` deps), NFR-005 = inspection
+(`flows.ts` + bundled skills), NFR-006 = metric (`evals/` harness), NFR-008 =
+test (skip + strict-abort paths). **Open evidence gaps:** none — the FR-017 and
+NFR-008 gaps flagged during review (Findings 1 and 6) were closed with new
+tests; `pnpm run test:coverage` passes at 100%.
+
+### Risk & Complexity — no high tech risk
+
+quoin is a low-novelty CLI: no concurrency, cryptography, or perf SLA, and is
+not `security_critical`. Tech risk is low across the board. The volatility
+cluster is **external-contract coupling**:
+
+| Req        | Tech | Volatility | Driver                                                |
+| ---------- | ---- | ---------- | ----------------------------------------------------- |
+| FR-017/019 | Low  | Medium     | `ts-plugin-kit` install/reconcile/registry contract   |
+| FR-018     | Low  | Med-High   | `package:`/npm source is forward-declared; will churn |
+| FR-020/021 | Low  | Medium     | `ix-flow` CLI argument contract (unpinned, NFR-007)   |
+| NFR-006    | Low  | Medium     | agent-pty evals depend on the external model provider |
+
+**Top hazard:** FR-018's npm source — the highest-churn item — but it is
+isolated in `parseSourceArg`, so the blast radius is contained.
+
+### Scope & Boundary — external deps are all _assumed_
+
+In scope: arg dispatch, catalog assembly, authoring-pack emission, default-set
+reconcile trigger, plugin source mapping, workflow launch. External
+dependencies and how they are verified **locally**:
+
+| Dependency                | Relationship                           | Verified locally?                                                      |
+| ------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
+| `@agent-ix/ts-plugin-kit` | delegated (install/registry/reconcile) | Assumed — exercised via path-source fixtures, not a contract test      |
+| `ix-flow`                 | spawned process                        | Assumed — tested against a **fake** `ix-flow` binary, not the real CLI |
+| `quire`                   | command emitted, never run by quoin    | Assumed — only the command string is asserted                          |
+| `@agent-ix/ix-cli-core`   | linked runtime context                 | Assumed                                                                |
+
+## Findings (analysis, continued)
+
+8. **No local contract tests against external tools (scope).** Every external
+   boundary is `assumed`. `ix-flow` is covered only by a fake-binary stand-in;
+   `quire`/`ts-plugin-kit` behavior is not contract-verified here (cross-repo
+   contracts such as the quire-rs shared store are asserted in those repos). If
+   an upstream CLI contract drifts, quoin's tests would not catch it. Low
+   priority for Phase 0; candidate for an integration-test layer later.
+9. **`package:`/npm source is the top churn item (risk).** FR-018 forward-
+   declares npm support that `ts-plugin-kit` rejects today. Isolated in
+   `parseSourceArg`; revisit when npm support lands.
+
 ## Gate
 
-**Accepted with action items, ready to commit.** The spec is a faithful backport
-of current behavior, validates under Quire, and every requirement traces to a
-real test. No blocker is a _spec_ defect — the open items are test gaps and
-known limitations:
+**Accepted — clean.** The spec is a faithful backport of current behavior,
+validates under Quire, and every requirement traces to a real test:
 
-- Finding 1 (FR-017 coverage gap) and Finding 6 (NFR-008 untested) are **test**
-  gaps, not spec gaps — they belong to the implementation, recorded here for the
-  backlog.
-- Findings 2–5, 7 and the StR/atomicity notes are accepted properties or
-  documented limitations.
+- Findings 1 (FR-017) and 6 (NFR-008) — the two test gaps found during review —
+  were **closed** with new tests; `pnpm run test:coverage` passes the 100% gate
+  (99 tests).
+- Findings 2–5, 7, 8, 9 and the StR/atomicity notes are accepted properties,
+  documented limitations, or low-priority follow-ups (cross-repo contract tests,
+  the forward-declared npm source) — none block the spec or a release.
 
-The spec accurately reflects `src/` as of this review and is safe to commit; the
-two test gaps should be closed before a release gate.
+All six `spec-review` analysis lenses (integrity, failure-domain, dependency,
+evidence, risk, scope) were run. The spec accurately reflects `src/` as of this
+review with no open action items.

--- a/spec/review.md
+++ b/spec/review.md
@@ -8,52 +8,129 @@ type: Review
 
 ## Scope
 
-Backsync review after the default-module set moved from a vendored
-`builtin-modules/` tree to a lazy marketplace install via
-`@agent-ix/ts-plugin-kit` (commit "feat: install default modules via
-ts-plugin-kit instead of vendoring"). FR-001/FR-002 reworded; FR-009/FR-010/FR-011
-and NFR-003 added; use cases and test matrix re-traced to the current code and
-`tests/`.
+Review of the Phase 0 spec **overhaul** — a complete, code-faithful backport of
+`src/` (`cli`, `catalog`, `write`, `plugins`, `modules`, `flows`). The prior
+coarse FR-001…FR-011 set was superseded by a capability-grouped FR-001…FR-021 /
+NFR-001…NFR-006 set; user stories were re-traced and US-006 (duplicate
+detection) was added; the test matrix was regenerated against `tests/`.
 
-## Findings (resolved)
+## Automated Checks
 
-- FR-001 / FR-002 rewording matches `src/modules.ts` (`ensureDefaultModules`,
-  `reconcile` mode `lazy`) and `src/plugins.ts` (registry at
-  `~/.ix/filament/registry.json`, install delegated to ts-plugin-kit). Verified.
-- FR-009 "pinned to a tag" softened: `default-modules.yaml` `spec-artifacts-app`
-  has no `ref:` (pins to default branch). FR now allows a default-branch pin
-  where no release tag exists.
-- FR-010 / US-003 corrected: quoin only _maps_ the source argument and hands
-  off to ts-plugin-kit; the unsupported-`package:`/npm error is thrown by
-  ts-plugin-kit's `resolveSource` at install time, not by quoin. Wording now
-  attributes the error correctly.
-- FR-011 ordering (`QUOIN_MODULE_PATHS` then `~/.ix/filament/modules`) matches
-  `src/catalog.ts:defaultModuleRoots`; shared store read by quire-rs documented.
-- US-001 now also `traces_to` FR-001 (lazy default-module install is a stated
-  dependency of the authoring flow).
-- Cross-references: all US→FR links resolve; all matrix test names match
-  `test(...)` names in `tests/index.test.ts` / `tests/scripts.test.ts` verbatim.
+- **ID format & sequence:** `FR-001…FR-021`, `NFR-001…NFR-006`, `US-001…US-006`
+  — all 3-digit, sequential, no gaps or duplicates. No malformed IDs (no `FR-1`
+  / `US-12` forms).
+- **Link integrity:** every `US → FR` `traces_to` target (FR-010/011/012/013/
+  014/015/017/018/019/020/021) resolves to a declared FR.
+- **Quire validation:** `quire validate --scope . "spec/**/*.md"` exits 0.
+- **Test suite:** `make test` → 97 passed (9 files).
+
+## Checklist Results
+
+- ✅ ID format/uniqueness — pass (see Automated Checks).
+- ✅ US "As a / I want / So that" — all six now use the bold-marker shape the
+  `spec-artifacts-iso` US archetype asserts (US-002…US-005 were prose, fixed).
+- ✅ FR clarity/specificity — each FR names concrete inputs, outputs, and
+  observable behavior (flags, exit codes, file paths, error text).
+- ✅ FR → behavior verifiable — every FR/NFR maps to a named `tests/` case in
+  `spec/matrix.md`.
+- ✅ Error paths documented — unknown command/subcommand, missing repo_dir,
+  unknown type, missing/empty manifest name, non-zero/signal ix-flow exit,
+  spawn error.
+- ⚠️ US acceptance criteria — only US-001 and US-006 carry Given/When/Then
+  examples; US-002…US-005 do not. Accepted: the ISO US archetype treats
+  acceptance examples as _illustrative, non-normative_, and verification lives
+  in the matrix, not in the US. Noted for completeness, non-blocking.
 
 ## Findings
 
-- FR-006 / US-005 (RESOLVED): `tests/flows.test.ts` now exercises `src/flows.ts`
-  (`specFlowNames`/`startSpecFlow`/`resolveSkillPath`/`runIxFlow`) with a real
-  fake `ix-flow` binary covering exit-0 / non-zero / signal / spawn-error and the
-  packaged + legacy skill layouts; `cli.test.ts` covers spec-flow dispatch.
-- Coverage gate (RESOLVED): `pnpm run test:coverage` now **passes at 100%**
-  (branches/functions/lines/statements). Two genuinely-unreachable defensive
-  branches in `src/cli.ts` (`helpFor` `?? ""`, `arrayFlag` string-case) were
-  removed rather than ignore-pragma'd, per the no-pragma coverage rule.
-- NFR-003: the "no git once installed and pinned" lazy short-circuit is correct
-  in code; reconcile idempotence is exercised across fixture-sharing tests. A
-  dedicated double-call assertion remains a nice-to-have (non-blocking).
-- US artifacts carry no Given/When/Then acceptance criteria or Priority — an
-  accepted property of this lightweight Phase 0 spec, noted for completeness.
-- Repo `CLAUDE.md` says `make test` "runs jest"; the project actually runs
-  vitest. Out of scope for spec/ edits, flagged for a follow-up doc fix.
+1. **Open coverage gap (FR-017) — action item.** `pnpm run test:coverage`
+   fails the declared 100% gate at 99.61% lines / 98.24% funcs. The sole gap is
+   the `(p) => p.name` mapping at `cli.ts:322` in `plugin ensure-defaults`,
+   reached only when the registry is non-empty; the existing test runs against
+   an empty registry. **Action:** add an `ensure-defaults` test that seeds ≥1
+   plugin and asserts the reported `plugins` array. (`make test` itself is
+   green; only the coverage script is red.)
+
+2. **Framework FRs are intentionally not US-traced.** FR-001…FR-009 and FR-016
+   describe CLI-framework and catalog-assembly mechanics (arg grammar, version,
+   help, config root, module-root location, dedup, manifest parsing, the
+   committed default set). They are enabling requirements with no standalone
+   user story and are covered directly by the matrix → `tests/`. This is an
+   accepted structure, not a traceability gap.
+
+3. **Scope boundaries are explicit and match code.** Validation execution
+   (`quire`), workflow lifecycle (`ix-flow`), and install/registry mechanics
+   (`ts-plugin-kit`) are stated Out of Scope and are invoked as external
+   processes / delegated calls — consistent with `flows.ts` (spawns `ix-flow`),
+   `write.ts` (emits, does not run, the `quire` command), and `plugins.ts`
+   (delegates to `ts-plugin-kit`). NFR-004 captures the standalone-dependency
+   boundary.
+
+4. **`package:`/npm source is forward-declared.** FR-018 and US-003 correctly
+   state that `package:` maps to an npm source that `ts-plugin-kit` rejects at
+   install time; quoin only maps the argument. Behavior matches
+   `plugins.ts:parseSourceArg`.
+
+5. **Doc drift (out of spec scope).** Repo `CLAUDE.md` still says
+   `make test # run jest`; the project runs vitest. Flagged for a follow-up
+   doc fix; no spec change required.
+
+## Analysis Lenses (spec-integrity + spec-failure-domain)
+
+Both lenses from the `spec-review` process were run against `spec.md` + `src/`:
+
+**Integrity (completeness / consistency / atomicity):**
+
+- ✅ Multi-source lookup tie-break is an explicit decision — FR-008 (first-wins
+  by module name / resolved root) and FR-012 (duplicate type detection).
+- ✅ Forward-declared dependency (`package:`/npm) documents its interim
+  behavior — FR-018 (rejected by ts-plugin-kit at install time).
+- ➕ **External-CLI probe (fixed):** FRs delegate to `ix-flow`/`quire` with no
+  invocation contract. Added **NFR-007** (PATH resolution, no version pin in
+  Phase 0, absence/non-zero surfaces as non-zero exit, `quire` emitted not run).
+- ⚠️ **No StR layer (accepted).** Stakeholder intent is not derivable from code;
+  reverse-engineering an StR set would be fabrication. User stories carry the
+  stakeholder framing informally. A real StR layer is deferred to a phase with
+  product input — not a code-backport task.
+- ⚠️ **Atomicity (accepted).** FR-011 (list/show), FR-012 (detect/validate),
+  FR-019 (install/list/remove), and FR-021 (spawn/exit/handoff) each bundle a
+  small command family. Kept grouped for readability; each sub-behavior still
+  has its own named test in `spec/matrix.md`. Splitting is a future option.
+
+**Failure domain (extension / identity / purity / topology):**
+
+- ✅ Entity identity keys are all explicit — module by `name`, catalog entry by
+  `kind:name`, module root by resolved path, registry plugin by `name`.
+- ✅ Topology/purity: catalog assembly is a flat, one-level-deep filesystem scan
+  with guaranteed termination and no user-evaluated logic — no cycle or
+  deep-nesting exposure.
+- ➕ **Extension-point failure policy (fixed + flagged):** a corrupt installed
+  `manifest.yaml` aborts _all_ catalog operations (strict), while a missing one
+  is skipped. Captured as **NFR-008**. Open design question: strict-abort means
+  one bad module blocks even `catalog list`; a resilient skip-and-warn may be
+  better UX. Flagged for a product decision; current behavior documented as-is.
+
+## Findings (analysis)
+
+6. **NFR-008 strict-abort is untested — action item.** The skip-on-missing path
+   is tested; the abort-on-malformed-manifest path is not. Add a corrupt-manifest
+   fixture asserting the throw.
+7. **External-tool versions unpinned (NFR-007) — known limitation.** `ix-flow`
+   and `quire` are resolved from `PATH` with no minimum-version check. Acceptable
+   for Phase 0; revisit when either tool's CLI contract changes.
 
 ## Gate
 
-Phase 0 accepted. Spec content matches current behavior; the prior FR-006/US-005
-flow-test gap and the coverage-gate mismatch are both resolved (100% coverage,
-`flows.ts` unit-tested).
+**Accepted with action items, ready to commit.** The spec is a faithful backport
+of current behavior, validates under Quire, and every requirement traces to a
+real test. No blocker is a _spec_ defect — the open items are test gaps and
+known limitations:
+
+- Finding 1 (FR-017 coverage gap) and Finding 6 (NFR-008 untested) are **test**
+  gaps, not spec gaps — they belong to the implementation, recorded here for the
+  backlog.
+- Findings 2–5, 7 and the StR/atomicity notes are accepted properties or
+  documented limitations.
+
+The spec accurately reflects `src/` as of this review and is safe to commit; the
+two test gaps should be closed before a release gate.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -3,6 +3,7 @@ type: master-requirements
 name: quoin
 org: agent-ix
 component_type: cli
+implementation_language: typescript
 title: "quoin Phase 0 Spec"
 ---
 
@@ -10,79 +11,137 @@ title: "quoin Phase 0 Spec"
 
 ## Purpose
 
-`quoin` SHALL provide a standalone installable CLI for spec-domain catalog,
-plugin, authoring-contract, Quire, and review/planning flow operations without
+`quoin` SHALL provide a standalone installable CLI that gives a spec-authoring
+agent a catalog-driven authoring contract, a user-extensible spec-module store,
+and launch points for governed review/matrix/planning workflows — without
 requiring the broader `ix` umbrella CLI.
 
 ## Scope
 
 ### In Scope
 
-- The `quoin` CLI surface: catalog list/show/validate, `write` authoring
-  packs, plugin install, and the launch of review/matrix/to-plan workflows.
-- The committed default Filament module set and its lazy reconciliation into
-  `~/.ix/filament/modules`, plus user/community plugin install records in
-  `~/.ix/filament/registry.json`.
+- The `quoin` command surface: argument parsing, `version`/help, `catalog`
+  list/show/validate, `write` authoring packs, `plugin`
+  install/list/remove/ensure-defaults, and the `review`/`matrix`/`to-plan`
+  workflow launchers.
+- Assembly of a Filament catalog from module roots (`QUOIN_MODULE_PATHS` plus
+  the installed module store) and the authoring contract it exposes (skeletons,
+  schemas, module roots).
+- The committed default Filament module set (`default-modules.yaml`) and its
+  lazy, idempotent reconciliation into `~/.ix/filament/modules`, plus
+  user/community plugin install records in `~/.ix/filament/registry.json`.
+- Construction of the `quire validate` command for authored spec files.
 
 ### Out of Scope
 
-- Workflow lifecycle control (resume/advance/gate/status), which `ix-flow`
-  owns after launch.
-- Frontmatter-driven validation of authored spec files, which `quire` owns;
-  `quoin` authors, quire validates.
+- Workflow lifecycle control (resume/advance/gate/status), owned by `ix-flow`
+  after a run is launched.
+- Frontmatter-driven validation of authored spec files, owned by `quire`;
+  `quoin` constructs the validation command and `quire` executes it.
+- Install/registry/reconcile mechanics, owned by `@agent-ix/ts-plugin-kit`;
+  `quoin` maps CLI source arguments to typed sources and delegates.
 
 ## System Overview
 
-`quoin` is a standalone CLI that assembles a Filament catalog from module
-roots, authors artifact/object files from catalog skeletons, installs
-user/community modules through `@agent-ix/ts-plugin-kit`, and hands lifecycle
-control of review/matrix/planning workflows to `ix-flow`. It does not vendor the
-default modules; the committed `default-modules.yaml` declares them as pinned
-`git-subdir` sources that are reconciled on first catalog access into the shared
-`~/.ix/filament/modules` store also read by quire-rs.
+`quoin` is a single `main(argv)` dispatcher built on
+`@agent-ix/ix-cli-core`. It parses a leading command (and, for `catalog` and
+`plugin`, a subcommand), resolves a config root, configures the shared runtime
+context, and dispatches to the catalog, authoring, plugin, or workflow surface.
+It assembles a Filament catalog from module roots, authors nothing itself —
+instead returning the local skeletons, schemas, and a `quire validate` command
+that the calling agent uses as its authoring contract. It installs
+user/community modules through `@agent-ix/ts-plugin-kit` and hands lifecycle
+control of review/matrix/planning workflows to `ix-flow`.
+
+It does not vendor the default modules; the committed `default-modules.yaml`
+declares them as pinned `git-subdir` sources reconciled on first catalog access
+into the shared `~/.ix/filament/modules` store also read by quire-rs, so
+authoring and validation see an identical catalog.
 
 ## Requirements Architecture
 
 The requirement classes that make up this specification — Functional
-Requirements, Non-Functional Requirements, and User Stories — and how they trace
-to one another are listed below. Functional and Non-Functional Requirements are
-enumerated in the Requirements table; User Stories that drive them are listed in
-Use Cases and authored under `spec/usecase/`.
+Requirements (FR), Non-Functional Requirements (NFR), and User Stories (US) —
+and how they trace to one another are listed below. Functional and
+Non-Functional Requirements are enumerated in the Requirements table; the User
+Stories that drive them are listed under Use Cases and authored in
+`spec/usecase/`.
 
-### Requirements
+### Functional Requirements — CLI Framework
 
-| ID      | Requirement                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Verification |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| FR-001  | The CLI SHALL lazily install the committed default Filament module set into `~/.ix/filament/modules` on first catalog access, idempotently and with zero git once each module is installed and pinned. It SHALL additionally expose `quoin plugin ensure-defaults` to perform this install on demand and report the resulting registry, so external tools (e.g. `quire validate` lazy-init) can trigger the bootstrap explicitly rather than via the side effect of `catalog`/`write`. | Test         |
-| FR-002  | The CLI SHALL maintain user/community plugin install records in `~/.ix/filament/registry.json` and materialize installed modules under `~/.ix/filament/modules`, delegating install/registry mechanics to `@agent-ix/ts-plugin-kit`.                                                                                                                                                                                                                                                   | Test         |
-| FR-003  | The CLI SHALL expose catalog list/show/validate commands.                                                                                                                                                                                                                                                                                                                                                                                                                              | Test         |
-| FR-004  | The CLI SHALL expose `write <repo_dir> --types <types>` authoring packs from catalog entries.                                                                                                                                                                                                                                                                                                                                                                                          | Test         |
-| FR-005  | Type lookup for authoring packs SHALL be case-insensitive.                                                                                                                                                                                                                                                                                                                                                                                                                             | Test         |
-| FR-006  | The CLI SHALL keep review/matrix/to-plan workflows and hand lifecycle control to `ix-flow`.                                                                                                                                                                                                                                                                                                                                                                                            | Test         |
-| FR-007  | The CLI SHALL describe scope-based Quire validation for changed spec files.                                                                                                                                                                                                                                                                                                                                                                                                            | Test         |
-| FR-008  | The spec SHALL define use-case-matched eval scenarios for authoring, validation, plugins, and workflows.                                                                                                                                                                                                                                                                                                                                                                               | Test         |
-| FR-009  | The CLI SHALL ship `default-modules.yaml` as the committed, canonical-ready default module set, declaring each module as a `git-subdir` source pinned to the same tag its Python wheel is built from where a release tag exists (a module without a release tag MAY pin to its default branch).                                                                                                                                                                                        | Test         |
-| FR-010  | The CLI SHALL map `path:`, `github:`, and `package:` plugin-install source arguments to typed `ts-plugin-kit` sources (`path`/`github`/`npm`), and SHALL hand them to `ts-plugin-kit` for install; the `package:`/npm source is not yet supported and `ts-plugin-kit` rejects it with an unsupported-source error at install time.                                                                                                                                                     | Test         |
-| FR-011  | The CLI SHALL assemble the catalog from module roots in order: `QUOIN_MODULE_PATHS` (colon-separated), then modules installed under `~/.ix/filament/modules`; the same directory is the shared module store read by quire-rs.                                                                                                                                                                                                                                                          | Test         |
-| NFR-001 | Workflow definitions SHOULD avoid redefining doc/object type vocabularies.                                                                                                                                                                                                                                                                                                                                                                                                             | Review       |
-| NFR-002 | Authoring evals SHOULD record latency, token usage, tool-call count, validation attempts, and context fetches.                                                                                                                                                                                                                                                                                                                                                                         | Review       |
-| NFR-003 | Default-module reconciliation SHALL be idempotent and perform no network/git work once each module is installed and pinned, so repeated catalog/write invocations stay offline-safe.                                                                                                                                                                                                                                                                                                   | Test         |
+| ID     | Requirement                                                                                                                                                                                                                                                                                           | Verification |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-001 | The CLI SHALL parse a leading command and (for `catalog`/`plugin`) a subcommand, `--flag=value` and `--flag value` long flags, `-x` short boolean flags, and bare positionals, accumulating repeated `--types` and `--target` flags into ordered lists.                                               | Test         |
+| FR-002 | The CLI SHALL print its package version (read from `package.json`) for the `version` command, `--version`, or `-v`, and SHALL fail if the package version is missing or non-string.                                                                                                                   | Test         |
+| FR-003 | The CLI SHALL print root usage when invoked with no command, and command-scoped help for `--help`/`-h` on `write`, `catalog`, `plugin`, and the spec-flow commands, falling back to root usage for unrecognized commands.                                                                             | Test         |
+| FR-004 | The CLI SHALL resolve a config root from `--config-root` (defaulting to `~/.ix` via `IX_HOME`), export it to `IX_HOME`, and configure the shared `ix-cli-core` runtime context with namespace `ix` and project config root `<cwd>/.ix`, disabling project config when `--no-project-config` is given. | Test         |
+| FR-005 | The CLI SHALL reject an unknown command or an unknown `catalog`/`plugin` subcommand by throwing an error that includes usage, and SHALL exit non-zero.                                                                                                                                                | Test         |
+
+### Functional Requirements — Catalog
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                                                                             | Verification |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-006 | The catalog loader SHALL treat a candidate path as a module root when it directly contains `manifest.yaml`, or when one of its immediate child directories contains `manifest.yaml`; non-directory and unresolvable candidates SHALL be skipped.                                                                                                                        | Test         |
+| FR-007 | The catalog loader SHALL assemble module roots in order: `QUOIN_MODULE_PATHS` (colon-separated) first, then every module directory under `~/.ix/filament/modules`; the latter is the shared module store read by quire-rs.                                                                                                                                              | Test         |
+| FR-008 | The catalog loader SHALL ignore duplicate resolved module roots and duplicate module names on a first-wins basis, so a `QUOIN_MODULE_PATHS` module overrides an installed module of the same name.                                                                                                                                                                      | Test         |
+| FR-009 | For each module the loader SHALL read `name` (defaulting to the directory basename), optional `version`, and the `artifact_types`/`object_types` entries (ignoring malformed entries); artifact entries SHALL resolve `frontmatter_schema_ref` to a schema path, and every type SHALL resolve a skeleton from `skeletons/<Type>.md` with a lowercase-filename fallback. | Test         |
+| FR-010 | Catalog type lookup SHALL be case-insensitive, so `FR` and `fr` resolve to the same entry.                                                                                                                                                                                                                                                                              | Test         |
+| FR-011 | `catalog list` SHALL print one `name@version root` line per module (or the full catalog as `--json`), and `catalog show <type>` SHALL print the entry's kind/name/module/root (or the entry as `--json`) and error when the type is unknown or omitted.                                                                                                                 | Test         |
+| FR-012 | The loader SHALL flag any type name declared as the same kind by more than one module as a duplicate, and `catalog validate` SHALL exit non-zero emitting `{ok:false,duplicates}` on stderr when duplicates exist, otherwise report the module count (text or `--json`).                                                                                                | Test         |
+
+### Functional Requirements — Authoring
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                               | Verification |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-013 | `quoin write <repo_dir> --types <type[,type...]>` SHALL require at least one type and a `repo_dir` that exists and is a directory, SHALL split type lists on commas (trimming and dropping empties), and SHALL error with the sorted list of available types when a requested type is not in the catalog. | Test         |
+| FR-014 | For each resolved type `write` SHALL emit an authoring contract — name, kind, module name, module root, and any skeleton and schema paths — rendered as text (or `--json`), marking a type with neither skeleton nor schema as "manifest only".                                                           | Test         |
+| FR-015 | `write` SHALL emit a Quire validation command `quire validate --scope <shell-quoted repo_root> "spec/**/*.md"` scoped to the resolved repo root, shell-quoting paths that need it.                                                                                                                        | Test         |
+
+### Functional Requirements — Module Store & Plugins
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                                                                                                           | Verification |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-016 | The CLI SHALL ship `default-modules.yaml` as the committed default module set, validated as a `ts-plugin-kit` marketplace manifest, declaring each module as a `git-subdir` source pinned to the tag its Python wheel is built from where a release tag exists (a module without a release tag MAY pin to its default branch).                                                                        | Test         |
+| FR-017 | The CLI SHALL lazily reconcile the default module set into `~/.ix/filament/modules` on first `catalog`/`write` access (idempotently, with no git once installed), and SHALL expose `plugin ensure-defaults` as an explicit entry point that performs the install and reports the resulting registry for external tools (e.g. `quire validate`).                                                       | Test         |
+| FR-018 | The CLI SHALL map plugin source arguments to typed `ts-plugin-kit` sources: `path:<dir>` → `path`, `github:<owner>/<repo>[@<ref>]` → `github`, `github:<owner>/<repo>//<subdir>[@<ref>]` → `git-subdir`, `package:<pkg>[@<ver>]` → `npm`, and a bare argument → `path`. The `npm` source is not yet supported and `ts-plugin-kit` rejects it at install time.                                         | Test         |
+| FR-019 | The CLI SHALL maintain user/community plugin records in `~/.ix/filament/registry.json` and materialize modules (copy) under `~/.ix/filament/modules` via `ts-plugin-kit`, reading each module's name from its `manifest.yaml` (root or single nested dir); `plugin list` SHALL print the registry's plugins and `plugin remove <name>` SHALL delete the module directory and drop its registry entry. | Test         |
+
+### Functional Requirements — Workflows
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                                               | Verification |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-020 | The CLI SHALL expose the `review`, `matrix`, and `to-plan` workflow launchers, resolving each workflow's skill path across `IX_SPEC_WORKFLOWS_ROOT`, the packaged skills, a sibling `ix-spec-workflows` checkout, and `~/.ix/plugins`, and erroring when no candidate contains the skill.                                                 | Test         |
+| FR-021 | On launch the CLI SHALL spawn `ix-flow run <flow> --path <skill> --config-root <home> --state-dir <home>/flows` with optional `--id`/`--json`/`--target` arguments, propagate ix-flow's exit code (defaulting to 1 on signal), surface spawn errors, and hand all subsequent lifecycle control (resume/advance/gate/status) to `ix-flow`. | Test         |
+
+### Non-Functional Requirements
+
+| ID      | Requirement                                                                                                                                                                                                                                                                                                                                       | Verification |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| NFR-001 | Default-module reconciliation SHALL be idempotent and perform no network or git work once each module is installed and pinned, so repeated `catalog`/`write` invocations stay offline-safe.                                                                                                                                                       | Test         |
+| NFR-002 | Catalog assembly SHALL be deterministic for a given set of module roots: stable root ordering, first-wins dedup, and sorted duplicate-module lists.                                                                                                                                                                                               | Test         |
+| NFR-003 | Command, argument, and lookup failures SHALL surface as thrown errors or non-zero exit codes with actionable messages (available types, usage text, source diagnostics) rather than silent or partial output.                                                                                                                                     | Test         |
+| NFR-004 | `quoin` SHALL run standalone: its only runtime dependencies are `@agent-ix/ix-cli-core`, `@agent-ix/ts-plugin-kit`, and a YAML parser; `ix-flow` and `quire` are invoked as external processes, not linked.                                                                                                                                       | Review       |
+| NFR-005 | Workflow definitions SHOULD reference catalog-defined artifact/object types rather than redefining the doc/object type vocabulary.                                                                                                                                                                                                                | Review       |
+| NFR-006 | The agent-facing eval set SHALL record latency, token usage, tool-call count, validation attempts, and repeated context fetches per scenario.                                                                                                                                                                                                     | Review       |
+| NFR-007 | The external tools `ix-flow` and `quire` SHALL be invoked by name from `PATH` and are not version-pinned in Phase 0 (a known limitation); `ix-flow` unavailability or a non-zero exit SHALL surface as a non-zero `quoin` exit, and the `quire` validation command SHALL be emitted for the calling agent to run rather than executed by `quoin`. | Test         |
+| NFR-008 | A candidate module path without a `manifest.yaml` SHALL be skipped during catalog assembly, but a present-but-unparseable `manifest.yaml` SHALL abort assembly (strict) rather than be silently dropped, so a corrupt installed module is surfaced rather than hidden.                                                                            | Review       |
 
 ### Use Cases
 
-| ID     | Summary                                         |
-| ------ | ----------------------------------------------- |
-| US-001 | Author a root artifact with supporting objects. |
-| US-002 | Discover an authoring contract before editing.  |
-| US-003 | Install and use a community spec module.        |
-| US-004 | Validate changed spec files.                    |
-| US-005 | Start a gated spec workflow.                    |
+| ID     | Summary                                             |
+| ------ | --------------------------------------------------- |
+| US-001 | Author a root artifact with supporting objects.     |
+| US-002 | Discover an authoring contract before editing.      |
+| US-003 | Install and use a community spec module.            |
+| US-004 | Validate changed spec files.                        |
+| US-005 | Start a gated spec workflow.                        |
+| US-006 | Detect conflicting type definitions across modules. |
 
 ## Evals
 
-The minimum agent-facing eval set is defined in `spec/evals.md`. Evals SHALL
-match the use cases above and SHOULD capture success, latency, token usage,
-tool-call count, validation attempts, and repeated context fetches.
+The minimum agent-facing eval set is defined in `spec/evals.md` (Matrix-002) and
+implemented by the agent-pty-driven harness in `evals/`. Evals SHALL match the
+use cases above and record the metrics required by NFR-006.
 
 ## Module Store
 
@@ -92,10 +151,9 @@ modules. The committed `default-modules.yaml` declares the default set as pinned
 `~/.ix/filament/modules/<name>/` on first catalog access (triggered from
 `catalog` and `write`, and on demand via `quoin plugin ensure-defaults` — the
 explicit entry point external tools such as `quire validate` shell out to for
-lazy-init). The plugin registry lives at
-`~/.ix/filament/registry.json`. The same `~/.ix/filament/modules` directory is
-the shared module store also read by quire-rs, so installs and validation see an
-identical catalog.
+lazy init). The plugin registry lives at `~/.ix/filament/registry.json`. The
+same `~/.ix/filament/modules` directory is the shared module store read by
+quire-rs, so installs and validation see an identical catalog.
 
 ## References
 
@@ -104,4 +162,4 @@ identical catalog.
 - `@agent-ix/ts-plugin-kit` — marketplace install, reconcile, and registry
   primitives for the default set and user/community plugins.
 - `ix-flow` — workflow lifecycle (resume/advance/gate/status) after launch.
-- `quire-cli` — frontmatter-driven validation over authored spec files.
+- `quire` — frontmatter-driven validation over authored spec files.

--- a/spec/usecase/US-001-author-root-artifact-with-objects.md
+++ b/spec/usecase/US-001-author-root-artifact-with-objects.md
@@ -3,11 +3,13 @@ id: US-001
 title: "Author a root artifact with supporting objects"
 type: US
 relationships:
-  - target: "ix://agent-ix/quoin/FR-001"
+  - target: "ix://agent-ix/quoin/FR-010"
     type: "traces_to"
-  - target: "ix://agent-ix/quoin/FR-004"
+  - target: "ix://agent-ix/quoin/FR-013"
     type: "traces_to"
-  - target: "ix://agent-ix/quoin/FR-005"
+  - target: "ix://agent-ix/quoin/FR-014"
+    type: "traces_to"
+  - target: "ix://agent-ix/quoin/FR-017"
     type: "traces_to"
 ---
 

--- a/spec/usecase/US-002-discover-authoring-contract.md
+++ b/spec/usecase/US-002-discover-authoring-contract.md
@@ -3,9 +3,9 @@ id: US-002
 title: "Discover an authoring contract before editing"
 type: US
 relationships:
-  - target: "ix://agent-ix/quoin/FR-003"
+  - target: "ix://agent-ix/quoin/FR-011"
     type: "traces_to"
-  - target: "ix://agent-ix/quoin/FR-004"
+  - target: "ix://agent-ix/quoin/FR-013"
     type: "traces_to"
 ---
 
@@ -13,9 +13,9 @@ relationships:
 
 ## Story
 
-As an agent preparing a change, I want to inspect a type by name and retrieve
-the authoring pack for that type, so that I can keep the file structure aligned
-with the catalog contract.
+**As an** agent preparing a change
+**I want** to inspect a type by name and retrieve the authoring pack for that type
+**So that** I can keep the file structure aligned with the catalog contract.
 
 ## Context
 

--- a/spec/usecase/US-003-install-community-module.md
+++ b/spec/usecase/US-003-install-community-module.md
@@ -3,11 +3,11 @@ id: US-003
 title: "Install and use a community spec module"
 type: US
 relationships:
-  - target: "ix://agent-ix/quoin/FR-002"
+  - target: "ix://agent-ix/quoin/FR-011"
     type: "traces_to"
-  - target: "ix://agent-ix/quoin/FR-003"
+  - target: "ix://agent-ix/quoin/FR-018"
     type: "traces_to"
-  - target: "ix://agent-ix/quoin/FR-004"
+  - target: "ix://agent-ix/quoin/FR-019"
     type: "traces_to"
 ---
 
@@ -15,11 +15,9 @@ relationships:
 
 ## Story
 
-As a user adopting a community module, I want to install the module once under
-`~/.ix/filament/modules` (recorded in `~/.ix/filament/registry.json`), confirm
-that its types appear in the active catalog, and request those types in an
-authoring pack, so that the new vocabulary participates in authoring and
-validation just like the default modules.
+**As a** user adopting a community module
+**I want** to install the module once under `~/.ix/filament/modules` (recorded in `~/.ix/filament/registry.json`), confirm that its types appear in the active catalog, and request those types in an authoring pack
+**So that** the new vocabulary participates in authoring and validation just like the default modules.
 
 ## Context
 

--- a/spec/usecase/US-004-validate-changed-spec-files.md
+++ b/spec/usecase/US-004-validate-changed-spec-files.md
@@ -3,7 +3,7 @@ id: US-004
 title: "Validate changed spec files"
 type: US
 relationships:
-  - target: "ix://agent-ix/quoin/FR-007"
+  - target: "ix://agent-ix/quoin/FR-015"
     type: "traces_to"
 ---
 
@@ -11,9 +11,9 @@ relationships:
 
 ## Story
 
-As an agent completing spec edits, I want a scoped Quire command for the target
-repository, so that validation checks the changed files using frontmatter to
-select the matching rule set.
+**As an** agent completing spec edits
+**I want** a scoped Quire command for the target repository
+**So that** validation checks the changed files using frontmatter to select the matching rule set.
 
 ## Context
 

--- a/spec/usecase/US-005-start-gated-spec-workflow.md
+++ b/spec/usecase/US-005-start-gated-spec-workflow.md
@@ -3,7 +3,9 @@ id: US-005
 title: "Start a gated spec workflow"
 type: US
 relationships:
-  - target: "ix://agent-ix/quoin/FR-006"
+  - target: "ix://agent-ix/quoin/FR-020"
+    type: "traces_to"
+  - target: "ix://agent-ix/quoin/FR-021"
     type: "traces_to"
 ---
 
@@ -11,9 +13,9 @@ relationships:
 
 ## Story
 
-As a user running the spec lifecycle, I want `quoin` to launch the spec-domain
-workflow and `ix-flow` to manage phase progression and human gates, so that the
-workflow engine stays separate from the catalog and authoring surface.
+**As a** user running the spec lifecycle
+**I want** `quoin` to launch the spec-domain workflow and `ix-flow` to manage phase progression and human gates
+**So that** the workflow engine stays separate from the catalog and authoring surface.
 
 ## Context
 

--- a/spec/usecase/US-006-detect-conflicting-type-definitions.md
+++ b/spec/usecase/US-006-detect-conflicting-type-definitions.md
@@ -1,0 +1,61 @@
+---
+id: US-006
+title: "Detect conflicting type definitions across modules"
+type: US
+relationships:
+  - target: "ix://agent-ix/quoin/FR-011"
+    type: "traces_to"
+  - target: "ix://agent-ix/quoin/FR-012"
+    type: "traces_to"
+---
+
+# [US-006] Detect conflicting type definitions across modules
+
+## Story
+
+**As a** user assembling a catalog from default and community modules
+**I want** `quoin` to tell me when two modules declare the same artifact or object type
+**So that** I can resolve the conflict before authoring against an ambiguous contract.
+
+## Context
+
+Once a user installs community modules alongside the default set, two modules can
+declare the same type name (for example, two object modules each defining
+`domain`). Authoring against such a catalog is ambiguous: the agent cannot know
+which module's skeleton and schema apply.
+
+The expected command shape is:
+
+```bash
+quoin catalog list
+quoin catalog validate
+```
+
+`catalog validate` should report a clean catalog with its module count, or fail
+with the conflicting type names and the modules that declare them, so the user
+can remove or re-scope a module before continuing.
+
+## Acceptance Examples (Illustrative)
+
+These examples clarify expectations; they are illustrative, not verification
+criteria.
+
+### [US-006-EX-1] Clean catalog validates
+
+- **Given** a catalog whose type names are each declared by a single module
+- **When** the user runs `quoin catalog validate`
+- **Then** the command succeeds and reports the number of modules
+
+### [US-006-EX-2] Conflicting types are surfaced
+
+- **Given** two installed modules that both declare an object type named `domain`
+- **When** the user runs `quoin catalog validate`
+- **Then** the command exits non-zero and names the duplicated type and the
+  modules that declare it
+
+## Dependencies
+
+- The active catalog is assembled from `QUOIN_MODULE_PATHS` and the installed
+  module store under `~/.ix/filament/modules`.
+- Duplicate detection compares type names within the same kind (artifact or
+  object) across modules.

--- a/spec/usecase/index.md
+++ b/spec/usecase/index.md
@@ -13,3 +13,4 @@ description: "Index of artifacts in this directory."
 - [US-003: Install and use a community spec module](./US-003-install-community-module.md)
 - [US-004: Validate changed spec files](./US-004-validate-changed-spec-files.md)
 - [US-005: Start a gated spec workflow](./US-005-start-gated-spec-workflow.md)
+- [US-006: Detect conflicting type definitions across modules](./US-006-detect-conflicting-type-definitions.md)

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -126,6 +126,15 @@ describe("loadCatalog", () => {
     expect(catalog.modules).toEqual([]);
   });
 
+  test("aborts (strict) on a present but unparseable manifest.yaml", () => {
+    // NFR-008: a missing manifest is skipped, but a corrupt one surfaces rather
+    // than being silently dropped — loadCatalog throws instead of returning a
+    // partial catalog.
+    const dir = tmp("bad-manifest");
+    writeFileSync(join(dir, "manifest.yaml"), "name: [unterminated\n");
+    expect(() => loadCatalog([dir])).toThrow();
+  });
+
   test("handles modules with and without a version and artifacts with/without schemaRef", () => {
     const root = tmp("versions");
     writeModule(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -404,6 +404,23 @@ describe("runPlugin", () => {
     expect(Array.isArray(out.plugins)).toBe(true);
   });
 
+  test("ensure-defaults reports installed plugin names from a non-empty registry", async () => {
+    const home = tmp("home");
+    const mod = businessModule(tmp("plugin-src"));
+    const c = captureLog();
+    try {
+      await main(["plugin", "install", `path:${mod}`, "--config-root", home]);
+      // With a plugin already in the registry, ensure-defaults exercises the
+      // `listPlugins().map((p) => p.name)` reporting path (cli.ts).
+      await main(["plugin", "ensure-defaults", "--config-root", home]);
+    } finally {
+      c.restore();
+    }
+    const out = JSON.parse(c.lines[c.lines.length - 1]);
+    expect(out.ensured).toBe(true);
+    expect(out.plugins).toContain("spec-objects-business");
+  });
+
   test("remove deletes a plugin and prints confirmation", async () => {
     const home = tmp("home");
     const mod = businessModule(tmp("plugin-src"));


### PR DESCRIPTION
## Summary

Complete overhaul of the Phase 0 spec as a faithful, code-grounded backport of `src/` (`cli`, `catalog`, `write`, `plugins`, `modules`, `flows`). The prior coarse FR-001..FR-011 set is superseded by a capability-grouped **FR-001..FR-021 / NFR-001..NFR-008** set, user stories reviewed and re-traced (+US-006), the test matrix regenerated against `tests/`, and a full `/spec-review` recorded.

## What changed

- **spec/spec.md** — 21 FRs + 8 NFRs covering arg grammar, version/help, config root, catalog assembly/dedup/duplicate-detection, authoring packs, plugin source grammar + lifecycle, ix-flow launch contract, plus NFR-007 (external-tool contract) and NFR-008 (catalog resilience) surfaced by analysis.
- **spec/usecase/** — normalized US-002..005 to the iso bold-marker shape, re-pointed all US→FR traces, added US-006 (duplicate type detection).
- **spec/matrix.md** — every FR/NFR/US mapped to a named vitest case; 100% coverage gate.
- **spec/review.md** — full `/spec-review`: automated checks, checklist, and all six analysis lenses (integrity, failure-domain, dependency, evidence, risk, scope).
- **tests/** — closed the two gaps the review surfaced (FR-017 `ensure-defaults` non-empty registry; NFR-008 strict-abort on corrupt manifest).

## Verification

- `quire validate` exits 0
- `make lint` clean, prettier clean
- `make test` 99/99; `pnpm run test:coverage` passes the 100% gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)