### PR TITLE
spec: convert single-criterion Validation Criteria to the asserted table

### DIFF
--- a/spec/stakeholder/StR-001-standalone-cli.md
+++ b/spec/stakeholder/StR-001-standalone-cli.md
@@ -32,11 +32,12 @@ in any repo, including ones outside the IX platform.
 
 ## Validation Criteria
 
-This need is satisfied when `quoin` installs as a single package and runs its
-catalog, authoring, plugin, workflow, and update surfaces using only its own
-runtime dependencies, resolving its configuration root from a flag or a sensible
-default without any platform-wide setup. Satisfaction is demonstrated by
-installing the package alone and exercising each command surface successfully.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-001-VC-1 | `quoin` installs as a single package and runs its catalog, authoring, plugin, workflow, and update surfaces using only its own runtime dependencies, resolving its configuration root from a flag or a sensible default without any platform-wide setup. | Demonstration |
+
+Satisfaction is demonstrated by installing the package alone and exercising each command surface successfully.
 
 ## Stakeholders
 

--- a/spec/stakeholder/StR-002-extensible-vocabulary.md
+++ b/spec/stakeholder/StR-002-extensible-vocabulary.md
@@ -29,12 +29,12 @@ author keeps one consistent authoring and validation flow.
 
 ## Validation Criteria
 
-This need is satisfied when an author installs a module from a supported source,
-sees its types appear in the active catalog, requests those types in an authoring
-contract, and validates files authored against them — with the installed module
-treated identically to a default module. Satisfaction is demonstrated by
-installing a module from a path and from a GitHub source and authoring against
-its types.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-002-VC-1 | An author installs a module from a supported source, sees its types appear in the active catalog, requests those types in an authoring contract, and validates files authored against them — with the installed module treated identically to a default module. | Demonstration |
+
+Satisfaction is demonstrated by installing a module from a path and from a GitHub source and authoring against its types.
 
 ## Stakeholders
 

--- a/spec/stakeholder/StR-003-shared-catalog.md
+++ b/spec/stakeholder/StR-003-shared-catalog.md
@@ -31,11 +31,12 @@ enforced, so a clean authoring pass predicts a clean validation pass.
 
 ## Validation Criteria
 
-This need is satisfied when the modules `quoin` reads to build an authoring
-contract are the same modules `quire` reads to validate, such that a file authored
-to the returned skeleton and schema validates without rule mismatch. Satisfaction
-is demonstrated by authoring an artifact from a `quoin` contract and validating it
-with `quire` against the same store.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-003-VC-1 | The modules `quoin` reads to build an authoring contract are the same modules `quire` reads to validate, such that a file authored to the returned skeleton and schema validates without rule mismatch. | Demonstration |
+
+Satisfaction is demonstrated by authoring an artifact from a `quoin` contract and validating it with `quire` against the same store.
 
 ## Stakeholders
 

--- a/spec/stakeholder/StR-004-governed-workflows.md
+++ b/spec/stakeholder/StR-004-governed-workflows.md
@@ -30,11 +30,12 @@ remains the single launch point an author already knows.
 
 ## Validation Criteria
 
-This need is satisfied when an author starts a review, matrix, or planning
-workflow through `quoin` and then drives its progression — resume, advance,
-acknowledge gates, inspect status — through the workflow engine, with the run's
-state persisted across invocations. Satisfaction is demonstrated by launching a
-workflow and continuing it to completion through the engine.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-004-VC-1 | An author starts a review, matrix, or planning workflow through `quoin` and then drives its progression — resume, advance, acknowledge gates, inspect status — through the workflow engine, with the run's state persisted across invocations. | Inspection |
+
+Satisfaction is demonstrated by launching a workflow and continuing it to completion through the engine.
 
 ## Stakeholders
 

--- a/spec/stakeholder/StR-005-offline-reproducible.md
+++ b/spec/stakeholder/StR-005-offline-reproducible.md
@@ -31,11 +31,12 @@ local.
 
 ## Validation Criteria
 
-This need is satisfied when the default module set is declared at fixed versions,
-installed once, and thereafter served from the local store with no network or
-version-resolution work on repeated catalog access — yielding identical results
-across runs. Satisfaction is demonstrated by exercising catalog and authoring
-commands repeatedly with no network activity after the first install.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-005-VC-1 | The default module set is declared at fixed versions, installed once, and thereafter served from the local store with no network or version-resolution work on repeated catalog access — yielding identical results across runs. | Inspection |
+
+Satisfaction is demonstrated by exercising catalog and authoring commands repeatedly with no network activity after the first install.
 
 ## Stakeholders
 

--- a/spec/stakeholder/StR-006-current-via-self-update.md
+++ b/spec/stakeholder/StR-006-current-via-self-update.md
@@ -26,11 +26,12 @@ both public releases and local development snapshots by choice of registry.
 
 ## Validation Criteria
 
-This need is satisfied when running the update command compares the installed
-version to the latest published version and upgrades in place, while a check-only
-invocation reports availability without changing anything, and an explicit
-registry can be selected. Satisfaction is demonstrated by a check that reports an
-available upgrade and an update that installs it.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-006-VC-1 | Running the update command compares the installed version to the latest published version and upgrades in place, while a check-only invocation reports availability without changing anything, and an explicit registry can be selected. | Demonstration |
+
+Satisfaction is demonstrated by a check that reports an available upgrade and an update that installs it.
 
 ## Stakeholders
 


### PR DESCRIPTION
agent-ix/spec-artifacts-iso#11. These needs state **one criterion** followed by a "Satisfaction is demonstrated by …" sentence naming the evidence for the whole need.

```
| StR-001-VC-1 | `quoin` installs as a single package and runs its catalog, authoring, plugin,
                 workflow, and update surfaces using only its own runtime dependencies… | Demonstration |

Satisfaction is demonstrated by installing the package alone and exercising each command surface successfully.
```

The criterion becomes one row with its sentence carried across **whole**; the evidence sentence is kept below the table, where it applies to the need rather than to any single row.

**Nothing is split, so nothing can be mis-split.** The converter still refuses anything carrying `, when` / `; when` connectors, so a genuinely enumerated sentence is never collapsed into one row.