### PR TITLE
chore(modules): pin spec-artifacts-process to v0.4.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.2.0
 
   - name: spec-artifacts-process
-    version: "0.3.0"
+    version: "0.4.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.3.0
+      ref: v0.4.0
 
   - name: spec-objects-business
     version: "0.3.0"


### PR DESCRIPTION
## What

Bumps the `spec-artifacts-process` default-module pin from `v0.3.0` to **v0.4.0** (version + git-subdir `ref`).

## Why

v0.4.0 adds `gap-analysis` to the SpecReview `analysis` enum (agent-ix/spec-artifacts-process#5, tagged + wheel published). With this pin, the `gap-analysis` skill's SpecReview output validates, so the EV-030..EV-033 evals are green in CI (previously RED-by-design pending the release).

## Validation

Rebuilt the eval seed fresh: the reconcile clones spec-artifacts-process at the real `v0.4.0` git tag and the seeded module carries the `gap-analysis` enum (no local-path hack). The 4 gap-analysis evals run green against this released configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)