### PR TITLE
fix(ci): make `test` depend on `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,13 @@
 build:
 	pnpm run build
 
+# `test` depends on `build`: oclif resolves commands from `./dist/commands`
+# (package.json `oclif.commands`), so the dispatch-parity test sees an empty
+# command list without a build. CI runs `make install` then `make test` with no
+# build step in between, which is why that test passed locally — where a stale
+# `dist/` lingers — and failed on every clean runner.
 .PHONY: test
-test:
+test: build
 	pnpm run test
 
 .PHONY: test-json


### PR DESCRIPTION
quoin CI has **failed on every run since 2026-06-28**. The failing assertion is the oclif dispatch-parity test: `config.commandIDs` comes up empty.

## Cause

`package.json` points oclif at `./dist/commands`, and the shared CI workflow runs `make install` then `make test` **with no build in between**. On a clean runner `dist/` does not exist, so oclif discovers no commands.

The test passed locally only because a stale `dist/` lingered from an earlier build. `rm -rf dist && make test` reproduces the CI failure exactly — that is how this was confirmed rather than guessed.

## Fix

`test: build` — the dependency lives here, not in the shared workflow, so this does not change behaviour for every other consumer of `nodejs-actions/build-test.yml`.

## Verification

`rm -rf dist && make test` now builds first and passes **179/179**; before this change the same command failed.

Found while trying to release quoin for A4 of the spec-PBT program — the release job correctly skipped publishing because tests failed, so nothing shipped.