### PR TITLE
chore: pin the default modules to v0.7.0 and release 0.7.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.5.0"
+    version: "0.7.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.5.0
+      ref: v0.7.0
 
   - name: spec-artifacts-app
     version: "0.3.0"
@@ -28,13 +28,13 @@ entries:
       ref: v0.3.0
 
   - name: spec-artifacts-process
-    version: "0.5.0"
+    version: "0.7.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.5.0
+      ref: v0.7.0
 
   - name: spec-objects-business
     version: "0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-ix/quoin",
   "description": "Spec-driven development for Claude Code — author validated, ISO/IEC/IEEE 29148-aligned specs, then plan and build against them.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "MIT",
   "type": "module",
   "files": [


### PR DESCRIPTION
`spec-artifacts-iso` and `spec-artifacts-process` were pinned at **v0.5.0**, two releases behind. Both were tagged **v0.7.0** and published to the internal PyPI today, carrying:

- the StR/NFR **binding-criteria table contract** (agent-ix/spec-artifacts-iso#11)
- the **TestMatrix `body_extraction` contract** (spec-artifacts-process FR-003)

## Why the pin bump is the delivery step

Module adoption is **per-repo through this file**. `quoin module ensure-defaults` resolves the *pinned ref*, not latest — verified earlier when checking whether publishing would broadcast to every repo at once. It does not. So publishing the modules alone reaches nobody; these pins are what actually delivers the contracts to consumers.

That also means this bump is a deliberate step rather than a side effect of the publishes, and it is the point at which consumers begin seeing enforcement.

## Version

`0.6.1 → 0.7.0` — a minor, since consumers picking up the new pins get enforcement they did not have before.

`make test` 179/179, `make lint` clean.