### PR TITLE
chore(modules): pin spec-artifacts-process v0.8.0 (CR-018)

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.3.0
 
   - name: spec-artifacts-process
-    version: "0.7.0"
+    version: "0.8.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.7.0
+      ref: v0.8.0
 
   - name: spec-objects-business
     version: "0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-ix/quoin",
   "description": "Spec-driven development for Claude Code — author validated, ISO/IEC/IEEE 29148-aligned specs, then plan and build against them.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "type": "module",
   "files": [


### PR DESCRIPTION
The pin resolves the **pinned ref, not the latest tag**, so a published module reaches nobody until this file moves.

v0.8.0 carries CR-018, which makes the TestMatrix `Priority` column optional. Without this bump every repo using the shipped default set keeps validating against a contract that requires a column **49 of 169** ecosystem matrices never authored.

Needs quire-rs ≥ v0.16.0 (quire-cli v0.10.0) for the `optional_columns` assert key.

Bumps quoin to `0.8.0`. 179 tests pass, lint clean.