### PR TITLE
feat(skills): open authored artifact in filament-ide cockpit

### DIFF
--- a/skills/spec-to-plan/SKILL.md
+++ b/skills/spec-to-plan/SKILL.md
@@ -63,3 +63,10 @@ This skill produces or updates a **plan bundle** at `<project_root>/plan/<Plan-i
 
 Validate the bundle with:
 `quire validate --scope <project_root> "plan/**/*.md"`
+
+## Open in the review cockpit
+
+After the bundle validates, run `filament open <plan-bundle>/plan.md` to open the
+plan in the running filament-ide cockpit (it fires the `filament-ide://` deep link
+and prints a clickable link as a fallback). Skip silently if the `filament`
+command is not installed.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -63,7 +63,13 @@ Run only the steps the request needs; stop after IT.
    FRs; an FR/NFR/IT links back to the US/FR it serves).
 5. Run `quire validate <glob> [glob2 ...]` over the changed spec scope and fix
    every error before continuing.
-6. **Stop at IT.** Then ask the user whether to build the test matrix
+6. **Open in the review cockpit.** After validation passes, run
+   `filament open <primary-artifact>` to open the authored artifact in the running
+   filament-ide cockpit (it fires the `filament-ide://` deep link and prints a
+   clickable link as a fallback). Use the main artifact you created — the
+   new/edited `FR-XXX.md`, or `spec/spec.md` when starting a spec. Skip silently if
+   the `filament` command is not installed.
+7. **Stop at IT.** Then ask the user whether to build the test matrix
    (`spec-matrix`) and run review (`spec-review`) — unless they already requested
    them. Only run those on confirmation.
 


### PR DESCRIPTION
`specify` and `spec-to-plan` now run `filament open <artifact>` as their final
step (after `quire` validation), firing the `filament-ide://` deep link so the
just-authored artifact opens automatically in the running filament-ide review
cockpit — with a clickable link printed as a fallback. Skipped silently when the
`filament` command isn't installed.

This is the quoin side of the filament-ide v2 "open in cockpit" handoff (US-007 /
FR-011..014). The app side (deep-link scheme + `filament open` CLI) ships in
filament-ide.

## User story
> I run `/specify` → the FR opens in the cockpit. I run `/spec-to-plan` → the
> plan opens in the cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)