### PR TITLE
fix: resync package.json version with the published registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-ix/quoin",
   "description": "Spec-driven development for Claude Code — author validated, ISO/IEC/IEEE 29148-aligned specs, then plan and build against them.",
-  "version": "0.1.3",
+  "version": "0.6.1",
   "license": "MIT",
   "type": "module",
   "files": [


### PR DESCRIPTION
`package.json` said **`0.1.3`** while npm `latest` is **`0.6.0`** and the git tags reach `v0.6.0` — five minor versions of drift.

## Why it matters

The release workflow publishes the version in `package.json`. Dispatching it **reported success while shipping nothing**: 0.1.3 is below every version already on the registry, so `latest` never moved and #49's skill changes did not reach consumers.

A green release run that ships nothing is the worst shape of this bug, because it looks done.

## Evidence

```
npm view @agent-ix/quoin versions  ->  … 0.5.4 0.5.5 0.6.0     (no 0.1.3)
npm view @agent-ix/quoin dist-tags ->  { "latest": "0.6.0" }
```

Checked after the run that reported success — the registry is unchanged.

## Fix

Bumped to **0.6.1**, a patch over the published 0.6.0, which is what #49 (documenting the enforced Test Matrix vocabularies in the spec-matrix skill) actually is.

Found while releasing quoin for A4 of the spec-PBT program.