### PR TITLE
docs(spec-matrix): offer the full enforced Type/Priority/Status vocabularies

### DIFF
--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -9,7 +9,7 @@ heart of gap-analysis: a matrix row marked ✅ means nothing unless a tagged tes
 Built by `spec-matrix` (`quoin/skills/spec-matrix/SKILL.md`). Key tables:
 
 - **Test Case Summary** — `Test ID | Title | Type | Priority | Traces To | Status`, where
-  `Test ID` = `TC-xxx`, `Traces To` = `FR-XXX-AC-X` etc., `Status` ∈ `✅ ⚠️ ❌ 🚧`.
+  `Test ID` = `TC-xxx`, `Traces To` = `FR-XXX-AC-X` etc., `Status` ∈ `✅ ⚠️ ❌ 🚧 ⛔`.
 - **Per-requirement coverage** — StR/US/FR/NFR → AC → TC → Status tables.
 
 ## Tracking-tag patterns in test code

--- a/skills/spec-app-review/references/checklist.md
+++ b/skills/spec-app-review/references/checklist.md
@@ -178,7 +178,10 @@ For each artifact file (StR, US, FR, NFR):
 
 - [ ] File `spec/tests.md` exists
 - [ ] Coverage table maps every AC to at least one TC
-- [ ] TC entries include Type (Unit/Integration/E2E/Security) and Priority
+- [ ] TC entries include Type and Priority, each a single value from the
+      enforced vocabularies (see `spec-matrix/SKILL.md` § Test Case Summary —
+      `Security` is not one of them; a security test takes the Type that
+      describes how it runs)
 - [ ] Component ownership note explains which repo runs each TC
 - [ ] Constraint boundary tests section maps CON IDs to TCs
 

--- a/skills/spec-matrix/SKILL.md
+++ b/skills/spec-matrix/SKILL.md
@@ -53,12 +53,77 @@ is advisory; this skill treats it as a quality gate for the matrix.)
     -   Map `NFR` -> `TC`.
     -   Map `C` (Constraints) -> `TC`.
 3.  Enumerate: List all Test Cases with ID, Title, Type, Priority, Status.
+    See `Test Case Summary` below for the `Type` and `Priority` vocabularies —
+    both are validated, so a value outside the set fails `quire validate`.
 4.  Define Detailed TCs (Optional):
     -   For complex tests, create at:
         -   Single Repo: `spec/test-cases/TC-XXX.md`
         -   Multi-Repo: `specs/<category>/<component>/spec/test-cases/TC-XXX.md`
 5.  Verify: Ensure all 6 rules are satisfied.
 6.  Status: Mark as ✅ Complete only when all rules are met.
+
+## Test Case Summary
+
+The `## Test Case Summary` table is structurally validated by `quire validate`
+against the `TestMatrix` archetype (`spec-artifacts-process` FR-003). Columns are
+exactly `Test ID | Title | Type | Priority | Traces To | Status`.
+
+The vocabularies below are **not owned by this skill**. The single source is
+`spec_artifacts_process/manifest.yaml` (`traceability.vocabularies.test_type`,
+mirrored into `column_choices`); if this list and the manifest ever disagree, the
+manifest wins and this section is the bug.
+
+### `Type` — exactly one value per row
+
+Pick by *what makes the test fail*, not by which framework runs it.
+
+| Value | Use when |
+|---|---|
+| `Unit` | One function/module in isolation, example-based. The default. |
+| `Integration` | Two or more components, or a real dependency (DB, service, browser). |
+| `E2E` | The whole system through its outermost interface, as a user drives it. |
+| `Property` | The criterion holds **over a domain of inputs**, and the test generates them. See below. |
+| `Fuzz` | Untargeted/mutational input generation looking for crashes, not a stated property. |
+| `Benchmark` | The criterion is a latency/throughput number; the test measures it. |
+| `Static` | Proved by analysis over the source — a lint, an audit script, an architecture check. No runtime. |
+| `Compile` | The failure mode *is* a compile error (type-level guarantee, `forbid(unsafe_code)`). |
+| `Snapshot` | Byte/DOM-identity against a stored artifact. |
+| `Manual` | Verified by a human procedure; no automated gate. |
+
+**When `Property` rather than `Unit`.** Read the acceptance criterion and ask
+whether it quantifies. A criterion that names one input and one expected output
+is a `Unit` example. A criterion that asserts something for *every* input, or
+relates two runs to each other, is property-shaped:
+
+- **Invariant** — "output is always sorted", "the count never exceeds `max_size`"
+- **Round-trip** — "parse then render returns the original bytes"
+- **Idempotence** — "applying it twice equals applying it once"
+- **Metamorphic** — "reordering the inputs does not change the result"
+- **Oracle** — "the fast path agrees with the reference implementation"
+
+Words like *always*, *never*, *for any*, *regardless of*, *preserves*,
+*round-trips*, *deterministic*, *order-independent* are the signal. Where a
+criterion is property-shaped, prefer `Property` — a generated test discriminates
+the claim, a single example only witnesses it.
+
+`Property` is a first-class value: do not downgrade a property-shaped criterion
+to `Unit` because the repo has no generator yet. Author the row, and let the
+missing generator show up as a gap.
+
+### `Priority`
+
+`P0` | `P1` | `P2` | `P3` | `P4`.
+
+### `Status`
+
+`✅` complete · `⚠️` partial · `❌` failed · `🚧` in progress · `⛔` retired.
+A marker may be followed by text (`✅ Complete`); the marker must come first.
+
+### `Traces To`
+
+Comma-separated requirement ids (`FR-012-AC-3`, `US-004-AC-1`), ranges allowed
+(`FR-012-AC-1..3`), optional trailing ` (note)`. Trace to the **criterion**, not
+the requirement, and never to another `TC`.
 
 ## React Components (Conditional)
 
@@ -100,3 +165,4 @@ Use template section `## Integration Test Matrix` with:
 -   ⚠️ Partial
 -   ❌ Missing
 -   🚧 In Progress
+-   ⛔ Retired

--- a/skills/spec-matrix/assets/test-matrix-example.md
+++ b/skills/spec-matrix/assets/test-matrix-example.md
@@ -25,7 +25,7 @@ This is an example test matrix demonstrating comprehensive test coverage for the
 |----------------|---------------------|------------|-----------------|
 | FR-001 | FR-001-AC-1 | TC-001 | ✅ Complete |
 | FR-001 | FR-001-AC-2 | TC-002 | ✅ Complete |
-| FR-001 | FR-001-AC-3 | TC-006 | ✅ Complete |
+| FR-001 | FR-001-AC-3 | TC-006, TC-022 | ✅ Complete |
 | FR-001 | FR-001-AC-4 | TC-007 | ✅ Complete |
 | FR-001 | FR-001-AC-5 | TC-008 | ✅ Complete |
 | FR-001 | FR-001-AC-6 | TC-009 | ✅ Complete |
@@ -55,8 +55,14 @@ This is an example test matrix demonstrating comprehensive test coverage for the
 | TC-017 | Malformed YAML Handling | Integration | P1 | EC-003 | ❌ Missing |
 | TC-018 | Symlinks to K8s Configs | Integration | P2 | EC-004 | ❌ Missing |
 | TC-019 | Repository Changes During Clone | Integration | P2 | EC-005 | ❌ Missing |
+| TC-022 | Resource identification is order-independent and idempotent over any generated manifest set | Property | P1 | FR-001-AC-3 | ✅ Pass |
 
 **Note**: Detailed test case definitions are in the `test-cases/` directory.
+
+**Note on `Type`**: TC-022 is `Property`, not `Unit`, because FR-001-AC-3 is
+quantified — it holds for *any* manifest set, not for one worked example. TC-006
+witnesses the criterion with a specific input; TC-022 discriminates it across a
+generated domain. Both are legitimate and they trace to the same AC.
 
 ## Option Permutation Matrix
 | Test Case | OPT-A (Shallow) | OPT-B (Full) | Expected Behavior |
@@ -94,4 +100,5 @@ This is an example test matrix demonstrating comprehensive test coverage for the
 | Unit | 3 | 3 | 0 | 0 | 100% |
 | Integration | 8 | 8 | 0 | 0 | 100% |
 | E2E | 0 | 0 | 0 | 0 | N/A |
+| Property | 1 | 1 | 0 | 0 | 100% |
 | Edge Cases | 5 | 3 | 0 | 2 | 60% |

--- a/skills/spec-matrix/assets/test-matrix-template.md
+++ b/skills/spec-matrix/assets/test-matrix-template.md
@@ -38,10 +38,16 @@ This matrix ensures comprehensive test coverage by transforming requirements int
 
 | Test ID | Title | Type | Priority | Traces To | Status |
 |---------|-------|------|----------|-----------|--------|
-| TC-001 | [Test Title] | [Unit/Integration/E2E] | [P0/P1/P2/P3] | [US-XXX-AC-X] | [✅/⚠️/❌/🚧] |
-| TC-002 | [Test Title] | [Unit/Integration/E2E] | [P0/P1/P2/P3] | [FR-XXX-AC-X] | [✅/⚠️/❌/🚧] |
+| TC-001 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [US-XXX-AC-X] | [✅/⚠️/❌/🚧/⛔] |
+| TC-002 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [FR-XXX-AC-X] | [✅/⚠️/❌/🚧/⛔] |
 
 **Note**: Detailed test case definitions should be in separate files in `test-cases/` directory.
+
+**`Type`** shows the four most common values inline. The full enforced set is
+`Unit`, `Integration`, `E2E`, `Property`, `Fuzz`, `Benchmark`, `Static`,
+`Compile`, `Snapshot`, `Manual` — see the `Test Case Summary` section of
+`SKILL.md` for when each applies. Use exactly one value per row; the vocabulary
+is validated, so `Unit / pg_test` and other compounds are rejected.
 
 ## Option Permutation Matrix
 | Test Case | OPT-A | OPT-B | OPT-C | Expected Behavior |


### PR DESCRIPTION
Closes #47.

`spec-artifacts-process` FR-003 made `spec/tests.md` structurally validated, but the spec-matrix template still offered a narrower vocabulary than the contract enforces. An agent following the skill could never author a `Property` row or a `P4` row without deviating from the template.

`Property` is the value that matters for the wider program (umbrella agent-ix/quire-rs#17): its aim is to turn property-shaped acceptance criteria into executable property-based tests, and `Property` rows cannot be produced by rule while the template does not offer the value.

## Changes

| File | What |
|---|---|
| `assets/test-matrix-template.md` | Example rows show `Unit/Integration/E2E/Property`, `P0..P4`, full status set incl. `⛔`. Note points at SKILL.md for the remaining six Type values and warns that compound values (`Unit / pg_test` — 72 occurrences in the ecosystem sweep) are rejected. |
| `SKILL.md` | New `## Test Case Summary` section: the four vocabularies, a table of when each `Type` applies, and how to read a criterion for quantification (invariant / round-trip / idempotence / metamorphic / oracle) to choose `Property` over `Unit`. Adds `⛔ Retired` to Markers. |
| `assets/test-matrix-example.md` | The worked example used only `Unit` and `Integration`. Adds TC-022 as a `Property` row, with a note on why it is `Property` while tracing to the same AC as an example-based test. |
| `gap-analysis/references/step-3-matrix-verification.md` | `Status` list was missing `⛔`. |
| `spec-app-review/references/checklist.md` | Listed Type as `Unit/Integration/E2E/**Security**`; `Security` is not in the enforced vocabulary at all. Now references the skill instead of restating a list. |

## Single source

The vocabulary is **not duplicated into quoin as data**. The new section names `spec_artifacts_process/manifest.yaml` (`traceability.vocabularies.test_type`, mirrored into `column_choices`, drift-guarded by `tests/test_manifest.py`) as the source and states that the manifest wins on disagreement.

`SKILL.md:88`’s `service | browser | event | database` is the Integration Test Matrix’s own column, not this one — left alone, per the issue.

## Verification

`make test` — 179 passed, 15 files. `make lint` — clean.

Note: this branch also picks up main; the 24 pre-existing `tests/cli.test.ts` failures seen on the stale local main were fixed by the oclif refactor already on origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)