### PR TITLE
spec: normalize requirement titles and headings to canonical form

### DIFF
--- a/spec/functional/FR-001-parse-command-line.md
+++ b/spec/functional/FR-001-parse-command-line.md
@@ -7,7 +7,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [FR-001] Parse the command line into command, flags, and positionals
+# FR-001: Parse the command line into command, flags, and positionals
 
 ## Description
 

--- a/spec/functional/FR-002-print-package-version.md
+++ b/spec/functional/FR-002-print-package-version.md
@@ -7,7 +7,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [FR-002] Report the installed package version
+# FR-002: Report the installed package version
 
 ## Description
 

--- a/spec/functional/FR-003-print-usage-and-help.md
+++ b/spec/functional/FR-003-print-usage-and-help.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-003] Print usage and command-scoped help
+# FR-003: Print usage and command-scoped help
 
 ## Description
 

--- a/spec/functional/FR-004-resolve-config-root.md
+++ b/spec/functional/FR-004-resolve-config-root.md
@@ -7,7 +7,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [FR-004] Resolve the config root and configure the runtime context
+# FR-004: Resolve the config root and configure the runtime context
 
 ## Description
 

--- a/spec/functional/FR-005-reject-unknown-commands.md
+++ b/spec/functional/FR-005-reject-unknown-commands.md
@@ -9,7 +9,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [FR-005] Reject unknown commands and subcommands
+# FR-005: Reject unknown commands and subcommands
 
 ## Description
 

--- a/spec/functional/FR-006-locate-module-roots.md
+++ b/spec/functional/FR-006-locate-module-roots.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-006] Locate a module root from a candidate path
+# FR-006: Locate a module root from a candidate path
 
 ## Description
 

--- a/spec/functional/FR-007-assemble-module-roots.md
+++ b/spec/functional/FR-007-assemble-module-roots.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-007] Assemble module roots in a defined order
+# FR-007: Assemble module roots in a defined order
 
 ## Description
 

--- a/spec/functional/FR-008-deduplicate-modules.md
+++ b/spec/functional/FR-008-deduplicate-modules.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-008] Deduplicate module roots and names first-wins
+# FR-008: Deduplicate module roots and names first-wins
 
 ## Description
 

--- a/spec/functional/FR-009-read-module-manifest.md
+++ b/spec/functional/FR-009-read-module-manifest.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-009] Read each module manifest into catalog entries
+# FR-009: Read each module manifest into catalog entries
 
 ## Description
 

--- a/spec/functional/FR-010-case-insensitive-type-lookup.md
+++ b/spec/functional/FR-010-case-insensitive-type-lookup.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-010] Look up catalog types case-insensitively
+# FR-010: Look up catalog types case-insensitively
 
 ## Description
 

--- a/spec/functional/FR-011-list-and-show-catalog.md
+++ b/spec/functional/FR-011-list-and-show-catalog.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-011] List the catalog and show a single type
+# FR-011: List the catalog and show a single type
 
 ## Description
 

--- a/spec/functional/FR-012-detect-duplicate-types.md
+++ b/spec/functional/FR-012-detect-duplicate-types.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-012] Detect duplicate type definitions and validate the catalog
+# FR-012: Detect duplicate type definitions and validate the catalog
 
 ## Description
 

--- a/spec/functional/FR-013-resolve-requested-types.md
+++ b/spec/functional/FR-013-resolve-requested-types.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-013] Resolve the requested types for an authoring pack
+# FR-013: Resolve the requested types for an authoring pack
 
 ## Description
 

--- a/spec/functional/FR-014-emit-authoring-contract.md
+++ b/spec/functional/FR-014-emit-authoring-contract.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-014] Emit an authoring contract per resolved type
+# FR-014: Emit an authoring contract per resolved type
 
 ## Description
 

--- a/spec/functional/FR-015-emit-quire-validate-command.md
+++ b/spec/functional/FR-015-emit-quire-validate-command.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-015] Emit a scoped Quire validation command
+# FR-015: Emit a scoped Quire validation command
 
 ## Description
 

--- a/spec/functional/FR-016-default-modules-schema.md
+++ b/spec/functional/FR-016-default-modules-schema.md
@@ -10,7 +10,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-016] Default module set manifest schema
+# FR-016: Default module set manifest schema
 
 ## Description
 

--- a/spec/functional/FR-017-reconcile-default-modules.md
+++ b/spec/functional/FR-017-reconcile-default-modules.md
@@ -11,7 +11,7 @@ relationships:
     type: "references"
 ---
 
-# [FR-017] Reconcile the default module set into the shared store
+# FR-017: Reconcile the default module set into the shared store
 
 ## Description
 

--- a/spec/functional/FR-018-map-plugin-sources.md
+++ b/spec/functional/FR-018-map-plugin-sources.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-018] Map plugin source arguments to typed sources
+# FR-018: Map plugin source arguments to typed sources
 
 ## Description
 

--- a/spec/functional/FR-019-manage-plugin-registry.md
+++ b/spec/functional/FR-019-manage-plugin-registry.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-019] Install, list, and remove plugins through the registry
+# FR-019: Install, list, and remove plugins through the registry
 
 ## Description
 

--- a/spec/functional/FR-020-resolve-workflow-skills.md
+++ b/spec/functional/FR-020-resolve-workflow-skills.md
@@ -9,7 +9,7 @@ relationships:
     type: "implements"
 ---
 
-# [FR-020] Expose workflow launchers and resolve their skills
+# FR-020: Expose workflow launchers and resolve their skills
 
 ## Description
 

--- a/spec/functional/FR-021-launch-ix-flow-runs.md
+++ b/spec/functional/FR-021-launch-ix-flow-runs.md
@@ -11,7 +11,7 @@ relationships:
     type: "references"
 ---
 
-# [FR-021] Launch workflow runs through ix-flow
+# FR-021: Launch workflow runs through ix-flow
 
 ## Description
 

--- a/spec/functional/FR-022-self-update.md
+++ b/spec/functional/FR-022-self-update.md
@@ -9,7 +9,7 @@ relationships:
     type: "references"
 ---
 
-# [FR-022] Upgrade quoin to the latest published release
+# FR-022: Upgrade quoin to the latest published release
 
 ## Description
 

--- a/spec/functional/FR-023-runtime-configuration.md
+++ b/spec/functional/FR-023-runtime-configuration.md
@@ -12,7 +12,7 @@ relationships:
     type: "specifies"
 ---
 
-# [FR-023] quoin runtime configuration surface
+# FR-023: quoin runtime configuration surface
 
 ## Description
 

--- a/spec/integration/IT-001-default-module-reconcile.md
+++ b/spec/integration/IT-001-default-module-reconcile.md
@@ -11,7 +11,7 @@ relationships:
     type: "verifies"
 ---
 
-# [IT-001] Default module set reconciles from pinned git tags, then serves offline
+# IT-001: Default module set reconciles from pinned git tags, then serves offline
 
 ## Objective
 

--- a/spec/integration/IT-002-github-plugin-install.md
+++ b/spec/integration/IT-002-github-plugin-install.md
@@ -9,7 +9,7 @@ relationships:
     type: "verifies"
 ---
 
-# [IT-002] Community plugin installs from a GitHub source into the catalog
+# IT-002: Community plugin installs from a GitHub source into the catalog
 
 ## Objective
 

--- a/spec/non-functional/NFR-001-idempotent-offline-reconcile.md
+++ b/spec/non-functional/NFR-001-idempotent-offline-reconcile.md
@@ -8,7 +8,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-001] Default-module reconciliation is idempotent and offline-safe
+# NFR-001: Default-module reconciliation is idempotent and offline-safe
 
 ## Statement
 

--- a/spec/non-functional/NFR-002-deterministic-catalog.md
+++ b/spec/non-functional/NFR-002-deterministic-catalog.md
@@ -10,7 +10,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-002] Catalog assembly is deterministic
+# NFR-002: Catalog assembly is deterministic
 
 ## Statement
 

--- a/spec/non-functional/NFR-003-actionable-errors.md
+++ b/spec/non-functional/NFR-003-actionable-errors.md
@@ -12,7 +12,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-003] Failures surface as actionable errors
+# NFR-003: Failures surface as actionable errors
 
 ## Statement
 

--- a/spec/non-functional/NFR-004-standalone-dependencies.md
+++ b/spec/non-functional/NFR-004-standalone-dependencies.md
@@ -8,7 +8,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [NFR-004] quoin runs as a standalone package
+# NFR-004: quoin runs as a standalone package
 
 ## Statement
 

--- a/spec/non-functional/NFR-005-catalog-driven-workflows.md
+++ b/spec/non-functional/NFR-005-catalog-driven-workflows.md
@@ -8,7 +8,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-005] Workflows reference catalog-defined types
+# NFR-005: Workflows reference catalog-defined types
 
 ## Statement
 

--- a/spec/non-functional/NFR-006-eval-metric-capture.md
+++ b/spec/non-functional/NFR-006-eval-metric-capture.md
@@ -8,7 +8,7 @@ relationships:
     type: "references"
 ---
 
-# [NFR-006] The agent eval set captures efficiency metrics
+# NFR-006: The agent eval set captures efficiency metrics
 
 ## Statement
 

--- a/spec/non-functional/NFR-007-external-tool-invocation.md
+++ b/spec/non-functional/NFR-007-external-tool-invocation.md
@@ -12,7 +12,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-007] External tools are invoked by name and surface their failures
+# NFR-007: External tools are invoked by name and surface their failures
 
 ## Statement
 

--- a/spec/non-functional/NFR-008-strict-manifest-parsing.md
+++ b/spec/non-functional/NFR-008-strict-manifest-parsing.md
@@ -10,7 +10,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-008] Corrupt manifests abort assembly rather than drop silently
+# NFR-008: Corrupt manifests abort assembly rather than drop silently
 
 ## Statement
 

--- a/spec/non-functional/NFR-009-single-source-skills-across-agents.md
+++ b/spec/non-functional/NFR-009-single-source-skills-across-agents.md
@@ -8,7 +8,7 @@ relationships:
     type: "constrains"
 ---
 
-# [NFR-009] Skills are authored once and consumed by every supported agent
+# NFR-009: Skills are authored once and consumed by every supported agent
 
 ## Statement
 

--- a/spec/stakeholder/StR-001-standalone-cli.md
+++ b/spec/stakeholder/StR-001-standalone-cli.md
@@ -11,7 +11,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-001] Authors run spec work from a standalone CLI
+# StR-001: Authors run spec work from a standalone CLI
 
 ## Stakeholder Need
 

--- a/spec/stakeholder/StR-002-extensible-vocabulary.md
+++ b/spec/stakeholder/StR-002-extensible-vocabulary.md
@@ -9,7 +9,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-002] Authors extend the spec vocabulary with community modules
+# StR-002: Authors extend the spec vocabulary with community modules
 
 ## Stakeholder Need
 

--- a/spec/stakeholder/StR-003-shared-catalog.md
+++ b/spec/stakeholder/StR-003-shared-catalog.md
@@ -11,7 +11,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-003] Authoring and validation share one consistent catalog
+# StR-003: Authoring and validation share one consistent catalog
 
 ## Stakeholder Need
 

--- a/spec/stakeholder/StR-004-governed-workflows.md
+++ b/spec/stakeholder/StR-004-governed-workflows.md
@@ -9,7 +9,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-004] Review, matrix, and planning run as governed workflows
+# StR-004: Review, matrix, and planning run as governed workflows
 
 ## Stakeholder Need
 

--- a/spec/stakeholder/StR-005-offline-reproducible.md
+++ b/spec/stakeholder/StR-005-offline-reproducible.md
@@ -11,7 +11,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-005] Authoring stays offline-safe and reproducible
+# StR-005: Authoring stays offline-safe and reproducible
 
 ## Stakeholder Need
 

--- a/spec/stakeholder/StR-006-current-via-self-update.md
+++ b/spec/stakeholder/StR-006-current-via-self-update.md
@@ -7,7 +7,7 @@ relationships:
     type: "satisfied_by"
 ---
 
-# [StR-006] Operators keep quoin current with one command
+# StR-006: Operators keep quoin current with one command
 
 ## Stakeholder Need
 

--- a/spec/usecase/US-001-author-root-artifact-with-objects.md
+++ b/spec/usecase/US-001-author-root-artifact-with-objects.md
@@ -15,7 +15,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-001] Author a root artifact with supporting objects
+# US-001: Author a root artifact with supporting objects
 
 ## Story
 

--- a/spec/usecase/US-002-discover-authoring-contract.md
+++ b/spec/usecase/US-002-discover-authoring-contract.md
@@ -11,7 +11,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-002] Discover an authoring contract before editing
+# US-002: Discover an authoring contract before editing
 
 ## Story
 

--- a/spec/usecase/US-003-install-community-module.md
+++ b/spec/usecase/US-003-install-community-module.md
@@ -13,7 +13,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-003] Install and use a community spec module
+# US-003: Install and use a community spec module
 
 ## Story
 

--- a/spec/usecase/US-004-validate-changed-spec-files.md
+++ b/spec/usecase/US-004-validate-changed-spec-files.md
@@ -9,7 +9,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-004] Validate changed spec files
+# US-004: Validate changed spec files
 
 ## Story
 

--- a/spec/usecase/US-005-start-gated-spec-workflow.md
+++ b/spec/usecase/US-005-start-gated-spec-workflow.md
@@ -11,7 +11,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-005] Start a gated spec workflow
+# US-005: Start a gated spec workflow
 
 ## Story
 

--- a/spec/usecase/US-006-detect-conflicting-type-definitions.md
+++ b/spec/usecase/US-006-detect-conflicting-type-definitions.md
@@ -11,7 +11,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-006] Detect conflicting type definitions across modules
+# US-006: Detect conflicting type definitions across modules
 
 ## Story
 
@@ -42,13 +42,13 @@ can remove or re-scope a module before continuing.
 These examples clarify expectations; they are illustrative, not verification
 criteria.
 
-### [US-006-EX-1] Clean catalog validates
+### US-006-EX-1: Clean catalog validates
 
 - **Given** a catalog whose type names are each declared by a single module
 - **When** the user runs `quoin catalog validate`
 - **Then** the command succeeds and reports the number of modules
 
-### [US-006-EX-2] Conflicting types are surfaced
+### US-006-EX-2: Conflicting types are surfaced
 
 - **Given** two installed modules that both declare an object type named `domain`
 - **When** the user runs `quoin catalog validate`

--- a/spec/usecase/US-007-review-into-specreview-docs.md
+++ b/spec/usecase/US-007-review-into-specreview-docs.md
@@ -11,7 +11,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-007] Review a spec into validated per-analysis review docs
+# US-007: Review a spec into validated per-analysis review docs
 
 ## Story
 
@@ -36,19 +36,19 @@ recorded, validated doc.
 
 These examples clarify expectations; they are illustrative, not verification criteria.
 
-### [US-007-EX-1] Subset review yields one validated doc per analysis
+### US-007-EX-1: Subset review yields one validated doc per analysis
 
 - **Given** a spec directory and a choice of `subset` with `integrity` and `dependency`
 - **When** the author runs the review
 - **Then** `spec/reviews/integrity.md` and `spec/reviews/dependency.md` are authored as `SpecReview` artifacts and pass `quire validate`
 
-### [US-007-EX-2] Coverage gate blocks an incomplete review
+### US-007-EX-2: Coverage gate blocks an incomplete review
 
 - **Given** a `subset` of two analyses but only one rendered doc
 - **When** the author tries to accept the review
 - **Then** acceptance is blocked, naming the missing analysis, until its doc exists
 
-### [US-007-EX-3] Out-of-set severity is rejected
+### US-007-EX-3: Out-of-set severity is rejected
 
 - **Given** a findings row whose `Severity` is `catastrophic`
 - **When** the doc is validated

--- a/spec/usecase/US-008-create-implementation-plan.md
+++ b/spec/usecase/US-008-create-implementation-plan.md
@@ -9,7 +9,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-008] Create an implementation plan from accepted requirements
+# US-008: Create an implementation plan from accepted requirements
 
 ## Story
 
@@ -37,21 +37,21 @@ later requirements rather than specifying them.
 These examples clarify the planner's expectations. They are illustrative only —
 not test cases and not verification criteria.
 
-### [US-008-EX-1] Start a new plan
+### US-008-EX-1: Start a new plan
 
 - **Given** a spec with accepted requirements and no existing plan
 - **When** the planner runs the planning workflow
 - **Then** a new plan is created as a self-describing bundle (its overview, a task
   per unit of work with dependencies between them, and its own index and change log)
 
-### [US-008-EX-2] Continue or branch into a second plan
+### US-008-EX-2: Continue or branch into a second plan
 
 - **Given** a project that already has one plan
 - **When** the planner runs the planning workflow again
 - **Then** they are offered the existing plan to continue, or can start a second,
   independent plan without disturbing the first
 
-### [US-008-EX-3] Dependencies and traceability are captured
+### US-008-EX-3: Dependencies and traceability are captured
 
 - **Given** requirements with ordering and verification needs
 - **When** the planner decomposes them into tasks

--- a/spec/usecase/US-009-install-in-any-coding-agent.md
+++ b/spec/usecase/US-009-install-in-any-coding-agent.md
@@ -7,7 +7,7 @@ relationships:
     type: "traces_to"
 ---
 
-# [US-009] Install quoin in the coding agent of my choice
+# US-009: Install quoin in the coding agent of my choice
 
 ## Story
 
@@ -34,13 +34,13 @@ agent's own plugin/skill mechanism.
 These examples clarify the adopter's expectations. They are illustrative only —
 not test cases and not verification criteria.
 
-### [US-009-EX-1] Install from Codex
+### US-009-EX-1: Install from Codex
 
 - **Given** a developer working in OpenAI Codex
 - **When** they add the quoin marketplace and install the plugin
 - **Then** quoin's skills appear in Codex without any per-agent re-authoring
 
-### [US-009-EX-2] Install from opencode or Copilot
+### US-009-EX-2: Install from opencode or Copilot
 
 - **Given** a developer working in opencode or GitHub Copilot
 - **When** they install quoin's skills for their agent (e.g. `gh skill install`


### PR DESCRIPTION
## What

Normalizes spec requirement titles/headings to the canonical readable form across `spec/`.

- **Frontmatter `title:`** cleaned — strip placeholder brackets and any duplicated code prefix. `id` already carries the code.
- **Body headings** flipped from `# [CODE] Title` / `# [CODE] [Title]` to `# CODE: Title`, including code-prefixed sub-headings.

## Why

Frontmatter `id` + `title` are the source of truth so renderers display code and title cleanly without parsing heuristics. The bracketed/placeholder/code-prefixed titles broke that contract. `CODE: Title` is the canonical heading form (skeletons updated to match).

## Safety

No renderer/validator/locator parses the H1 bracket form — all read frontmatter or match full heading text. Pure syntactic rewrite; no prose changed. Part of an ecosystem-wide normalization sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
