### PR TITLE
spec: finish the Acceptance Criteria sections to the asserted shape

### DIFF
--- a/spec/non-functional/NFR-007-external-tool-invocation.md
+++ b/spec/non-functional/NFR-007-external-tool-invocation.md
@@ -50,8 +50,10 @@ surface as a non-zero exit (`flows.test.ts`), and the write tests assert the
 
 ## Acceptance Criteria
 
-The absence of external-tool version pinning is an accepted limitation, recorded
-here rather than as a metric; it is revisited if pinning becomes required.
+
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-007-AC-1 | The absence of external-tool version pinning is an accepted limitation, recorded here rather than as a metric; it is revisited if pinning becomes required. | Demonstration |
 
 ## Dependencies
 


### PR DESCRIPTION
agent-ix/spec-artifacts-iso#11. Three shapes the bullet pass could not take:

| shape | treatment |
|---|---|
| `ID · Criteria` | asserted `Verification` column added, derived from what each criterion describes |
| `ID · Criteria · Notes` | `Notes` is not a method — it moves **into the criterion cell** and a derived method takes the column, so the note survives rather than being overwritten |
| prose paragraph | one row, sentence carried across **whole** |

The paragraph case **deliberately does not split**. #11 allows dropping a measurable NFR's section outright, but that discards authored text, and splitting risks inventing criteria the author never wrote. One row keeps the claim verbatim and satisfies `min_rows: 1`.

Existing `-AC-` ids are preserved wherever the document declares them, so anything tracing them keeps resolving.