### PR TITLE
feat: add update self-update command

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test-results:warnings": "./node_modules/.bin/jest-results warnings"
   },
   "dependencies": {
-    "@agent-ix/ix-cli-core": ">=0.10.4",
+    "@agent-ix/ix-cli-core": ">=0.10.5",
     "@agent-ix/ts-plugin-kit": ">=0.1.3",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@agent-ix/ix-cli-core':
-        specifier: '>=0.10.4'
-        version: 0.10.4(@oclif/core@4.11.4)
+        specifier: '>=0.10.5'
+        version: 0.10.5(@oclif/core@4.11.4)
       '@agent-ix/ts-plugin-kit':
         specifier: '>=0.1.3'
         version: 0.1.3
@@ -63,8 +63,8 @@ importers:
 
 packages:
 
-  '@agent-ix/ix-cli-core@0.10.4':
-    resolution: {integrity: sha512-sjZ1aYaa6msyjVFEBUCQyHgIjvkjUTlbgD8jEE8UVGHgu2AIcdgiEvUh6MfnUmbw8nj3xlyxX+heMFrn0OFzBA==}
+  '@agent-ix/ix-cli-core@0.10.5':
+    resolution: {integrity: sha512-Twe+we1yy7rcXAaZQd3mOVi/gfPc34BTmw8dLLjsUqiNdGp0tPYASi5kKcqkN4q6OEw0CPbPBpw9SVFaNXyS+A==}
     peerDependencies:
       '@oclif/core': '>=4.11.4'
 
@@ -1306,8 +1306,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1677,7 +1677,7 @@ packages:
 
 snapshots:
 
-  '@agent-ix/ix-cli-core@0.10.4(@oclif/core@4.11.4)':
+  '@agent-ix/ix-cli-core@0.10.5(@oclif/core@4.11.4)':
     dependencies:
       '@agent-ix/ix-ui-cli': 0.4.10
       '@agent-ix/ts-plugin-kit': 0.1.3
@@ -1926,7 +1926,7 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 10.2.5
-      semver: 7.8.3
+      semver: 7.8.4
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.17
@@ -2852,7 +2852,7 @@ snapshots:
 
   semver@7.8.2: {}
 
-  semver@7.8.3: {}
+  semver@7.8.4: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -20,11 +20,13 @@ Coverage is mapped requirement → test as `file :: "test name"`:
 - `flows.test.ts` / `flows-notfound.test.ts` — workflow launchers and the real
   fake `ix-flow` binary (exit 0 / non-zero / signal / spawn-error).
 - `scripts.test.ts` — built CLI help/version surface.
+- `update.test.ts` — `runUpdate` delegation to ix-cli-core's `runSelfUpdate`
+  (package coordinates, `--check`, `--registry`); module fully mocked.
 - `index.test.ts` — the public library surface end to end.
 
 > Coverage gate: `vite.config.ts` declares 100% v8 thresholds
 > (branches/functions/lines/statements). `make test` (`vitest run`) passes all
-> 99 tests and `pnpm run test:coverage` passes the gate at **100%**
+> 102 tests and `pnpm run test:coverage` passes the gate at **100%**
 > (branches/functions/lines/statements).
 
 ## Functional Requirements
@@ -52,6 +54,7 @@ Coverage is mapped requirement → test as `file :: "test name"`:
 | FR-019      | ✅ Covered | `plugins.test.ts` :: "install adds a plugin from a path source"; :: "installs, lists, then removes a plugin and its target dir + registry entry"; readModuleName suite ("reads the name from a top-level manifest.yaml"…); `cli.test.ts` :: "install without a source throws"; :: "remove without a name throws"; :: "remove deletes a plugin and prints confirmation"                                                          |
 | FR-020      | ✅ Covered | `flows.test.ts` :: "lists the bundled spec flows"; :: "throws for an unknown flow name"; `flows-notfound.test.ts` :: "throws when no candidate root contains the skill"                                                                                                                                                                                                                                                         |
 | FR-021      | ✅ Covered | `flows.test.ts` :: "resolves when ix-flow exits 0; builds id/json/target args"; :: "matrix runs the flow and propagates a non-zero exit code"; :: "defaults exit code to 1 when ix-flow is killed by a signal (null code)"; :: "rejects when ix-flow cannot be spawned (PATH has no ix-flow)"; `cli.test.ts` :: "review with --target/--json/--id runs the flow (ix-flow exit 0)"                                               |
+| FR-022      | ✅ Covered | `update.test.ts` :: "delegates to runSelfUpdate with quoin's package coordinates" (asserts packageName `@agent-ix/quoin`, currentVersion, header "quoin update", registry undefined → ambient config, check false); :: "passes --check through"; :: "passes a custom --registry through"                                                                                                                                        |
 
 ## Non-Functional Requirements
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -22,8 +22,8 @@ requiring the broader `ix` umbrella CLI.
 
 - The `quoin` command surface: argument parsing, `version`/help, `catalog`
   list/show/validate, `write` authoring packs, `plugin`
-  install/list/remove/ensure-defaults, and the `review`/`matrix`/`to-plan`
-  workflow launchers.
+  install/list/remove/ensure-defaults, the `review`/`matrix`/`to-plan`
+  workflow launchers, and the `update` self-update command.
 - Assembly of a Filament catalog from module roots (`QUOIN_MODULE_PATHS` plus
   the installed module store) and the authoring contract it exposes (skeletons,
   schemas, module roots).
@@ -46,7 +46,8 @@ requiring the broader `ix` umbrella CLI.
 `quoin` is a single `main(argv)` dispatcher built on
 `@agent-ix/ix-cli-core`. It parses a leading command (and, for `catalog` and
 `plugin`, a subcommand), resolves a config root, configures the shared runtime
-context, and dispatches to the catalog, authoring, plugin, or workflow surface.
+context, and dispatches to the catalog, authoring, plugin, workflow, or
+self-update surface.
 It assembles a Filament catalog from module roots, authors nothing itself —
 instead returning the local skeletons, schemas, and a `quire validate` command
 that the calling agent uses as its authoring contract. It installs
@@ -73,7 +74,7 @@ Stories that drive them are listed under Use Cases and authored in
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | FR-001 | The CLI SHALL parse a leading command and (for `catalog`/`plugin`) a subcommand, `--flag=value` and `--flag value` long flags, `-x` short boolean flags, and bare positionals, accumulating repeated `--types` and `--target` flags into ordered lists.                                               | Test         |
 | FR-002 | The CLI SHALL print its package version (read from `package.json`) for the `version` command, `--version`, or `-v`, and SHALL fail if the package version is missing or non-string.                                                                                                                   | Test         |
-| FR-003 | The CLI SHALL print root usage when invoked with no command, and command-scoped help for `--help`/`-h` on `write`, `catalog`, `plugin`, and the spec-flow commands, falling back to root usage for unrecognized commands.                                                                             | Test         |
+| FR-003 | The CLI SHALL print root usage when invoked with no command, and command-scoped help for `--help`/`-h` on `write`, `catalog`, `plugin`, `update`, and the spec-flow commands, falling back to root usage for unrecognized commands.                                                                   | Test         |
 | FR-004 | The CLI SHALL resolve a config root from `--config-root` (defaulting to `~/.ix` via `IX_HOME`), export it to `IX_HOME`, and configure the shared `ix-cli-core` runtime context with namespace `ix` and project config root `<cwd>/.ix`, disabling project config when `--no-project-config` is given. | Test         |
 | FR-005 | The CLI SHALL reject an unknown command or an unknown `catalog`/`plugin` subcommand by throwing an error that includes usage, and SHALL exit non-zero.                                                                                                                                                | Test         |
 
@@ -112,6 +113,12 @@ Stories that drive them are listed under Use Cases and authored in
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | FR-020 | The CLI SHALL expose the `review`, `matrix`, and `to-plan` workflow launchers, resolving each workflow's skill path across `IX_SPEC_WORKFLOWS_ROOT`, the packaged skills, a sibling `ix-spec-workflows` checkout, and `~/.ix/plugins`, and erroring when no candidate contains the skill.                                                 | Test         |
 | FR-021 | On launch the CLI SHALL spawn `ix-flow run <flow> --path <skill> --config-root <home> --state-dir <home>/flows` with optional `--id`/`--json`/`--target` arguments, propagate ix-flow's exit code (defaulting to 1 on signal), surface spawn errors, and hand all subsequent lifecycle control (resume/advance/gate/status) to `ix-flow`. | Test         |
+
+### Functional Requirements — Self-Update
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                                                                                                        | Verification |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| FR-022 | The CLI SHALL expose an `update` command that upgrades quoin to the latest published `@agent-ix/quoin` by delegating to `ix-cli-core`'s `runSelfUpdate` (npm view → compare to the running version → `npm install -g`), supporting `--check` (report availability without installing) and `--registry <url>` (force a registry); with no `--registry` the ambient npm config resolves the package. | Test         |
 
 ### Non-Functional Requirements
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { configureRuntimeContext } from "@agent-ix/ix-cli-core";
+import { configureRuntimeContext, runSelfUpdate } from "@agent-ix/ix-cli-core";
 
 import { findCatalogEntry, ixHome, loadCatalog } from "./catalog.js";
 import { ensureDefaultModules } from "./modules.js";
@@ -43,6 +43,7 @@ Usage:
   quoin plugin list
   quoin plugin remove <name>
   quoin review|matrix|to-plan [--target <ref>...]
+  quoin update [--check] [--registry <url>]
 
 Global flags:
   --json
@@ -141,6 +142,31 @@ Examples:
   quoin plugin ensure-defaults
 `;
 
+const UPDATE_USAGE = `quoin update
+
+Check for and install the latest published quoin.
+
+quoin is distributed on the public npm registry as @agent-ix/quoin. This command
+queries the registry for the latest version, compares it to the running version,
+and (unless --check) runs npm install -g to upgrade in place.
+
+Usage:
+  quoin update [--check] [--registry <url>]
+
+Flags:
+  --check               Report whether an update is available; do not install.
+  --registry <url>      Force an npm registry to query/install from. Defaults
+                        to your npm config (the registry @agent-ix resolves to,
+                        i.e. however quoin was installed). Pass
+                        https://registry.npmjs.org/ for public npm, or
+                        http://npm.ix/ for local dev snapshots.
+
+Examples:
+  quoin update
+  quoin update --check
+  quoin update --registry http://npm.ix/
+`;
+
 const FLOW_USAGE = `quoin workflows
 
 Start bundled spec review/planning workflows. quoin creates the workflow run in ~/.ix/flows.
@@ -185,6 +211,7 @@ export async function main(argv: string[]): Promise<void> {
     projectConfigEnabled: parsed.flags["no-project-config"] !== true,
   });
 
+  if (parsed.command === "update") return runUpdate(parsed);
   if (parsed.command === "catalog") return runCatalog(parsed);
   if (parsed.command === "plugin") return runPlugin(parsed);
   if (parsed.command === "write") return runWrite(parsed);
@@ -210,6 +237,7 @@ export function packageVersion(): string {
 }
 
 function helpFor(parsed: ParsedArgs): string {
+  if (parsed.command === "update") return UPDATE_USAGE;
   if (parsed.command === "write") return WRITE_USAGE;
   if (parsed.command === "catalog") return CATALOG_USAGE;
   if (parsed.command === "plugin") return PLUGIN_USAGE;
@@ -235,6 +263,18 @@ function runWrite(parsed: ParsedArgs): void {
       ? JSON.stringify(pack, null, 2)
       : formatAuthoringPack(pack),
   );
+}
+
+async function runUpdate(parsed: ParsedArgs): Promise<void> {
+  await runSelfUpdate({
+    packageName: "@agent-ix/quoin",
+    currentVersion: packageVersion(),
+    header: "quoin update",
+    // undefined → ambient npm config (the registry @agent-ix resolves to).
+    // Override for local dev with --registry http://npm.ix/.
+    registry: stringFlag(parsed, "registry"),
+    check: parsed.flags.check === true,
+  });
 }
 
 function runCatalog(parsed: ParsedArgs): void {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+// `quoin update` delegates to ix-cli-core's runSelfUpdate. Mock the whole
+// module so we assert the delegation contract (package name, flags) without
+// touching the network or npm. configureRuntimeContext is also imported by
+// main(), so it must be present as a no-op.
+// vi.mock is hoisted above module init, so the spy must be created inside
+// vi.hoisted (also hoisted) rather than referencing a plain top-level const.
+const { runSelfUpdate } = vi.hoisted(() => ({
+  runSelfUpdate: vi.fn(async () => ({ updated: false, latest: "9.9.9" })),
+}));
+vi.mock("@agent-ix/ix-cli-core", () => ({
+  configureRuntimeContext: () => {},
+  runSelfUpdate,
+}));
+
+import { main, packageVersion } from "../src/cli";
+
+describe("quoin update", () => {
+  it("delegates to runSelfUpdate with quoin's package coordinates", async () => {
+    await main(["update"]);
+    expect(runSelfUpdate).toHaveBeenCalledTimes(1);
+    expect(runSelfUpdate).toHaveBeenCalledWith({
+      packageName: "@agent-ix/quoin",
+      currentVersion: packageVersion(),
+      header: "quoin update",
+      registry: undefined,
+      check: false,
+    });
+  });
+
+  it("passes --check through", async () => {
+    runSelfUpdate.mockClear();
+    await main(["update", "--check"]);
+    expect(runSelfUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ check: true }),
+    );
+  });
+
+  it("passes a custom --registry through", async () => {
+    runSelfUpdate.mockClear();
+    await main(["update", "--registry", "http://npm.ix/"]);
+    expect(runSelfUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ registry: "http://npm.ix/" }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a \`quoin update\` command that upgrades quoin to the latest published \`@agent-ix/quoin\`, by delegating to \`@agent-ix/ix-cli-core\`'s \`runSelfUpdate\` (npm view → compare to running version → \`npm install -g\`).

- \`quoin update [--check] [--registry <url>]\`
- \`--check\` reports availability without installing; \`--registry\` forces a registry (defaults to the ambient npm config — however quoin was installed).
- Wires \`UPDATE_USAGE\` help, the dispatch branch, the top-level usage line, and the System Overview.

## Dependency

Requires \`@agent-ix/ix-cli-core >=0.10.5\` (the release that exports \`runSelfUpdate\`, published from agent-ix/ix-cli-core#2). The lockfile is relocked to 0.10.5 (resolved from public npm; 0 npm.ix refs). Verified at runtime: \`quoin update --check\` loads the real helper and reports correctly.

## Spec
- New **FR-022** (Self-Update section in \`spec/spec.md\`) + In-Scope surface, System Overview, and FR-003 (help list) edits.
- FR-022 added to \`spec/matrix.md\` with traceability to \`tests/update.test.ts\`.

## Tests
\`tests/update.test.ts\` (vitest) asserts the delegation contract: correct package coordinates, \`--check\` pass-through, \`--registry\` pass-through. Mocks only the \`@agent-ix/ix-cli-core\` import edge (via \`vi.hoisted\`). \`make build\` / \`make lint\` / \`make test\` (102 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)