### PR TITLE
Restore /specify artifact-authoring orchestration + completeness evals

### DIFF
--- a/docs/skills-audit.md
+++ b/docs/skills-audit.md
@@ -1,0 +1,45 @@
+# Quoin Skills Audit
+
+Evaluation of the spec-authoring skills quoin ships (`skills/*`) against the
+upstream reference repo `agent-ix/spec-skills`, to find content lost or degraded
+when the skills were ported into quoin. Done 2026-06-20.
+
+## Design context
+
+The per-artifact `spec-write-fr/us/nfr/str` skills were **intentionally retired**:
+each requirement type's rules now live in its **template** (the skeleton + schema
+that `quoin write --types <T>` returns from the catalog). So their absence is by
+design, not a gap. What must NOT be lost is the **orchestration** — telling the
+agent to author each requested type as a discrete artifact file, in sequence —
+and the **process/reasoning** that templates can't encode (US→FR derivation,
+integration-test reality rules).
+
+## Findings
+
+| Skill                                                                                                             | Status                                                                                                                                                                                                                                                             | Action                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specify`                                                                                                         | **Degraded** — dropped the workflow orchestration, the "author each type as a file" rule, US→FR derivation, app-spec scoping; became a thin `quoin write` wrapper. This caused a backport to produce FRs as `spec.md` table rows instead of `FR-XXX.md` artifacts. | **Fixed** — SKILL.md rewritten to request-scoped orchestration (author StR/US/FR/NFR/IT as discrete files, stop at IT, then ask about matrix/review). |
+| `spec-us-to-fr`                                                                                                   | Removed (process skill — derivation reasoning, not a template rule).                                                                                                                                                                                               | **Folded** into `specify/references/us-to-fr.md` (loaded on demand).                                                                                  |
+| `spec-write-it`                                                                                                   | Removed (process skill — real-by-default IT rules, not template-encoded).                                                                                                                                                                                          | **Folded** into `specify/references/integration-tests.md`.                                                                                            |
+| `spec-write-fr/us/nfr/str`                                                                                        | Removed; rules now template-encoded.                                                                                                                                                                                                                               | None — intended.                                                                                                                                      |
+| `spec-blueprint`                                                                                                  | Removed (archetype FR-composition audit).                                                                                                                                                                                                                          | **Excluded** by decision.                                                                                                                             |
+| `spec-object-review`                                                                                              | Carries `references/object-type-guide.md` whose `assets/*-template.md` paths point at templates that live in the catalog, not the skill.                                                                                                                           | **Fixed** — added a note that templates resolve via `quoin write` / `quoin catalog show`.                                                             |
+| `spec-app-review`                                                                                                 | `artifact_type`→`type` rename only.                                                                                                                                                                                                                                | None.                                                                                                                                                 |
+| `spec-dependency/evidence/failure-domain/integrity/matrix/review/risk-complexity/scope-boundary/security/to-plan` | Parity with upstream.                                                                                                                                                                                                                                              | None.                                                                                                                                                 |
+| `spec-ideation`                                                                                                   | quoin-only addition (exploratory drafting gate before `specify`).                                                                                                                                                                                                  | None.                                                                                                                                                 |
+
+## Open follow-up (not fixed here)
+
+`skills/spec-review/`, `skills/spec-matrix/`, and `skills/spec-to-plan/` each
+vendor a compiled `workflow-assets/dist/index.js` whose **flow registry still
+lists the removed skills** (`spec-write-str/us/fr/nfr/it`, `spec-us-to-fr`,
+`spec-blueprint`). If those `ix-flow` workflows try to invoke the missing skills
+as steps, they break. The source is `ix-spec-workflows` (archived), so
+regenerating the bundles is non-trivial — tracked as a separate follow-up, not
+part of the `specify` fix.
+
+## Guard
+
+EV-021..EV-025 in `spec/evals.md` (the `artifacts` check in `evals/lib/assert.mjs`)
+assert that spec-change requests produce the right artifact **types as discrete
+files** — a regression guard for the `specify` degradation above.

--- a/evals/lib/assert.mjs
+++ b/evals/lib/assert.mjs
@@ -3,7 +3,7 @@
 // and keys `quire validate` pass/fail on EXIT CODE only — `DuplicateArchetype`
 // warnings on stderr coexist with a passing (exit 0) validation.
 
-import { readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -47,6 +47,34 @@ export function matchFiles(repo, glob) {
   return listFiles(repo).filter((f) => re.test(f));
 }
 
+/** Read the frontmatter `type:` discriminator of a markdown file (null if none). */
+function frontmatterType(abs) {
+  let text;
+  try {
+    text = readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+  if (!text.startsWith("---")) return null;
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) return null;
+  const m = text
+    .slice(3, end)
+    .match(/^type:\s*["']?([A-Za-z0-9_-]+)["']?\s*$/m);
+  return m ? m[1] : null;
+}
+
+/** Map every `*.md` under root to its frontmatter `type` (repo-relative path -> type). */
+function artifactsByType(root) {
+  const byType = {};
+  for (const rel of listFiles(root)) {
+    if (!rel.toLowerCase().endsWith(".md")) continue;
+    const t = frontmatterType(join(root, rel));
+    if (t) (byType[t.toLowerCase()] ??= []).push(rel);
+  }
+  return byType;
+}
+
 function ixSpec(ctx, args, env) {
   return spawnSync(process.execPath, [ixSpecBin(), ...args], {
     cwd: ctx.repo,
@@ -59,6 +87,7 @@ function ixSpec(ctx, args, env) {
  * Assert a scenario's expectations against the final repo + config state.
  * @param expect {
  *   files?: string[], validate?: {globs, shouldPass},
+ *   artifacts?: {require?: {[TYPE]: {min?, dir?}}, absent?: string[]},
  *   flow?: [{id, defName}], cliRejects?: string[],
  *   plugin?: {name, present}, resolvesTo?: {type, moduleNameIncludes},
  *   sentinel?: "complete"|"failed"
@@ -87,6 +116,38 @@ export function assertExpectations(
     matchedFiles[glob] = hits.length;
     if (hits.length === 0)
       failures.push(`no file matched expected glob: ${glob}`);
+  }
+
+  // Artifact-completeness: a request must produce the right artifact TYPES as
+  // discrete files (an FR authored only as a row in spec.md's table is NOT an FR
+  // artifact and must fail here). Keyed on frontmatter `type:`.
+  if (expect.artifacts) {
+    const { require: required = {}, absent = [] } = expect.artifacts;
+    const byType = artifactsByType(scope);
+    const pathsFor = (type) => byType[type.toLowerCase()] ?? [];
+    for (const [type, spec] of Object.entries(required)) {
+      const { min = 1, dir } = spec ?? {};
+      let paths = pathsFor(type);
+      if (dir) {
+        const prefix = dir.replace(/\/+$/, "") + "/";
+        paths = paths.filter((p) => p.startsWith(prefix));
+      }
+      checks[`artifacts:${type}`] = { ok: paths.length >= min, paths };
+      if (paths.length < min) {
+        failures.push(
+          `expected >=${min} ${type} artifact(s)${dir ? ` under ${dir}/` : ""}, found ${paths.length}`,
+        );
+      }
+    }
+    for (const type of absent) {
+      const paths = pathsFor(type);
+      checks[`artifacts:absent:${type}`] = { ok: paths.length === 0, paths };
+      if (paths.length > 0) {
+        failures.push(
+          `expected no ${type} artifact but found ${paths.length}: ${paths.join(", ")}`,
+        );
+      }
+    }
   }
 
   let validation = null;

--- a/evals/lib/fixtures.mjs
+++ b/evals/lib/fixtures.mjs
@@ -11,6 +11,14 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
+/** Write an arbitrary file into the scenario repo (e.g. seed source code to backport). */
+export function writeRepoFile(ctx, repoRelTarget, content) {
+  const target = join(ctx.repo, repoRelTarget);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content);
+  return target;
+}
+
 /** Copy a module skeleton (from the snapshotted modules) into the scenario repo. */
 export function copySkeleton(ctx, moduleName, skeletonFile, repoRelTarget) {
   const src = join(ctx.modulesDir, moduleName, "skeletons", skeletonFile);

--- a/evals/scenarios/index.mjs
+++ b/evals/scenarios/index.mjs
@@ -7,7 +7,12 @@
 //  - env:     optional (ctx)=>extra env for BOTH the agent run and the ground-truth
 //             assertion (e.g. QUOIN_MODULE_PATHS).
 //  - expect:  ground-truth success checks (see lib/assert.mjs):
-//             files, validate, flow, cliRejects, plugin, resolvesTo, sentinel.
+//             files, validate, artifacts, flow, cliRejects, plugin, resolvesTo, sentinel.
+//
+// EV-021..EV-025 are the artifact-completeness set: they drive `/specify` for
+// request shapes (new project / add US / edit FR / add US+FR / backport) and use
+// the `artifacts` check to assert the EXACT artifact types were authored as
+// discrete files (an FR written only as a row in spec.md's table fails).
 //
 // The two canaries (EV-001 greenfield, EV-008 repair loop) are the cheapest, highest
 // -signal scenarios; `--canary` runs only those.
@@ -19,6 +24,7 @@ import {
   makeDevModule,
   makeRepos,
   removeSeededModule,
+  writeRepoFile,
 } from "../lib/fixtures.mjs";
 
 export const SCENARIOS = [
@@ -371,6 +377,127 @@ export const SCENARIOS = [
         },
       ],
       files: ["spec/**/*.md"],
+      validate: { globs: ["spec/**/*.md"], shouldPass: true },
+    },
+  },
+
+  // --- EV-021..EV-025: artifact-completeness for spec-change requests ---------
+  {
+    id: "EV-021",
+    useCase: "US-001",
+    prompt:
+      "Start a new spec for a small URL-shortener service: a user submits a long " +
+      "URL and gets back a short code that later redirects to the original. Create " +
+      "the spec under spec/ — author the user story and the functional requirement " +
+      "that implements it as their own files.",
+    expect: {
+      files: ["spec/spec.md"],
+      artifacts: {
+        require: {
+          US: { min: 1, dir: "spec/usecase" },
+          FR: { min: 1, dir: "spec/functional" },
+        },
+      },
+      validate: { globs: ["spec/**/*.md"], shouldPass: true },
+    },
+  },
+  {
+    id: "EV-022",
+    useCase: "US-001",
+    setup(ctx) {
+      copySkeleton(
+        ctx,
+        "spec-artifacts-iso",
+        "us.md",
+        "spec/usecase/US-001-existing.md",
+      );
+    },
+    prompt:
+      "The repo already contains spec/usecase/US-001-existing.md. Add a SECOND " +
+      "user story for a different capability (for example: an administrator " +
+      "disables a short code). Author it as its own file. Do not write functional " +
+      "or non-functional requirements.",
+    expect: {
+      artifacts: {
+        require: { US: { min: 2, dir: "spec/usecase" } },
+        absent: ["FR", "NFR", "IT"],
+      },
+      validate: { globs: ["spec/**/*.md"], shouldPass: true },
+    },
+  },
+  {
+    id: "EV-023",
+    useCase: "US-002",
+    setup(ctx) {
+      copySkeleton(
+        ctx,
+        "spec-artifacts-iso",
+        "fr.md",
+        "spec/functional/FR-001-checksums.md",
+      );
+    },
+    prompt:
+      "The repo has spec/functional/FR-001-checksums.md. Edit ONLY that file to " +
+      "change the requirement to be about verifying a signed release manifest. " +
+      "Keep it valid and re-validate. Do not create any new artifacts.",
+    expect: {
+      artifacts: {
+        require: { FR: { min: 1, dir: "spec/functional" } },
+        absent: ["US", "NFR", "IT"],
+      },
+      validate: {
+        globs: ["spec/functional/FR-001-checksums.md"],
+        shouldPass: true,
+      },
+    },
+  },
+  {
+    id: "EV-024",
+    useCase: "US-001",
+    prompt:
+      "Add a user story for a user exporting their data as a CSV file, and the " +
+      "functional requirement that implements it. Author each as its own artifact " +
+      "file and trace the FR back to the user story.",
+    expect: {
+      artifacts: {
+        require: {
+          US: { min: 1, dir: "spec/usecase" },
+          FR: { min: 1, dir: "spec/functional" },
+        },
+      },
+      validate: { globs: ["spec/**/*.md"], shouldPass: true },
+    },
+  },
+  {
+    id: "EV-025",
+    useCase: "US-001",
+    setup(ctx) {
+      writeRepoFile(
+        ctx,
+        "src/shorten.mjs",
+        [
+          "// Maps a long URL to a 6-char base62 code and stores the pair.",
+          "export function shorten(url, store) {",
+          "  if (!/^https?:\\/\\//.test(url)) throw new Error('invalid url');",
+          "  const code = Math.abs(hash(url)).toString(36).slice(0, 6);",
+          "  store.set(code, url);",
+          "  return code;",
+          "}",
+          "export function resolve(code, store) {",
+          "  if (!store.has(code)) throw new Error('unknown code');",
+          "  return store.get(code);",
+          "}",
+          "function hash(s) { let h = 0; for (const c of s) h = (h * 31 + c.charCodeAt(0)) | 0; return h; }",
+          "",
+        ].join("\n"),
+      );
+    },
+    prompt:
+      "Backport a spec from the code in src/shorten.mjs. Capture its behavior as " +
+      "functional requirement artifacts under spec/functional/ (not just a summary " +
+      "table). Validate the spec files.",
+    expect: {
+      artifacts: { require: { FR: { min: 1, dir: "spec/functional" } } },
       validate: { globs: ["spec/**/*.md"], shouldPass: true },
     },
   },

--- a/skills/spec-object-review/references/object-type-guide.md
+++ b/skills/spec-object-review/references/object-type-guide.md
@@ -2,6 +2,11 @@
 
 When an FR defines a domain object, set the `object:` frontmatter field and use the matching template.
 
+> The `assets/...-template.md` names below identify each object type's template
+> **within its catalog module** — they are not files shipped in this skill.
+> Obtain the actual skeleton + schema with `quoin write --types <type>` (or
+> inspect a type with `quoin catalog show <type>`).
+
 ## Business Objects (spec-objects-business)
 
 - `entity` / `aggregate_root` / `nested_entity`: Data entity, model, or aggregate → `assets/business/entity-template.md`

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -1,49 +1,99 @@
 ---
 name: specify
-description: Create or update spec files using quoin catalog authoring packs and Quire validation.
+description: Create or update spec artifacts from a design or change request. Orchestrates authoring each requested requirement type (StR/US/FR/NFR/IT) as a discrete file using quoin catalog templates and Quire validation.
 ---
 
 # Specify
 
 Use this skill when turning an agreed design, feature, or change request into
-spec artifacts and supporting spec objects.
+spec artifacts. `specify` decides **which artifacts the request needs**, authors
+each one **as its own file** using the catalog templates, and validates.
+
+## Scope to the request
+
+Author **only the artifact types the request calls for** — nothing more.
+
+- "Add a user story for X" → one US.
+- "Add the FR that implements US-003" → one FR (traced to US-003).
+- "Add a user story and the requirement that implements it" → one US **and** one FR.
+- "Edit FR-002 to …" → edit that one FR file in place.
+- "Start a spec for service X" / "backport a spec from this code" → the full
+  chain (`spec.md` + US + FR + NFR, and IT where there are external integrations).
+
+When unsure which types a request implies, decide from the request and state what
+you are creating. A backport or new feature almost always needs **FR artifacts**,
+not just a summary.
+
+## Requirements are files, not table rows
+
+Each requirement is a **discrete artifact file** with `type:` frontmatter. The
+Requirements table inside `spec.md` (master-requirements) is an **index/summary**
+— it never replaces the artifacts. Author every requested requirement as its own
+file under the matching directory:
+
+| Type | `type:` | Location                       |
+| ---- | ------- | ------------------------------ |
+| StR  | `StR`   | `spec/stakeholder/StR-XXX-*.md`|
+| US   | `US`    | `spec/usecase/US-XXX-*.md`     |
+| FR   | `FR`    | `spec/functional/FR-XXX-*.md`  |
+| NFR  | `NFR`   | `spec/non-functional/NFR-XXX-*.md` |
+| IT   | `IT`    | `spec/integration/IT-XXX-*.md` |
+
+> If a request asks for functional requirements and you produced only table rows
+> in `spec.md`, the request is **not done** — create the `FR-XXX.md` files.
 
 ## Process
 
-1. Identify the repository that owns the spec files.
-2. Identify every artifact and object type that will be created or edited.
-3. Run `quoin write <repo_dir> --types <type[,type...]>` once for the full set of types.
-4. Use the returned skeletons, schemas, module roots, and examples as the authoring contract.
-5. Author or edit the files directly in the target repo.
-6. Run `quire validate <glob> [glob2 ...]` over the changed spec scope.
-7. Fix validation errors before moving to review, matrix, or planning work.
+Run only the steps the request needs; stop after IT.
 
-## Type Selection
+1. Identify the repository that owns the spec files, and which artifact types the
+   request implies (any subset of StR, US, FR, NFR, IT).
+2. Run `quoin write <repo_dir> --types <type[,type...]>` **once** for the full
+   set. Use the returned skeletons, schemas, module roots, and examples as the
+   authoring contract — the per-type rules live in the template, not your memory.
+3. Author each artifact as its own file (table above), in this logical order,
+   skipping any type not requested:
+   - `spec.md` (only when starting a new spec) → StR → US →
+     **derive FR from US** (see [references/us-to-fr.md](references/us-to-fr.md))
+     → FR → NFR → IT (see [references/integration-tests.md](references/integration-tests.md)).
+4. Keep traceability in frontmatter `relationships:` (e.g. a US `traces_to` its
+   FRs; an FR/NFR/IT links back to the US/FR it serves).
+5. Run `quire validate <glob> [glob2 ...]` over the changed spec scope and fix
+   every error before continuing.
+6. **Stop at IT.** Then ask the user whether to build the test matrix
+   (`spec-matrix`) and run review (`spec-review`) — unless they already requested
+   them. Only run those on confirmation.
 
-Request all needed types together so the agent does not repeatedly fetch the
-same templates.
+## Functional requirements
 
-Examples:
+FRs are normative (`SHALL` / `SHALL NOT`), atomic, and independently verifiable,
+each with an Acceptance Criteria table (the `fr.md` skeleton enforces the shape).
 
-```bash
-quoin write . --types FR,domain,entity
-quoin write ../service --types StR,US,FR,NFR
-quoin write . --types process,configuration,value_object
-```
+- Derive FRs from the driving user story — see
+  [references/us-to-fr.md](references/us-to-fr.md).
+- A behavioral FR has no `object:` field. A **domain-typed** FR carries
+  `object: <type>` (e.g. `entity`, `event`, `api_endpoint`, `process`,
+  `configuration`) and uses that type's structural template. Look up the
+  type→template map and relationship verbs in
+  `spec-object-review`'s `references/object-type-guide.md`, and inspect a type
+  with `quoin catalog show <type>`.
 
-Type lookup is catalog-driven and case-insensitive. Types may come from bundled
-`spec-artifacts-*`, bundled `spec-objects-*`, user-installed modules, or
-community modules.
+## Application specs
 
-## Authoring Rules
+When `component_type: application`, initialize `spec.md` from
+`assets/app-spec-template.md`. Application specs own **only cross-service
+concerns** — architecture rationale (ADRs), cross-service sequence diagrams,
+system-level NFRs, the external consumer contract, scope boundaries, security
+model. Per-service detail (endpoint contracts, DB schemas, per-service NFRs)
+stays in the individual service specs. Otherwise use `assets/spec-template.md`.
 
-- Let frontmatter identify exactly what each file is. The discriminator field is
-  `type` (e.g. `type: FR`, `type: master-requirements`); it names the archetype the
-  document conforms to.
+## Authoring rules
+
+- Let frontmatter identify each file. The discriminator is `type` (e.g.
+  `type: FR`, `type: master-requirements`) — it names the archetype.
 - Use catalog skeletons and schemas rather than memory.
 - Keep workflow definitions out of artifact/object type vocabularies.
-- Validate every created or edited artifact with Quire.
-- Use `spec-review` after validation for quality, consistency, and completeness review.
+- Validate every created or edited artifact with Quire before finishing.
 
 ## Reserved OKF Files
 
@@ -59,11 +109,11 @@ author them like any other type:
 ```text
 spec/
 ├── spec.md
-├── stakeholder/
-├── usecase/
-├── functional/
-├── non-functional/
-├── integration/
+├── stakeholder/      # StR-XXX
+├── usecase/          # US-XXX
+├── functional/       # FR-XXX
+├── non-functional/   # NFR-XXX
+├── integration/      # IT-XXX
 ├── matrix/
 └── analysis/
 ```

--- a/skills/specify/references/integration-tests.md
+++ b/skills/specify/references/integration-tests.md
@@ -1,0 +1,72 @@
+# Authoring Integration Tests (IT)
+
+Load this when a request involves integration tests — i.e. the system talks to
+external services (HTTP APIs, event buses, databases, third-party/cloud APIs).
+The per-section shape comes from the `IT` template (`quoin write --types IT`);
+this file carries the *reasoning and reality rules* that the template can't
+enforce.
+
+## Scope
+
+HTTP client integrations, event bus connections (Kafka, RabbitMQ), database
+connections (Postgres, Redis), and external APIs. One test case per file,
+sequentially numbered (`IT-XXX`), saved to `spec/integration/IT-XXX-*.md`.
+
+## Reality rules — REAL by default
+
+> Integration tests are **ALWAYS REAL** by default. Nothing is mocked unless the
+> spec explicitly says so. An IT that only checks imports or constructs models
+> without exercising real behavior is a **GAP**.
+
+Every IT MUST include acceptance criteria from **both** categories:
+
+- **Real Setup ACs** — the non-mocked environment is established: service running
+  and healthy (real health endpoint), real dependencies available (DB, bus,
+  external service), fixtures loaded into real stores, config applied through real
+  loading paths.
+- **Real Output ACs** — real output from real services: HTTP responses
+  (status/headers/body), DB state changes (rows inserted/updated/deleted), events
+  published to and consumed from a real bus, file-system state, SSE/WebSocket
+  streams, LLM responses through real provider chains.
+
+| Real (required)                                   | Not real (GAP)                 |
+| ------------------------------------------------- | ------------------------------ |
+| POST to endpoint, assert response body            | `assert MyModel is not None`   |
+| Query DB after a write, verify rows changed       | `MyModel(field="value")`       |
+| Publish event, consume from real bus, verify load | `assert EventSchema is not None` |
+| GET /health, verify HTTP 200 + status body        | `assert app is not None`       |
+
+### Mocking policy
+
+- **Default: NO MOCKS.** ITs exercise real service boundaries.
+- **Approved mock targets** only when the spec explicitly requires it: external
+  third-party APIs (payment, auth, cloud) via test doubles over real HTTP;
+  external services outside the test boundary via contract-faithful stubs.
+- **Never mock**: HTTP transport, config loading, DB connections, file I/O,
+  session storage, event publishing, health endpoints, WebSocket/SSE connections.
+- When a mock IS used, the IT must state WHY the real service can't be used, WHAT
+  boundary the mock replaces, and HOW the mock is verified faithful.
+
+## Process
+
+1. List the external dependencies from the codebase (the integration points).
+2. Take the next `IT-XXX`; get the contract with `quoin write --types IT`.
+3. Fill the template: Target Integration (service + protocol), Preconditions
+   (environment + data state), Test Data (`TD-XXX` fixtures with rationale),
+   Execution Plan (atomic steps, each with a timeout and `IT-XXX-SC-XX` success
+   criterion), Expected Outcome (success condition + failure modes).
+4. **Traceability is required**: every IT links to ≥1 FR/StR/NFR via frontmatter
+   `relationships:` (`type: verifies`). Cross-component references are fine
+   (e.g. `ix://org/other-service/FR-001`) per ISO 29148 bidirectional traceability.
+
+## Patterns by service type
+
+- **API (FastAPI/REST)**: CRUD to real endpoints (verify codes/body/DB state);
+  invalid payloads → real 4xx; auth with/without creds → real 401/403.
+- **Database**: real Alembic migrations → schema state; insert/query/update/delete
+  → row state; constraint violations → real DB errors.
+- **Event-driven (FastStream)**: publish to a real topic, consume, verify payload;
+  produce an event, verify processing + side effects.
+- **Worker**: submit a real job → completion state; slow job → timeout + cleanup.
+- **Agent (LLM)**: deterministic scripted LLM via real API → verify tool calls;
+  real tool execution → file/process state; real SSE/WS → event sequence.

--- a/skills/specify/references/us-to-fr.md
+++ b/skills/specify/references/us-to-fr.md
@@ -1,0 +1,40 @@
+# Deriving Functional Requirements from a User Story
+
+Load this when a request involves turning user stories into functional
+requirements. It carries the *reasoning* for the derivation; the per-FR section
+rules come from the `FR` template (`quoin write --types FR`).
+
+## Rules
+
+- **Atomic**: decompose the story into specific, single-behavior FRs.
+- **Normative**: FRs use `SHALL` / `SHALL NOT` (a US never does).
+- **No copying**: translate intent into a technical specification — do not paste
+  the story text.
+- **Verifiable**: every FR carries its own Acceptance Criteria table.
+
+## Process
+
+1. **Analyze** the `US-XXX`: list the system responsibilities it implies.
+2. **Decompose** into typed FRs. A behavioral FR (no `object:`) captures logic
+   and business rules. A domain-typed FR carries `object: <type>` and is purely
+   structural:
+   - `entity` — data model with typed fields
+   - `event` — a domain event emitted
+   - `api_endpoint` — a REST/HTTP endpoint
+   - `queue` — a message contract
+   - `process` — an end-to-end workflow
+   - `state_machine` — an entity lifecycle
+   - `configuration` — a configuration schema
+   - Full list + relationship verbs: `spec-object-review`'s
+     `references/object-type-guide.md`; inspect any type with
+     `quoin catalog show <type>`.
+3. **Author** each FR as its own file (`quoin write --types FR` for the contract),
+   and link it back to the story via frontmatter `relationships:`
+   (`type: implements`, target the `US-XXX`).
+4. **Specify** inputs/outputs (typed and validated), error handling (failure
+   modes), and constraints (technical limits, not options).
+5. **Separation of concerns**: keep behavioral triggers/validation in behavioral
+   FRs; domain-typed FR acceptance criteria test **structure** only (schema/field
+   presence), never behavior. Do not duplicate behavioral ACs into a domain FR.
+6. **Save** to `spec/functional/FR-XXX-description.md` (single repo) or
+   `specs/<category>/<component>/spec/functional/FR-XXX-description.md` (multi-repo).

--- a/spec/evals.md
+++ b/spec/evals.md
@@ -49,15 +49,16 @@ agent can use the commands efficiently to produce valid spec artifacts.
 
 ## Variation Coverage
 
-| Dimension          | Required Variations                                                                                           |
-| ------------------ | ------------------------------------------------------------------------------------------------------------- |
-| Authoring mode     | greenfield repo, brownfield edit, multi-document creation, validation repair loop                             |
-| Type source        | bundled artifact, bundled object, installed local plugin, installed GitHub/plugin package, sibling dev module |
-| Type lookup        | canonical casing, lowercase input, mixed artifact/object request, unknown type                                |
-| Validation scope   | exact module scope, repo search scope, multiple glob arguments, changed-file subset, invalid document         |
-| Workflow lifecycle | review launch, matrix launch, to-plan launch, status inspection, human gate handoff                           |
-| Config state       | clean isolated `~/.ix`, existing plugin registry, plugin removal/reinstall                                    |
-| Agent efficiency   | one authoring pack reused across multiple files, no repeated template fetch for same type                     |
+| Dimension             | Required Variations                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Authoring mode        | greenfield repo, brownfield edit, multi-document creation, validation repair loop                             |
+| Type source           | bundled artifact, bundled object, installed local plugin, installed GitHub/plugin package, sibling dev module |
+| Type lookup           | canonical casing, lowercase input, mixed artifact/object request, unknown type                                |
+| Validation scope      | exact module scope, repo search scope, multiple glob arguments, changed-file subset, invalid document         |
+| Workflow lifecycle    | review launch, matrix launch, to-plan launch, status inspection, human gate handoff                           |
+| Config state          | clean isolated `~/.ix`, existing plugin registry, plugin removal/reinstall                                    |
+| Agent efficiency      | one authoring pack reused across multiple files, no repeated template fetch for same type                     |
+| Artifact completeness | request → required artifact set: new project, add US only, edit FR only, add US+FR, backport → FR artifacts   |
 
 ## Scenarios
 
@@ -82,10 +83,19 @@ agent can use the commands efficiently to produce valid spec artifacts.
 | EV-017 | US-001, US-002 | Author a larger feature spec set with cross-references.               | Agent authors StR + 2 US + 3 FR + NFR + domain + 2 entity, fetching each contract once; all validate.                              | success, latency, tool calls, tokens, context fetches     |
 | EV-018 | US-001         | Author objects drawn from three different object modules.             | One `write` pack resolves `domain`/`api_endpoint`/`configuration` across modules; all validate.                                    | success, latency, tool calls, tokens                      |
 | EV-020 | US-003         | Install a module from GitHub via a subdir source and author its type. | Agent runs `quoin plugin install github:owner/repo//subdir@ref` (real network clone), then authors and validates one of its types. | success, latency, tool calls, tokens                      |
+| EV-021 | US-001         | Start a new spec from a settled idea (greenfield).                    | Agent creates `spec.md` plus ≥1 US and ≥1 FR **as discrete files**; all validate. (`artifacts` check)                              | success, latency, tool calls, tokens                      |
+| EV-022 | US-001         | Add one user story to an existing spec.                               | Agent adds a new `US` file and creates **no** FR/NFR/IT artifacts; all validate. (`artifacts` require + absent)                    | success, latency, tool calls                              |
+| EV-023 | US-002         | Edit an existing FR in place.                                         | Agent modifies the FR file only, creating no new artifact types; the FR validates. (`artifacts` require + absent)                  | success, latency, tool calls, validation attempts         |
+| EV-024 | US-001         | Add a user story **and** the FR that implements it.                   | Agent authors **both** a `US` and an `FR` artifact (FR traced to the US); all validate. (`artifacts` require)                      | success, latency, tool calls, tokens                      |
+| EV-025 | US-001         | Backport a spec from a small source file.                             | Agent authors ≥1 `FR` artifact under `spec/functional/` (not just a `spec.md` table) capturing the code's behavior; all validate.  | success, latency, tool calls, tokens                      |
 
 > EV-016..EV-018 and EV-020 extend the original EV-001..EV-015 set (multi-repo,
-> larger spec-set, multi-module, real GitHub subdir install). They live alongside
-> the rest in `evals/scenarios/index.mjs`.
+> larger spec-set, multi-module, real GitHub subdir install). EV-021..EV-025 are
+> the **artifact-completeness** set: they drive `/specify` for spec-change request
+> shapes (new project, add US, edit FR, add US+FR, backport) and assert via the
+> `artifacts` check that the request produced the exact artifact **types** as
+> discrete files — guarding against requirements authored only as `spec.md` table
+> rows. They live alongside the rest in `evals/scenarios/index.mjs`.
 
 ## Harness Requirements
 


### PR DESCRIPTION
## Why

`/specify` had degraded into a thin `quoin write` wrapper that no longer told the agent to author each requested requirement type as a **discrete artifact file**. That is the root cause of a recent backport producing FRs as rows in `spec.md`'s table instead of `spec/functional/FR-XXX.md` artifacts. The per-artifact `spec-write-*` skills were intentionally retired (rules now live in the catalog **templates**), so the fix is to restore the **orchestration**, not those skills.

## Changes

- **`skills/specify/SKILL.md`** — rewritten as a request-scoped orchestrator: author only the requested types (StR/US/FR/NFR/IT) as discrete files, get the contract from `quoin write --types`, stop at IT, then ask about matrix/review. Restores domain-typing + application-spec scoping; states plainly that the `spec.md` table is an index, not a substitute for artifacts.
- **`skills/specify/references/`** — fold the retired *process* skills back in as on-demand references: `us-to-fr.md` (US→FR derivation) and `integration-tests.md` (real-by-default IT rules). `spec-blueprint` excluded.
- **Evals (Part C)** — new `artifacts` assertion in `evals/lib/assert.mjs` keyed on frontmatter `type:` (with `absent` for spurious types), and **EV-021..EV-025** (new-project / add-US / edit-FR / add-US+FR / backport) in `evals/scenarios/index.mjs` + `spec/evals.md`. These guard artifact completeness for spec-change requests — verified red/green at the harness level (FR-as-file passes, FR-as-table-row fails).
- **`docs/skills-audit.md`** — full skills gap evaluation across all quoin skills. Flags a latent follow-up: the compiled `workflow-assets/dist` flow registries in spec-review/matrix/to-plan still list the removed skills.
- **`spec-object-review/.../object-type-guide.md`** — note that templates resolve via the catalog, not skill-local assets.

## Verification

- `make lint` clean (prettier ✓), `make test` 99/99, `quire validate` exit 0.
- New `artifacts` assertion unit-checked red/green.
- Agent-pty eval run (EV-021..025 against the live agent) not run here (needs tmux+Claude); runnable via `make evals` / `node evals/run.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)