### PR TITLE
docs(specify): add authoring guidance for writing good requirements

### DIFF
--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -42,6 +42,21 @@ file under the matching directory:
 > If a request asks for functional requirements and you produced only table rows
 > in `spec.md`, the request is **not done** — create the `FR-XXX.md` files.
 
+## Writing good requirements
+
+The templates and Quire enforce *shape*; you supply the *judgment*. Author it well
+here so `spec-review` has less to send back. Three principles — full guidance with
+examples in [references/writing-good-requirements.md](references/writing-good-requirements.md):
+
+- **Scope: tight beats broad.** Prefer a narrow spec that fully defines its slice over
+  a sprawling, vague one. Treat `spec.md` §2.2 Out of Scope as first-class — decide
+  your non-goals deliberately; an empty Out-of-Scope is a smell.
+- **User stories: INVEST + no solution-prescribing.** Describe the user need with a
+  real "so that …"; let the FRs pick the mechanism.
+- **Acceptance criteria: cover the unhappy paths, be concrete.** Author happy/error/edge
+  and negative cases up front, in measurable terms ("returns HTTP 422 within 200ms",
+  not "handles errors gracefully").
+
 ## Process
 
 Run only the steps the request needs; stop after IT.
@@ -56,9 +71,12 @@ Run only the steps the request needs; stop after IT.
    - `spec.md` — **REQUIRED when starting a new spec**: the
      `type: master-requirements` root/index at `spec/spec.md`, authored from
      `assets/spec-template.md` (or `assets/app-spec-template.md` for an
-     application). Then → StR → US →
+     application); keep scope tight and fill Out of Scope deliberately
+     (see [references/writing-good-requirements.md](references/writing-good-requirements.md)).
+     Then → StR → US (INVEST, no solution-prescribing — same reference) →
      **derive FR from US** (see [references/us-to-fr.md](references/us-to-fr.md))
-     → FR → NFR → IT (see [references/integration-tests.md](references/integration-tests.md)).
+     → FR (cover unhappy paths, measurable ACs — same reference)
+     → NFR → IT (see [references/integration-tests.md](references/integration-tests.md)).
 4. Keep traceability in frontmatter `relationships:` (e.g. a US `traces_to` its
    FRs; an FR/NFR/IT links back to the US/FR it serves).
 5. Run `quire validate <glob> [glob2 ...]` over the changed spec scope and fix
@@ -74,6 +92,9 @@ each with an Acceptance Criteria table (the `fr.md` skeleton enforces the shape)
 
 - Derive FRs from the driving user story — see
   [references/us-to-fr.md](references/us-to-fr.md).
+- Make the ACs count: cover happy/error/edge and negative cases in concrete,
+  measurable terms — see
+  [references/writing-good-requirements.md](references/writing-good-requirements.md).
 - A behavioral FR has no `object:` field. A **domain-typed** FR carries
   `object: <type>` (e.g. `entity`, `event`, `api_endpoint`, `process`,
   `configuration`) and uses that type's structural template. Look up the

--- a/skills/specify/references/writing-good-requirements.md
+++ b/skills/specify/references/writing-good-requirements.md
@@ -1,0 +1,61 @@
+# Writing Good Requirements
+
+Load this when authoring StR/US/FR/NFR artifacts. The templates and Quire enforce
+*shape*; this file carries the *judgment* that makes a requirement good, not just
+well-formed. Authoring well here means `spec-review` has less to send back.
+
+## Scope: tight beats broad
+
+A narrow spec that fully defines its slice beats a sprawling one full of gaps.
+Resist widening scope to "cover everything" — an expansive, vague spec is worse than
+a tight, sharp one.
+
+Treat the `spec.md` §2.2 **Out of Scope** list as first-class. Deliberately decide
+what you are **not** building and write it down — an empty Out-of-Scope section is a
+smell, not a default. Naming non-goals is how you prevent scope creep during
+implementation.
+
+> **Bad:** §2.2 left empty; §2.1 In Scope reads "all user-facing features".
+> **Good:** In Scope: "CSV import of contacts". Out of Scope: "XLSX/JSON import,
+> de-duplication, field mapping UI — see future work."
+
+## User stories: INVEST + anti-patterns
+
+Aim for **INVEST** stories: **I**ndependent, **N**egotiable, **V**aluable,
+**E**stimable, **S**mall, **T**estable.
+
+Catch these anti-patterns while authoring, not in review:
+
+- **Vagueness** — "make it faster" says nothing testable. Name the user, the want,
+  and a measurable outcome.
+- **Solution-prescribing** — "add a dropdown menu" prescribes a mechanism. A user
+  story describes the *need*; the FRs choose the mechanism. If the US already names
+  the implementation, you have skipped the problem.
+- **Missing rationale** — every US carries a real "so that …". If you can't state the
+  value, question whether the story belongs in the spec.
+- **Internal focus** — "so that the team has less to maintain" benefits the team, not
+  the user. Frame the value around the user/stakeholder outcome.
+
+> **Bad:** "As a user, I want a dropdown to pick a timezone."
+> **Good:** "As a traveling user, I want event times shown in my current timezone so
+> that I don't miss meetings after I change locations." (The picker, if any, is an FR.)
+
+## Acceptance criteria: cover the unhappy paths, be concrete
+
+ACs are authored *here*, with the US/FR — don't defer coverage thinking to
+`spec-matrix`. Front-load it:
+
+- **Happy / error / edge from the start.** Walk the same ground the Six Coverage Rules
+  (`spec-matrix`) will later check — error paths, constraint boundaries, state
+  transitions, edge cases — while the behavior is fresh.
+- **Negative cases.** State what must *not* happen, not just what should: rejects,
+  refuses, never persists, leaves state unchanged.
+- **Concrete and measurable.** "Returns HTTP 422 within 200ms", not "handles errors
+  gracefully". Avoid subjective language (fast, robust, user-friendly) — if it can't
+  be measured, it can't be verified.
+- **Behavior, not implementation.** Assert the observable outcome, not how the code
+  achieves it.
+
+> **Bad:** "The system handles invalid input gracefully."
+> **Good:** "Given a payload missing `email`, when POST /contacts is called, then the
+> system returns HTTP 422 with error code `MISSING_FIELD` and persists no record."


### PR DESCRIPTION
## What

Adds authoring-time *judgment* to the `/specify` skill. Today the skill is strong on mechanics (artifact types, file layout, traceability, validation) but says nothing about what makes a requirement *good*, not just well-formed.

Folds in the substance of Anthropic's [`write-spec`](https://github.com/anthropics/knowledge-work-plugins/blob/main/product-management/skills/write-spec/SKILL.md) guidance, scoped to the pillars that fit quoin's spec-driven engineering world (formatting is left to quoin/quire).

## Changes

- **New** `skills/specify/references/writing-good-requirements.md` — three sections, each with a bad-vs-good example:
  - **Scope: tight beats broad** — narrow-and-complete over broad-and-vague; Out-of-Scope as first-class.
  - **User stories: INVEST + anti-patterns** — vagueness, solution-prescribing, missing "so that", internal focus.
  - **Acceptance criteria** — happy/error/edge + negative cases, concrete/measurable, behavior-not-implementation.
- **Edit** `skills/specify/SKILL.md` — new "Writing good requirements" section plus one-line pointers woven into the authoring order.

## Decisions

Reviewed all five Anthropic pillars one at a time:

| Pillar | Decision |
| --- | --- |
| Scope tightness & non-goals | Include |
| Prioritization (MoSCoW) | Skip — planning/sequencing concern |
| INVEST + US anti-patterns | Include |
| Acceptance-criteria quality | Include |
| Success metrics (leading/lagging) | Skip — PM territory |

Guiding lens: author well so `spec-review` has less to correct. No template or tooling changes; guidance maps to fields the templates already own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)