### PR TITLE
chore(modules): pin spec-artifacts-process v0.9.0 (CR-019)

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.3.0
 
   - name: spec-artifacts-process
-    version: "0.8.0"
+    version: "0.9.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.8.0
+      ref: v0.9.0
 
   - name: spec-objects-business
     version: "0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-ix/quoin",
   "description": "Spec-driven development for Claude Code — author validated, ISO/IEC/IEEE 29148-aligned specs, then plan and build against them.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "type": "module",
   "files": [


### PR DESCRIPTION
v0.9.0 admits the `IT` test-id prefix alongside `TC`, mirroring the two evidence archetypes `spec-artifacts-iso` declares.

Until this pin moves, the shipped default set keeps rejecting `IT-` ids that the iso module itself mints (`IT-{next:03d}`).

Bumps quoin to `0.9.0`. 179 tests pass.