### PR TITLE
Clear the brace-expansion advisories before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,10 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/agent-ix/quoin.git"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": ">=5.0.8"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: '>=5.0.8'
+
 importers:
 
   .:
@@ -709,9 +712,6 @@ packages:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -719,12 +719,9 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2408,17 +2405,11 @@ snapshots:
 
   auto-bind@5.0.1: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   before-after-hook@3.0.2: {}
 
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2874,11 +2865,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.9
 
   mlly@1.8.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 minimumReleaseAge: 14400
 minimumReleaseAgeExclude:
   - "@agent-ix/*"
+  # Security patch needed sooner than the soak window.
+  - "brace-expansion"
 
 updateConfig:
   ignoreDependencies:


### PR DESCRIPTION
`pnpm audit --prod --audit-level high` reports four high `brace-expansion` DoS advisories, all reaching us through `@oclif/core` (`minimatch`, and `ejs>jake>filelist>minimatch`). The release workflow gates on that audit, so **this would have blocked the first release carrying the org work** — caught by checking before tagging rather than after.

They surface now because `ix-cli-core@0.12.0` moved `@oclif/core` from `peerDependencies` to `dependencies`, pulling its transitive tree into the production audit scope for the first time.

Overrides `brace-expansion` to `>=5.0.8` and excludes it from `minimumReleaseAge` — 5.0.8 was newer than the soak window. Same fix already applied in `ix-cli-core`, `filament-plan-sync`, and `ix-cli`.

The override only takes effect on a fresh resolution, so `pnpm-lock.yaml` is regenerated.

### Verification

No known vulnerabilities. **179 passed, 100% statements / branches / functions / lines**, `tsc`/`eslint`/`build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)