### PR TITLE
Pin spec-artifacts-process to v0.13.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.12.0"
+    version: "0.13.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.12.0
+      ref: v0.13.0
 
   - name: spec-objects-business
     version: "0.6.0"


### PR DESCRIPTION
Picks up the widened legacy trace-tag patterns (FR-004-AC-8): a comment carrying a comma-separated list now *declares* every id it names, so the engine binds all of them rather than only the first.

**Requires quire-rs >= v0.21.0 / quire >= v0.15.0**, both released. Against an older engine a widened group yields one id of literally `"A, B"`, which resolves to nothing — strictly worse than the bug.

No effect on quoin's own coverage: #73 already split quoin's 24 list-bearing comments onto their own lines, so this repo carries no such line today. The pin matters for every repo quoin scans.

Part of agent-ix/quire-rs#68.

## Verification

`make test` — 24 files, 229 tests passed. `make lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)