### PR TITLE
Pin spec-artifacts-process to v0.12.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.11.0"
+    version: "0.12.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.11.0
+      ref: v0.12.0
 
   - name: spec-objects-business
     version: "0.6.0"


### PR DESCRIPTION
The last step of agent-ix/quoin#65. Picks up `no_source_symbol: [Eval, Manual]` (agent-ix/spec-artifacts-process#26).

## Measured here, against quire 0.14.0 and a freshly resolved module set

```
status lies      40 → 0
no_symbol_rows    0 → 40
backed          109/273 (unchanged)
```

```json
{ "reference": "traces-to-evals", "row_id": "TC-EV-001",
  "test_type": "Eval", "target_ids": ["TC-EV-001", "US-001"] }
```

The 40 are this repo's agent-behaviour evals. They are verified by driving an agent against a live scenario, so no source symbol exists to tag. The rollup now says exactly that, instead of reporting them as rows claiming evidence they do not have.

**Backed/total is unchanged.** The exemption withdraws the accusation, not the fact — the rows are still listed as unbacked.

## The whole arc for this repo

| stage | status lies |
|---|---|
| before any of this | 55 |
| #73 — comma-listed trace comments split | 40 |
| this PR — eval rows exempted | **0** |

## Verification

- `node scripts/release-drift.js pins` — **8 current, 0 behind, 0 unresolved** (the checker added in #71, doing its job)
- Module set re-resolved from an empty registry, so the pin is what was read
- `make lint` clean, `make test` 225/225

🤖 Generated with [Claude Code](https://claude.com/claude-code)