### PR TITLE
Release 0.13.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
Cuts 0.13.0 and declares it in `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.

main has release-relevant changes sitting ahead of `v0.12.3`:

- `default-modules.yaml` + `package.json` — spec-artifacts-process pinned to v0.13.0 (#76)
- both plugin manifests — the version unfreeze (#77)

Bumping the manifests in the same commit as the release keeps the `release-drift manifests` guard honest: it compares the declared version against the latest tag, so the two have to move together.

Tag `v0.13.0` follows immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)