### PR TITLE
build(deps): bump actions/checkout from 4 to 7 in release-drift

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -17,7 +17,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history + tags so `git describe` works
       - name: Fail if src/ changed since the latest release tag


### PR DESCRIPTION
Dependabot bumped `install-smoke.yml` (#12) but not `release-drift.yml`. This brings the remaining quoin workflow to checkout v7 so all workflows are consistent.

One-line change, mirrors #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)