### PR TITLE
Multi-agent plugin support: Codex, opencode, GitHub Copilot

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "quoin",
+  "interface": {
+    "displayName": "Quoin"
+  },
+  "plugins": [
+    {
+      "name": "quoin",
+      "source": { "source": "local", "path": "./" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "quoin",
+  "version": "0.1.0",
+  "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Quoin",
+    "category": "Productivity"
+  }
+}

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "quoin",
+  "owner": {
+    "name": "Agent IX"
+  },
+  "metadata": {
+    "description": "Spec authoring, review, matrix, and planning skills + workflows for Agent IX."
+  },
+  "plugins": [
+    {
+      "name": "quoin",
+      "source": "./",
+      "description": "Spec authoring, review, matrix, and planning skills for Agent IX."
+    }
+  ]
+}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,11 +1,12 @@
 name: install-smoke
 
 # Clean-room check that a brand-new community user can install quoin from public
-# npm and load its Claude Code plugin (skills/workflows). Uses PLUGIN_SOURCE=local
-# so it validates THIS revision's plugin manifest rather than whatever is already
-# on the default branch. No secrets required: plugin install is pure git, so the
-# "skills present" assertions run without auth (the live plugin-load check is
-# skipped when no subscription credential is present).
+# npm and install its plugin into Claude Code, OpenAI Codex, opencode, and GitHub
+# Copilot. Uses PLUGIN_SOURCE=local so it validates THIS revision's plugin
+# manifests rather than whatever is already on the default branch. The Claude and
+# Codex stages need no secrets (plugin install is pure git); the opencode/Copilot
+# stages use `gh skill`, which authenticates with the built-in GITHUB_TOKEN (read
+# access to this repo) — without it they skip, not fail.
 
 on:
   pull_request:
@@ -24,4 +25,5 @@ jobs:
       - name: Clean-room install + plugin smoke (local plugin source)
         env:
           PLUGIN_SOURCE: local
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./smoke/run.sh

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,10 @@ evals:
 evals-all:
 	node evals/run.mjs --all --model $(MODEL) --repeats $(REPEATS)
 
-# Community install smoke test (clean-room Docker: public npm + Claude plugin).
-# Verifies an outside developer can `npm i -g @agent-ix/quoin` and load the
-# plugin (skills/workflows) into Claude Code. See smoke/README.md.
+# Community install smoke test (clean-room Docker: public npm + agent plugins).
+# Verifies an outside developer can `npm i -g @agent-ix/quoin` and install the
+# plugin into Claude Code, OpenAI Codex, opencode, and GitHub Copilot.
+# See smoke/README.md.
 .PHONY: install-smoke
 install-smoke:
 	./smoke/run.sh

--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ The default module set defines the spec archetypes and domain-object vocabulary.
 
 ## Install
 
-Installing quoin into Claude is **two steps**: the CLI (from public npm) and the plugin
-that adds the [skills](#agent-skills) and [workflows](#agent-workflows) to Claude Code. No Anthropic API
-key is required — your Claude subscription is used.
+Installing quoin is **two steps**: the CLI (from public npm) and a plugin that adds the
+[skills](#agent-skills) and workflows to your coding agent. The same skill bundle installs
+into **Claude Code, OpenAI Codex, opencode, and GitHub Copilot** — pick your agent below. No
+Anthropic API key is required — your existing agent subscription is used.
 
 **1. Install the CLIs** (`quoin` plus `ix-flow`, which runs the workflow lifecycle commands):
 
@@ -117,15 +118,64 @@ key is required — your Claude subscription is used.
 npm install -g @agent-ix/quoin@latest @agent-ix/ix-flow@latest
 ```
 
-**2. Add the plugin to Claude Code** (run these inside Claude Code):
+**2. Add the plugin to your coding agent:**
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+Run these inside Claude Code:
 
 ```text
 /plugin marketplace add agent-ix/quoin
 /plugin install quoin@quoin
 ```
 
-That registers quoin's spec-authoring skills and workflows so you can drive them by asking
-the agent.
+</details>
+
+<details>
+<summary><b>OpenAI Codex</b></summary>
+
+```bash
+codex plugin marketplace add agent-ix/quoin
+codex plugin add quoin
+```
+
+Or browse and install quoin from the `/plugins` menu inside the Codex TUI.
+
+</details>
+
+<details>
+<summary><b>opencode</b></summary>
+
+Install the skills with the GitHub CLI (requires `gh` ≥ 2.90.0). `--all` installs
+the whole bundle; `--scope user` makes it available in every repo:
+
+```bash
+gh skill install agent-ix/quoin --all --scope user --agent opencode
+```
+
+</details>
+
+<details>
+<summary><b>GitHub Copilot</b></summary>
+
+With the Copilot CLI:
+
+```bash
+copilot plugin marketplace add agent-ix/quoin
+copilot plugin install quoin@quoin
+```
+
+Or install the skills with the GitHub CLI (requires `gh` ≥ 2.90.0):
+
+```bash
+gh skill install agent-ix/quoin --all --scope user --agent github-copilot
+```
+
+</details>
+
+Either way, that registers quoin's spec-authoring skills and workflows so you can drive them
+by asking the agent.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "skills/",
     "bin/",
     ".claude-plugin/",
+    ".codex-plugin/",
+    ".agents/",
+    ".github/plugin/",
     "LICENSE",
     "README.md"
   ],

--- a/smoke/Dockerfile
+++ b/smoke/Dockerfile
@@ -11,11 +11,23 @@
 FROM node:24-bookworm-slim
 
 ARG CLAUDE_VERSION=latest
+ARG CODEX_VERSION=latest
 
+# Base tools + the GitHub CLI from GitHub's official apt repo (>= 2.90 for
+# `gh skill`, which installs the opencode/Copilot skill bundles). Claude Code
+# and the Codex CLI are installed globally; opencode and Copilot need no host
+# CLI here — their install path is `gh skill install`.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git jq ca-certificates \
+ && apt-get install -y --no-install-recommends git jq ca-certificates wget \
+ && mkdir -p -m 755 /etc/apt/keyrings \
+ && wget -nv -O/tmp/ghkey.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+ && cat /tmp/ghkey.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/* \
- && npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
+ && npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION} @openai/codex@${CODEX_VERSION}
 
 # Per-package identity consumed by the generic entrypoint/assert scripts.
 ENV PKG=@agent-ix/quoin \
@@ -26,6 +38,6 @@ ENV PKG=@agent-ix/quoin \
     HOME=/root
 
 COPY . /smoke
-RUN chmod +x /smoke/entrypoint.sh /smoke/assert.sh /smoke/run.sh
+RUN chmod +x /smoke/entrypoint.sh /smoke/assert.sh /smoke/agents.sh /smoke/run.sh
 
 ENTRYPOINT ["/smoke/entrypoint.sh"]

--- a/smoke/README.md
+++ b/smoke/README.md
@@ -1,8 +1,9 @@
 # Community install smoke test
 
 A clean-room, repeatable check that a brand-new developer can install `quoin`
-from **public npm** and use it **inside Claude Code** with no Agent-IX internal
-config and no Anthropic API key.
+from **public npm** and use it as a plugin in the coding agent of their choice —
+**Claude Code, OpenAI Codex, opencode, and GitHub Copilot** — with no Agent-IX
+internal config and no Anthropic API key.
 
 ```bash
 make install-smoke                       # from the repo root (real community path)
@@ -12,42 +13,63 @@ PKG_VERSION=0.2.1 ./smoke/run.sh         # pin for byte-for-byte reproducibility
 
 ## Plugin source
 
-- `PLUGIN_SOURCE=github` (default) installs the plugin from `agent-ix/quoin` on
-  GitHub's default branch — the exact path a community user follows.
-- `PLUGIN_SOURCE=local` installs the plugin from the mounted checkout — validates
-  the manifest in _this_ revision before it reaches the default branch. CI uses
-  this (see `.github/workflows/install-smoke.yml`) so a PR's own changes are
-  tested.
+- `PLUGIN_SOURCE=github` (default) installs from `agent-ix/quoin` on GitHub's
+  default branch — the exact path a community user follows.
+- `PLUGIN_SOURCE=local` installs from the mounted checkout — validates the
+  manifests in _this_ revision before they reach the default branch. CI uses this
+  (see `.github/workflows/install-smoke.yml`) so a PR's own changes are tested.
+
+The Claude Code and Codex stages honor `PLUGIN_SOURCE` (they install this repo's
+plugin manifests). The opencode and Copilot stages add **no repo-specific files**
+— they install the existing `skills/` tree with the exact `gh skill install
+<repo>` command users run — so they always install from the published `agent-ix/`
+repo. Note: in `PLUGIN_SOURCE=github`, the Codex stage needs this repo's
+`.codex-plugin/` + `.agents/plugins/marketplace.json` to already be on the default
+branch; before they are pushed, use `PLUGIN_SOURCE=local`.
 
 ## What it does
 
-A fresh `node:24` container with **no `.npmrc` and no `@agent-ix` scope
-override** (exactly an outside user's machine):
+A fresh `node:24` container with **no `.npmrc` and no `@agent-ix` scope override**
+(exactly an outside user's machine), with `gh` (≥ 2.90, GitHub's official apt
+repo) and the Claude Code + Codex CLIs preinstalled:
 
 1. **Stage 1 — public npm.** `npm install -g @agent-ix/quoin` from
    `registry.npmjs.org` and runs the `quoin` bin. Proves the published CLI and
    its full dependency tree resolve from public npm with zero auth.
-2. **Stage 2 — Claude plugin.** `claude plugin marketplace add` + `plugin
+2. **Stage 2 — Claude Code plugin.** `claude plugin marketplace add` + `plugin
 install` (the CLI form of the README's `/plugin` steps) clone and install the
-   plugin.
-3. **Assert.** For every skill/workflow in [`expected.txt`](./expected.txt) (14
-   skills + 3 workflows): the file is present in the plugin cache **and** — the
-   part that matters to a user — the skill is exposed as a usable `/command`.
-   That comes from Claude's `system/init` event (loaded `plugins[]`,
-   `plugin_errors`, and skills as `slash_commands`), which Claude emits **before
-   authentication**, so the whole test is deterministic and needs **no
-   credentials**. A skill present on disk but missing from the command list is a
-   FAIL — the "installed but I don't see it in Claude" failure mode.
+   plugin, then assert against [`expected.txt`](./expected.txt) (14 skills + 3
+   workflows): every artifact is present in the plugin cache **and** — the part
+   that matters to a user — each skill is exposed as a usable `/command` (from
+   Claude's pre-auth `system/init` event: loaded `plugins[]`, `plugin_errors`,
+   skills as `slash_commands`). A skill on disk but missing from the command list
+   is a FAIL.
+3. **Stage 3 — Codex / opencode / Copilot** ([`agents.sh`](./agents.sh)).
+   Filesystem-install depth: each agent's documented install path runs and every
+   `skill <name>` from `expected.txt` must land as a `SKILL.md` on disk (the 3
+   workflow entries are a Claude-plugin concept and are not checked here).
+   - **Codex** — `codex plugin marketplace add` + `codex plugin add
+<plugin>@<marketplace>`, exercising this repo's `.codex-plugin/plugin.json`
+     and `.agents/plugins/marketplace.json`. Git + local cache, no OpenAI auth.
+   - **opencode** — `gh skill install <repo> --all --agent opencode`.
+   - **GitHub Copilot** — `gh skill install <repo> --all --agent github-copilot`.
+
+The cross-agent depth is intentionally filesystem-level (install succeeds + skill
+files present) — the analog of the "skills present" half of the Claude check. The
+richer "loaded and usable as a command" assertion stays Claude-specific.
 
 ## Auth
 
-None required. The plugin install is plain git and the slash-command check reads
-the pre-auth init event, so everything runs without an Anthropic API key or a
-subscription token — which is what makes it CI-friendly.
+The Claude stage needs none — plugin install is plain git and the slash-command
+check reads the pre-auth init event. The opencode/Copilot stages use **`gh skill`,
+which authenticates with `GH_TOKEN`**: `run.sh` passes your `GH_TOKEN`/`GITHUB_TOKEN`
+or `gh auth token` through to the container (read-only; never persisted in the
+image). Without a token those two stages may fail or rate-limit. Codex needs no
+auth for marketplace/plugin add.
 
-(`run.sh` will bind-mount `~/.claude/.credentials.json` read-only if present, so
-the `claude -p` probe can also complete a real turn on your subscription; the
-token is never read or extracted. It is optional and changes no assertions.)
+(`run.sh` also bind-mounts `~/.claude/.credentials.json` read-only if present, so
+the `claude -p` probe can complete a real turn on your subscription; optional,
+changes no assertions.)
 
 This complements the `agent-pty` evals (`make evals`), which measure a real
 agent's token/tool/latency behavior; this harness only verifies installability.

--- a/smoke/agents.sh
+++ b/smoke/agents.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Stage 3 — clean-room install check for the NON-Claude coding agents.
+#
+# For each additional agent quoin/ix-flow supports as a first-class plugin, run
+# that agent's DOCUMENTED install path and assert every `skill <name>` line in
+# expected.txt lands as a SKILL.md on disk. Depth is intentionally
+# filesystem-level (install command succeeds + skill files present) — the
+# cross-agent analog of the "skills present" half of the Claude check in
+# assert.sh. The richer "loaded and usable as a /command" assertion stays
+# Claude-specific (each agent would need its own credentialed live session).
+#
+#   OpenAI Codex      codex plugin marketplace add <src> + codex plugin add
+#                     <plugin>@<marketplace> — exercises THIS repo's
+#                     .codex-plugin/plugin.json + .agents/plugins/marketplace.json.
+#                     Marketplace add/plugin add are git + local cache (no OpenAI
+#                     auth needed).
+#   opencode          gh skill install <src> --agent opencode
+#   GitHub Copilot    gh skill install <src> --agent github-copilot
+#                     gh skill reads the repo's skills/ tree; auth via GH_TOKEN.
+#
+# PLUGIN_SOURCE (shared with Stage 2): github → install from agent-ix/<repo>'s
+# default branch (validates what is LIVE; the Codex marketplace manifest must be
+# pushed first); local → install from the mounted /repo checkout (validates THIS
+# revision, the CI/PR path).
+set -uo pipefail
+
+: "${REPO:?REPO not set}"
+: "${PLUGIN:?PLUGIN not set}"
+: "${MARKETPLACE:?MARKETPLACE not set}"
+PLUGIN_SOURCE="${PLUGIN_SOURCE:-github}"
+export HOME="${HOME:-/root}"
+fail=0
+
+SMOKE_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXPECTED="$SMOKE_DIR/expected.txt"
+
+# The bundle's user-visible skills (the `skill <name>` lines in expected.txt).
+SKILLS=()
+while read -r kind name _; do
+  [ "${kind:-}" = "skill" ] && SKILLS+=("$name")
+done < "$EXPECTED"
+
+# Codex validates THIS repo's new manifest (.codex-plugin + .agents marketplace),
+# so its source honors PLUGIN_SOURCE: local → the mounted /repo checkout (this
+# revision); github → agent-ix/<repo>'s default branch (must be pushed first).
+case "$PLUGIN_SOURCE" in
+  github) CODEX_SRC="$REPO" ;;
+  local)
+    CODEX_SRC=/repo
+    if [ ! -f /repo/.agents/plugins/marketplace.json ]; then
+      echo "   FAIL  PLUGIN_SOURCE=local but /repo/.agents/plugins/marketplace.json is missing"
+      exit 1
+    fi
+    ;;
+  *) echo "   FAIL  unknown PLUGIN_SOURCE=$PLUGIN_SOURCE"; exit 2 ;;
+esac
+
+# opencode & GitHub Copilot add NO repo-specific files — they install the
+# existing skills/ tree with the exact `gh skill install <repo>` command users
+# run, and that tree is identical on the published branch. So these stages always
+# install from the published $REPO regardless of PLUGIN_SOURCE. (`gh skill
+# --from-local` recursively re-discovers nested workflow-asset skills as
+# duplicate names; the published-repo path uses the shallow skills/*/SKILL.md
+# convention — what users actually invoke.)
+GH_SRC="$REPO"
+
+# assert every expected skill has a SKILL.md somewhere under $1
+assert_skills_in() {
+  local root="$1" agent="$2" miss=0 s
+  for s in "${SKILLS[@]}"; do
+    if [ -n "$(find "$root" -path "*/$s/SKILL.md" 2>/dev/null | head -1)" ]; then
+      echo "   PASS  [$agent] skill present: $s"
+    else
+      echo "   FAIL  [$agent] skill MISSING: $s"; miss=1
+    fi
+  done
+  return "$miss"
+}
+
+# --- OpenAI Codex (native marketplace — validates the .codex-plugin manifest) ---
+echo
+echo "## Stage 3a — OpenAI Codex   (codex plugin marketplace add $CODEX_SRC; plugin add $PLUGIN@$MARKETPLACE)"
+if codex plugin marketplace add "$CODEX_SRC" </dev/null >/tmp/codex.log 2>&1 \
+   && codex plugin add "$PLUGIN@$MARKETPLACE" </dev/null >>/tmp/codex.log 2>&1; then
+  assert_skills_in "$HOME/.codex/plugins/cache" codex || fail=1
+else
+  echo "   FAIL  [codex] install failed:"; sed 's/^/         /' /tmp/codex.log | tail -20; fail=1
+fi
+
+# opencode & GitHub Copilot install via `gh skill`, which authenticates with
+# GH_TOKEN. When no token is available (e.g. a contributor without `gh auth`),
+# SKIP these two stages with a warning rather than fail — the analog of the
+# optional Claude subscription credential. CI passes GITHUB_TOKEN so they assert.
+if [ -n "${GH_TOKEN:-}" ] || gh auth status >/dev/null 2>&1; then
+
+  # --- opencode (gh skill — the documented opencode path) ---
+  echo
+  echo "## Stage 3b — opencode        (gh skill install $GH_SRC --all --agent opencode)"
+  rm -rf /tmp/smoke-opencode
+  if gh skill install "$GH_SRC" --all --agent opencode --dir /tmp/smoke-opencode >/tmp/opencode.log 2>&1; then
+    assert_skills_in /tmp/smoke-opencode opencode || fail=1
+  else
+    echo "   FAIL  [opencode] gh skill install failed:"; sed 's/^/         /' /tmp/opencode.log | tail -20; fail=1
+  fi
+
+  # --- GitHub Copilot (gh skill — the documented Copilot CLI / gh path) ---
+  echo
+  echo "## Stage 3c — GitHub Copilot  (gh skill install $GH_SRC --all --agent github-copilot)"
+  rm -rf /tmp/smoke-copilot
+  if gh skill install "$GH_SRC" --all --agent github-copilot --dir /tmp/smoke-copilot >/tmp/copilot.log 2>&1; then
+    assert_skills_in /tmp/smoke-copilot github-copilot || fail=1
+  else
+    echo "   FAIL  [github-copilot] gh skill install failed:"; sed 's/^/         /' /tmp/copilot.log | tail -20; fail=1
+  fi
+
+else
+  echo
+  echo "## Stage 3b/3c — opencode & GitHub Copilot: SKIPPED"
+  echo "   no GH token (set GH_TOKEN or run \`gh auth login\`); \`gh skill install\` needs auth"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "## STAGE 3 RESULT: PASS — Codex, opencode, and GitHub Copilot install the bundle's skills"
+else
+  echo "## STAGE 3 RESULT: FAIL — see misses above"
+fi
+exit "$fail"

--- a/smoke/entrypoint.sh
+++ b/smoke/entrypoint.sh
@@ -104,4 +104,16 @@ timeout 180 claude -p "Reply with the single word: ok" \
   || echo "   note: claude print-turn exited non-zero (init event still captured for assertions)"
 
 # ======================================================================
-/smoke/assert.sh "$STREAM"
+/smoke/assert.sh "$STREAM"; claude_rc=$?
+
+# ======================================================================
+# Stage 3 — the additional coding agents (Codex / opencode / GitHub Copilot).
+# Filesystem-install depth: each agent's documented install path runs and the
+# bundle's skills must land on disk. See smoke/agents.sh.
+/smoke/agents.sh; agents_rc=$?
+
+echo
+echo "=================================================================="
+echo " Summary:  Claude Code stage rc=$claude_rc   other-agents stage rc=$agents_rc"
+echo "=================================================================="
+[ "$claude_rc" -eq 0 ] && [ "$agents_rc" -eq 0 ]

--- a/smoke/run.sh
+++ b/smoke/run.sh
@@ -23,12 +23,24 @@ REPO_ROOT="$(cd "$SMOKE_DIR/.." && pwd)"
 IMAGE="quoin-install-smoke"
 PKG_VERSION="${PKG_VERSION:-latest}"
 CLAUDE_VERSION="${CLAUDE_VERSION:-latest}"
+CODEX_VERSION="${CODEX_VERSION:-latest}"
 PLUGIN_SOURCE="${PLUGIN_SOURCE:-github}"
 
-echo ">> build $IMAGE (CLAUDE_VERSION=$CLAUDE_VERSION)"
-docker build -t "$IMAGE" --build-arg CLAUDE_VERSION="$CLAUDE_VERSION" "$SMOKE_DIR"
+echo ">> build $IMAGE (CLAUDE_VERSION=$CLAUDE_VERSION CODEX_VERSION=$CODEX_VERSION)"
+docker build -t "$IMAGE" \
+  --build-arg CLAUDE_VERSION="$CLAUDE_VERSION" \
+  --build-arg CODEX_VERSION="$CODEX_VERSION" "$SMOKE_DIR"
 
 args=(--rm -e PKG_VERSION="$PKG_VERSION" -e PLUGIN_SOURCE="$PLUGIN_SOURCE")
+
+# gh skill install (opencode / GitHub Copilot stages) authenticates with GH_TOKEN.
+GH_TOKEN_VALUE="${GH_TOKEN:-${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}}"
+if [ -n "$GH_TOKEN_VALUE" ]; then
+  args+=(-e GH_TOKEN="$GH_TOKEN_VALUE")
+  echo ">> passing GH_TOKEN for gh skill install"
+else
+  echo ">> WARN: no GH token (gh skill install for opencode/Copilot may fail or rate-limit)"
+fi
 
 if [ "$PLUGIN_SOURCE" = "local" ]; then
   args+=(-v "$REPO_ROOT:/repo:ro")

--- a/spec/non-functional/NFR-009-single-source-skills-across-agents.md
+++ b/spec/non-functional/NFR-009-single-source-skills-across-agents.md
@@ -1,0 +1,55 @@
+---
+id: NFR-009
+title: "Skills are authored once and consumed by every supported agent"
+type: NFR
+quality_attribute: portability
+relationships:
+  - target: "ix://agent-ix/quoin/US-009"
+    type: "constrains"
+---
+
+# [NFR-009] Skills are authored once and consumed by every supported agent
+
+## Statement
+
+quoin SHALL maintain a single skill tree under `skills/<name>/SKILL.md` as the
+sole source of skill content, and each supported coding agent (Claude Code,
+OpenAI Codex, opencode, GitHub Copilot) SHALL install from that one tree. Per-agent
+plugin and marketplace manifests SHALL add only discovery and install metadata and
+SHALL NOT contain a duplicated copy of any skill body.
+
+## Scope
+
+- Applies to: the `skills/` tree and the per-agent manifests that reference it
+  (`.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/marketplace.json`,
+  `.github/plugin/marketplace.json`).
+- Operational context: installing quoin as a plugin from any supported agent.
+
+## Rationale
+
+A single skill tree is what lets quoin add agents without forking content: every
+agent reads the same `SKILL.md` files, so behavior stays identical and there is no
+second copy to drift. Manifests differ per agent only in how they point at that
+tree, keeping the maintenance cost of each additional agent close to one small
+manifest.
+
+## Measurement and Evaluation
+
+| Metric                                                              | Target | Threshold | Method     |
+| ------------------------------------------------------------------- | ------ | --------- | ---------- |
+| Copies of any skill body outside the single `skills/` tree          | 0      | 0         | Inspection |
+| Per-agent manifests that point at a skill tree other than `skills/` | 0      | 0         | Inspection |
+
+## Verification
+
+The repository is inspected to confirm exactly one `skills/` tree holds all
+`SKILL.md` bodies, and each per-agent manifest (`.claude-plugin/`,
+`.codex-plugin/plugin.json`, and the Codex/Copilot marketplace files) resolves its
+skills to that same tree rather than carrying duplicated content.
+
+## Dependencies
+
+- **Upstream**: [US-009](../usecase/US-009-install-in-any-coding-agent.md) install
+  quoin in the coding agent of choice.
+- **Downstream**: the single-source rule governs how any future agent's manifest is
+  added.

--- a/spec/non-functional/index.md
+++ b/spec/non-functional/index.md
@@ -16,3 +16,4 @@ description: "Index of non-functional requirements (NFR) for quoin."
 - [NFR-006: The agent eval set captures efficiency metrics](./NFR-006-eval-metric-capture.md)
 - [NFR-007: External tools are invoked by name and surface their failures](./NFR-007-external-tool-invocation.md)
 - [NFR-008: Corrupt manifests abort assembly rather than drop silently](./NFR-008-strict-manifest-parsing.md)
+- [NFR-009: Skills are authored once and consumed by every supported agent](./NFR-009-single-source-skills-across-agents.md)

--- a/spec/usecase/US-009-install-in-any-coding-agent.md
+++ b/spec/usecase/US-009-install-in-any-coding-agent.md
@@ -1,0 +1,61 @@
+---
+id: US-009
+title: "Install quoin in the coding agent of my choice"
+type: US
+relationships:
+  - target: "ix://agent-ix/quoin/StR-001"
+    type: "traces_to"
+---
+
+# [US-009] Install quoin in the coding agent of my choice
+
+## Story
+
+**As a** developer adopting spec-driven development in my own coding agent
+**I want** to install quoin as a plugin in whichever agent I already use — Claude
+Code, OpenAI Codex, opencode, or GitHub Copilot
+**So that** quoin's spec-authoring skills and workflows are available in my agent
+without my having to switch tools or re-author anything per agent.
+
+This story expresses the adopter's perspective in informal language and does not
+prescribe the manifest formats or install commands each agent uses.
+
+## Context
+
+Today quoin installs as a Claude Code plugin only, even though its skills are
+plain `skills/<name>/SKILL.md` files that several coding agents can read. Adopters
+on Codex, opencode, or Copilot have no first-class install path and must copy
+files by hand. Because the same skill tree is the common denominator across these
+agents, the same bundle should be installable from each of them through that
+agent's own plugin/skill mechanism.
+
+## Acceptance Examples (Illustrative)
+
+These examples clarify the adopter's expectations. They are illustrative only —
+not test cases and not verification criteria.
+
+### [US-009-EX-1] Install from Codex
+
+- **Given** a developer working in OpenAI Codex
+- **When** they add the quoin marketplace and install the plugin
+- **Then** quoin's skills appear in Codex without any per-agent re-authoring
+
+### [US-009-EX-2] Install from opencode or Copilot
+
+- **Given** a developer working in opencode or GitHub Copilot
+- **When** they install quoin's skills for their agent (e.g. `gh skill install`
+  or `copilot plugin marketplace add`)
+- **Then** the same skills they would get in Claude Code become available
+
+## Dependencies (Contextual)
+
+Relationships observed during discovery. Upstream: the standalone-install
+stakeholder need ([StR-001](../stakeholder/StR-001-standalone-cli.md)).
+Downstream: a non-functional requirement that the skill tree stay the single
+source of truth across agents. These are potential relationships, not formal
+traceability.
+
+## Traceability (Informative)
+
+This user story traces to the stakeholder need for installing quoin as a single,
+self-contained adoption unit. Links may be updated as understanding evolves.

--- a/spec/usecase/index.md
+++ b/spec/usecase/index.md
@@ -16,3 +16,4 @@ description: "Index of artifacts in this directory."
 - [US-006: Detect conflicting type definitions across modules](./US-006-detect-conflicting-type-definitions.md)
 - [US-007: Review a spec into validated per-analysis review docs](./US-007-review-into-specreview-docs.md)
 - [US-008: Create an implementation plan from accepted requirements](./US-008-create-implementation-plan.md)
+- [US-009: Install quoin in the coding agent of my choice](./US-009-install-in-any-coding-agent.md)


### PR DESCRIPTION
## What

Make `quoin` installable as a first-class plugin in **OpenAI Codex, opencode, and GitHub Copilot**, alongside the existing Claude Code path. All four agents install from the **same `skills/<name>/SKILL.md` tree** — per-agent manifests add only discovery/install metadata.

## Install paths

| Agent | Command | New files |
|---|---|---|
| Claude Code | `/plugin marketplace add agent-ix/quoin` + `/plugin install` | — (existing) |
| OpenAI Codex | `codex plugin marketplace add agent-ix/quoin` + `codex plugin add quoin@quoin` | `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json` |
| opencode | `gh skill install agent-ix/quoin --all --scope user --agent opencode` | — (reads `skills/`) |
| GitHub Copilot | `copilot plugin marketplace add agent-ix/quoin` **or** `gh skill install … --agent github-copilot` | `.github/plugin/marketplace.json` (Copilot also reads existing `.claude-plugin/plugin.json`) |

## Changes

- **Spec** — `US-009` (install in the agent of choice) + `NFR-009` (single skills tree, no per-agent duplication); Quire-validated.
- **Manifests** — Codex + Copilot marketplace files, shipped in the npm tarball (`package.json` `files[]`).
- **README** — `## Install` restructured into collapsible per-agent `<details>` sections.
- **Smoke test** — dockerized clean-room `make install-smoke` extended from Claude-only to a 4-agent Stage 3 (filesystem-install depth). Codex via its native CLI (validates the new manifest); opencode/Copilot via `gh skill`. CI passes `GITHUB_TOKEN`; gh-skill stages skip (not fail) without a token.

## Verification

- `make install-smoke` (`PLUGIN_SOURCE=local`): **PASS** — Claude Code (skills load as `/commands`) + Codex + opencode + GitHub Copilot (all 14 skills land on disk).
- Live: `gh skill install … --agent github-copilot` lands skills in `~/.copilot/skills/`; `codex plugin marketplace add` registers and installs the plugin.

> Note: the Codex **github-mode** path (`make install-smoke` default) goes green once these manifests are on `main` — this PR delivers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)