### PR TITLE
Unfreeze the plugin manifest version so installers actually update

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.1.0",
+  "version": "0.12.3",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.1.0",
+  "version": "0.12.3",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -32,6 +32,12 @@ jobs:
           pnpm install --frozen-lockfile
       - name: Fail if release-relevant paths changed since the latest tag
         run: node scripts/release-drift.js check
+      - name: Fail if a plugin manifest declares a version other than the latest tag
+        # Hosts key their plugin cache on this number and read it from the
+        # branch, not from a tag or a tarball, so a frozen version leaves every
+        # installer on an old tree no matter how many releases ship.
+        if: always()
+        run: node scripts/release-drift.js manifests
       - name: Report default module pins against latest tags
         # Report-only: pinning behind latest is sometimes deliberate. This step
         # exists so the state is known, not so it can block.

--- a/scripts/release-drift.js
+++ b/scripts/release-drift.js
@@ -12,10 +12,20 @@
  *   pins   Reports each default-modules.yaml pin against that repo's latest
  *          tag. Reports only — pinning behind latest is sometimes deliberate,
  *          and the value is knowing rather than being forced.
+ *
+ *   manifests
+ *          Fails when an agent plugin manifest declares a version other than
+ *          the latest release tag. Unlike package.json — which CI stamps from
+ *          the tag and never commits back — these manifests are read straight
+ *          out of the checked-out branch by the host (Claude Code clones the
+ *          marketplace repo and materializes a cache keyed on the declared
+ *          version). A frozen version therefore means installers never see an
+ *          update: quoin shipped 32 tags while .claude-plugin/plugin.json sat
+ *          at 0.1.0, and every install stayed on the tree from the first tag.
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +39,12 @@ const repoRoot =
 
 /** Shipped paths that are built rather than committed, and their source. */
 const BUILD_OUTPUT_SOURCES = { "dist/": "src" };
+
+/** Agent plugin manifests whose `version` the host reads from the branch. */
+const PLUGIN_MANIFESTS = [
+  ".claude-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+];
 
 /**
  * Release-relevant paths, derived from what the package actually ships.
@@ -65,6 +81,28 @@ export function comparePins(entries, latestTags) {
       state = "behind";
     }
     return { name: entry.name, url, pinned, latest: latest ?? "", state };
+  });
+}
+
+/**
+ * Compare each plugin manifest's declared version against the release tag.
+ *
+ * `manifests` maps a repo-relative path to its parsed contents, or to null when
+ * the file is absent. An absent manifest is reported rather than failed — the
+ * repo simply does not package for that host — but a present-and-stale one is a
+ * hard failure, since it silently pins every installer to an old tree.
+ */
+export function compareManifestVersions(manifests, tag) {
+  const expected = tag.replace(/^v/, "");
+  return Object.entries(manifests).map(([path, manifest]) => {
+    if (!manifest) return { path, declared: "", expected, state: "absent" };
+    const declared = manifest.version ?? "";
+    return {
+      path,
+      declared,
+      expected,
+      state: declared === expected ? "current" : "stale",
+    };
   });
 }
 
@@ -120,6 +158,26 @@ function readModules() {
   return parse(readFileSync(join(repoRoot, "default-modules.yaml"), "utf8"));
 }
 
+function readManifests() {
+  const manifests = {};
+  for (const path of PLUGIN_MANIFESTS) {
+    const absolute = join(repoRoot, path);
+    manifests[path] = existsSync(absolute)
+      ? JSON.parse(readFileSync(absolute, "utf8"))
+      : null;
+  }
+  return manifests;
+}
+
+/** The newest release tag, or "" when the repo has never been tagged. */
+function latestReleaseTag() {
+  try {
+    return git(["describe", "--tags", "--abbrev=0"], { stdio: "pipe" });
+  } catch {
+    return "";
+  }
+}
+
 const commands = {
   paths() {
     for (const path of releasePaths(readPackage())) {
@@ -129,12 +187,7 @@ const commands = {
 
   check() {
     const paths = releasePaths(readPackage());
-    let lastTag = "";
-    try {
-      lastTag = git(["describe", "--tags", "--abbrev=0"], { stdio: "pipe" });
-    } catch {
-      lastTag = "";
-    }
+    const lastTag = latestReleaseTag();
     if (!lastTag) {
       console.log("No release tags yet; nothing to compare against.");
       return 0;
@@ -161,6 +214,27 @@ const commands = {
     console.log(`Changed since ${lastTag}:`);
     console.log(changed);
     return 1;
+  },
+
+  manifests() {
+    const lastTag = latestReleaseTag();
+    if (!lastTag) {
+      console.log("No release tags yet; nothing to compare against.");
+      return 0;
+    }
+
+    const rows = compareManifestVersions(readManifests(), lastTag);
+    for (const row of rows) {
+      console.log(`${row.path}  ${row.declared || "-"}  ${row.state}`);
+    }
+
+    const stale = rows.filter((row) => row.state === "stale");
+    for (const row of stale) {
+      console.log(
+        `::error::${row.path} declares version ${row.declared || "(none)"} but the latest tag is ${lastTag}. Hosts key their plugin cache on this number, so installers stay on the old tree until it moves.`,
+      );
+    }
+    return stale.length ? 1 : 0;
   },
 
   pins() {
@@ -207,6 +281,11 @@ const commands = {
     console.log("  check   Fail if release-relevant paths changed since the");
     console.log("          latest tag (paths derived from package.json files)");
     console.log("  paths   Print the derived release-relevant path list");
+    console.log("  manifests");
+    console.log(
+      "          Fail if an agent plugin manifest declares a version",
+    );
+    console.log("          other than the latest release tag");
     console.log("  pins    Report default-modules.yaml pins vs latest tags");
     console.log("  help    Show this help message");
     return 0;

--- a/tests/release-drift.test.ts
+++ b/tests/release-drift.test.ts
@@ -45,6 +45,14 @@ function fixtureRepo() {
   );
   mkdirSync(join(root, "src"));
   writeFileSync(join(root, "src", "index.ts"), "export const x = 1;\n");
+  // Both agent plugin manifests, declaring the version of the tag below.
+  for (const dir of [".claude-plugin", ".codex-plugin"]) {
+    mkdirSync(join(root, dir));
+    writeFileSync(
+      join(root, dir, "plugin.json"),
+      JSON.stringify({ name: "fixture", version: "0.1.0" }, null, 2),
+    );
+  }
   git("add", "-A");
   git("commit", "-qm", "release");
   git("tag", "v0.1.0");
@@ -52,6 +60,16 @@ function fixtureRepo() {
   return {
     root,
     git,
+    /**
+     * Tag a later release. The commit matters: `git describe` resolves ties on
+     * a single commit arbitrarily, so a second tag needs its own commit to
+     * reliably read as the newer one.
+     */
+    tagRelease: (tag: string) => {
+      writeFileSync(join(root, "src", "index.ts"), `export const x = 2;\n`);
+      git("commit", "-qam", `release ${tag}`);
+      git("tag", tag);
+    },
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
@@ -100,6 +118,65 @@ test("a change outside the shipped file set does not trip the guard", () => {
     repo.git("commit", "-qm", "notes");
 
     expect(run(["check"], { QUOIN_DRIFT_ROOT: repo.root }).status).toBe(0);
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("plugin manifests declaring the release tag pass", () => {
+  const repo = fixtureRepo();
+  try {
+    const result = run(["manifests"], { QUOIN_DRIFT_ROOT: repo.root });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("current");
+    expect(result.stdout).not.toContain("::error::");
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("a manifest frozen behind the release tag fails, naming both versions", () => {
+  const repo = fixtureRepo();
+  try {
+    // The real defect: releases shipped while plugin.json stayed at 0.1.0.
+    repo.tagRelease("v0.12.3");
+
+    const result = run(["manifests"], { QUOIN_DRIFT_ROOT: repo.root });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("::error::");
+    expect(result.stdout).toContain("0.1.0");
+    expect(result.stdout).toContain("v0.12.3");
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("one host's manifest drifting alone still fails", () => {
+  const repo = fixtureRepo();
+  try {
+    repo.tagRelease("v0.12.3");
+    writeFileSync(
+      join(repo.root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "fixture", version: "0.12.3" }, null, 2),
+    );
+
+    const result = run(["manifests"], { QUOIN_DRIFT_ROOT: repo.root });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("::error::.codex-plugin/plugin.json");
+    expect(result.stdout).not.toContain("::error::.claude-plugin");
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test("an absent manifest is reported, not failed", () => {
+  const repo = fixtureRepo();
+  try {
+    rmSync(join(repo.root, ".codex-plugin"), { recursive: true, force: true });
+
+    const result = run(["manifests"], { QUOIN_DRIFT_ROOT: repo.root });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("absent");
   } finally {
     repo.cleanup();
   }


### PR DESCRIPTION
## Why

`.claude-plugin/plugin.json` has declared `0.1.0` since it was created, across **32 release tags**. Hosts read that number out of the checked-out branch and key their plugin cache on it, so every installer has been pinned to the tree from the first tag.

Concretely, on a machine here: `~/.claude/plugins/cache/quoin/quoin/0.1.0/` is the only directory that has ever existed, holding a snapshot from 2026-06-22 — 52 commits behind main. It is missing `spec-correctness` and `spec-ears-analysis` entirely, and its `gap-analysis` still hand-greps the matrix instead of calling `quire coverage` (#64). That is what surfaced this: the skill was fixed on main and nobody was running the fix.

`.codex-plugin/plugin.json` had the same freeze.

## What

- Both manifests → `0.12.3`, the current tag. Plugin version and release version are one number from here on.
- New `release-drift manifests` command fails when a manifest declares anything other than the latest tag, wired into the release-drift workflow after `check`. Absent manifest reports; present-and-stale is a hard error.
- Tests cover match, behind, one-host-drifting-alone, and absent.

`package.json` is deliberately left alone: CI stamps it from the tag and never commits it back, which works because npm reads the tarball, not the branch. The plugin manifests have to be committed to be seen.

## Verification

- `make test` — 233/233
- `make lint` — clean
- `node scripts/release-drift.js manifests` — both manifests `current`; hand-editing either one to `0.1.0` exits 1 naming both versions

After this merges and a release is tagged, `/plugin` update should materialize `cache/quoin/quoin/0.12.3/` with the current skill set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)