### PR TITLE
Remove the inert brace-expansion pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,10 +114,5 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/agent-ix/quoin.git"
-  },
-  "pnpm": {
-    "overrides": {
-      "brace-expansion": ">=5.0.8"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion: '>=5.0.8'
-
 importers:
 
   .:
@@ -715,12 +712,18 @@ packages:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2415,9 +2418,15 @@ snapshots:
 
   auto-bind@5.0.1: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   before-after-hook@3.0.2: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -2883,7 +2892,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 2.1.4
 
   mlly@1.8.2:
     dependencies:


### PR DESCRIPTION
Closes #66.

The `pnpm.overrides` entry pinned `brace-expansion` to `>=5.0.8`. Under pnpm 10.33 the graph already resolves what it needs on its own, so the override only forced one version across unrelated subtrees.

## Change
- Drop the `pnpm.overrides` block from `package.json`
- Regenerate `pnpm-lock.yaml` (`make update-lock`)

## Verification
- Lockfile now resolves `brace-expansion@5.0.9` and `brace-expansion@2.1.4` naturally, each where it belongs
- `pnpm audit` reports **zero** `brace-expansion` advisories
- `make lint` clean, `make test` 225/225 passing

Remaining audit findings are pre-existing and unrelated (`pnpm` devDependency pinned below 11.5.3/11.7.0, `postcss` via `vite`) — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)