### PR TITLE
docs(skills): record the two-root --scope semantics after quire-rs CR-045

### DIFF
--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -26,6 +26,14 @@ validated against, so the two cannot drift.
 quire coverage --scope <project_root> --json
 ```
 
+`--scope` is the repository root, and stays so. Since quire-cli v0.16.0 (quire-rs CR-045)
+the command derives **two roots** from it and never interchanges them: spec documents are
+read from `<project_root>/spec` only, and trace tags from the source tree at
+`<project_root>` excluding `spec/`. This invocation needs no second flag — but a project
+whose `spec/` directory is missing now exits with a diagnostic naming the missing document
+root instead of silently scanning the whole repository, and a matrix outside `spec/` (a
+fixture, a `plan/` copy) mints nothing.
+
 Do **not** pass `--strict`. Whether a gap blocks is this skill's verdict rule (Step 6), not
 the command's exit code.
 

--- a/skills/gap-analysis/references/step-6-specreview-artifact.md
+++ b/skills/gap-analysis/references/step-6-specreview-artifact.md
@@ -88,6 +88,12 @@ will not bind it — and a reader cannot tell which they are looking at unless i
 quire validate --scope <project_root> "reviews/**/*.md"
 ```
 
+**Always pass `--scope <project_root>` explicitly, as above.** A relative glob resolves
+under `--scope` only in scoped mode (no `--module`); with `--module` it resolves against
+the process working directory, and an omitted `--scope` defaults to `.` — either way a
+sweep launched from a parent directory silently validates the wrong tree (or nothing)
+while exiting 0 for whatever it did match.
+
 Fix any validation error (frontmatter pattern, `analysis` enum, findings headers/ids/severity)
 before reporting completion. Then tell the user the artifact path and the Verdict.
 

--- a/skills/spec-correctness/references/step-7-report-and-handoff.md
+++ b/skills/spec-correctness/references/step-7-report-and-handoff.md
@@ -48,6 +48,11 @@ Before finishing, prove every emitted tag actually **binds** — not that it exi
 quire coverage --scope <repo> --json
 ```
 
+`--scope` is the repository root. Since quire-cli v0.16.0 (quire-rs CR-045) the command
+derives two roots from it: documents from `<repo>/spec` only, trace tags from the source
+tree excluding `spec/`. A repo with no `spec/` directory exits with a diagnostic naming
+the missing document root, and a matrix outside `spec/` mints nothing.
+
 For each `row_id` this run emitted, confirm the id appears among the backed ids: its
 minting document's group must count it, and it must not appear in `untracked_symbols`.
 


### PR DESCRIPTION
Closes #82 (depends on agent-ix/quire-rs#91, shipped in quire-cli v0.16.0).

1. **gap-analysis step 3**: the invocation is **unchanged** — both roots derive from the one `--scope` as designed (no second flag). What changed underneath is now recorded: documents read from `<root>/spec` only, code walk excludes `spec/`, missing `spec/` is a named error, an out-of-tree matrix mints nothing.
2. **gap-analysis step 6**: the glob-resolution trap written down — verified against `quire-cli validate.rs scoped_path`: a relative glob resolves under `--scope` only in scoped mode (no `--module`); with `--module` it resolves against the process CWD, and an omitted `--scope` defaults to `.`. (The ticket's blanket 'resolves against CWD' claim was half-right.)
3. **spec-correctness step 7** runs the identical `quire coverage --scope` invocation and wasn't named by the ticket — same note added. `spec-to-plan` (`plan/**`) and `spec-ears-analysis` (`spec/reviews/…`) use per-document positional validation, not the bundle walk — unaffected, checked.

**Verdict stability**: `quire coverage --scope . --json` over spec-artifacts-process is **byte-identical** before/after the traversal split, so a gap-analysis verdict over a compliant repo is unchanged. **Disappearing-findings audit**: documents outside `spec/` never minted in the repos checked (archetype targets only bind typed FR/NFR docs; the matrix is path-bound to `spec/tests.md`) — no stale SpecReview rollups found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)