### PR TITLE
chore: pin spec-artifacts-iso v0.8.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.7.0"
+    version: "0.8.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.7.0
+      ref: v0.8.0
 
   - name: spec-artifacts-app
     version: "0.3.0"


### PR DESCRIPTION
Stage 4 of the `ac` grammar promotion. spec-artifacts-iso v0.8.0 declares `ac:vacuous-outcome` and `ac:non-singular` as `error` via the FR-048 `grammar_severity` map (agent-ix/spec-artifacts-iso#12).

**A published module reaches nobody until this pin moves** — this is the commit that actually turns the promotion on for quoin consumers.

Safe to land: both checks measure **0** across the corpus (4,448 docs / 192 repos / 11,045 cells), so no existing document starts failing. A document that *reintroduces* either shape now fails validation rather than warning, which is the point.

Gates: `make test` ✅ (179 passed) · `make lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)