### PR TITLE
Pin the default module set to spec-artifacts-process v0.11.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.10.0"
+    version: "0.11.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.10.0
+      ref: v0.11.0
 
   - name: spec-objects-business
     version: "0.6.0"


### PR DESCRIPTION
**v0.12.2 is broken for a fresh install.** `default-modules.yaml` still pinned `spec-artifacts-process` at **v0.10.0**, and 0.12.2 shipped with it.

That pin has no `trace_tags`, no `document_references`, and no `spec-correctness` value in the `SpecReview.analysis` enum. So for anyone installing quoin today, 0.12.2 fails in both directions at once:

- **`quire coverage` backs zero rows** and reports `0/0 (100%)` — exactly the ecosystem-wide failure the 0.12.2 work exists to fix.
- **The `spec-correctness` skill cannot write its own artifact.** It emits `analysis: spec-correctness`, which fails `quire validate` against v0.10.0.

## Why it got through

This machine had the module updated by hand to v0.11.0 before the release was verified. Every check — including the end-to-end `quire coverage --scope .` run with no `--module` override — passed against a state no new user has. The verification was real; the environment was not representative.

## Scope of the audit

All eight pins were checked against their upstream tags:

| module | pinned | latest |
| --- | --- | --- |
| spec-artifacts-process | v0.10.0 → **v0.11.0** | v0.11.0 |
| spec-artifacts-iso | v0.9.0 | v0.9.0 ✅ |
| spec-artifacts-app | v0.5.0 | v0.5.0 ✅ |
| spec-objects-business | v0.6.0 | v0.6.0 ✅ |
| spec-objects-architecture | v0.6.0 | v0.6.0 ✅ |
| spec-objects-enterprise | v0.5.0 | v0.5.0 ✅ |
| spec-objects-operational | v0.6.0 | v0.6.0 ✅ |
| spec-objects-security | v0.5.0 | v0.5.0 ✅ |

This was the only stale one.

## The guard that should have caught it

`release-drift.yml` diffs `src/` only, and `default-modules.yaml` is at the package root — so it is structurally blind to a stale module pin. Filed as a follow-up.

225 tests pass. Ships as v0.12.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)