### PR TITLE
docs(skills): correct the exit-0 claim and backport the two-root notes

### DIFF
--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -62,6 +62,18 @@ code, edit the plan, or change the matrix. Its only write is the SpecReview arti
 
 All steps required except Step 4, which is gated on user choice.
 
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
 ## The optional semantic review
 
 Steps 1–3 are mechanical and cheap. Step 4 is an expensive, judgment-heavy LLM pass.

--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -34,6 +34,18 @@ whose `spec/` directory is missing now exits with a diagnostic naming the missin
 root instead of silently scanning the whole repository, and a matrix outside `spec/` (a
 fixture, a `plan/` copy) mints nothing.
 
+**Check the version before relying on any of that.** The "since v0.16.0" premise is not
+enforced anywhere — nothing probes it, and a user on ≤ 0.15.0 silently gets the pre-split
+traversal semantics, where the walk covers the whole repository and a matrix outside
+`spec/` mints. One line, before the first invocation:
+
+```bash
+quire --version    # expect >= 0.16.0; on an older build the roots are not split
+```
+
+If it is older, say so in `## Coverage` rather than reading the report as if the split
+applied.
+
 Do **not** pass `--strict`. Whether a gap blocks is this skill's verdict rule (Step 6), not
 the command's exit code.
 
@@ -44,8 +56,11 @@ The report carries exactly the findings this step produces:
 | `unbacked_rows` | A declared reference row whose trace targets have no backing `verifies` relation. Each carries `reference`, `document`, `row_id`, `target_ids`. |
 | `status_lies` | A row whose status classes as `complete` while nothing backs it. Adds the authored `status` string. |
 | `untracked_symbols` | A test carrying a trace tag that resolves to no declared row. Carries `path`, `symbol`, `trace_id`. |
+| `no_symbol_rows` | An unbacked row whose **declared verification method mints no source symbol** — an eval, an inspection, a demonstration (quire-rs FR-050-AC-16 / CR-041). Carries `reference`, `document`, `row_id`, `test_type`, `target_ids`. **Read this before triaging `unbacked_rows`**: a row listed here is exempt from `status_lies` by its own method, and reporting it as an unbacked-row finding asserts something impossible. Absent from the JSON entirely when the module declares no `no_source_symbol` vocabulary. |
+| `criteria` | Per-document acceptance-criteria property counts (quire-rs FR-050-AC-13 / CR-028): `document`, `archetype`, `criteria`, `property_shaped`, `by_property`. Data for the `spec-correctness` handoff, never a verdict — a low property-shaped share describes a corpus, it does not fail one. Absent when the corpus binds no criteria. |
 | `groups` | Per minting document: `document`, `target`, `backed`, `total`. |
-| `totals` | `backed` / `total` across the bundle. |
+| `diagnostics` | Declarations that selected nothing and why (quire-rs FR-050-AC-19 / CR-054): an unreadable declared `document:`, an archetype no document has when the model minted nothing, or a model with no trace targets. Absent when every declaration selected. A non-empty list means the numbers below it are measuring less than you think. |
+| `totals` | `backed` / `total` across the bundle, plus `criteria` / `property_shaped` when the corpus binds criteria. |
 
 ## Reconcile, producing findings
 

--- a/skills/gap-analysis/references/step-6-specreview-artifact.md
+++ b/skills/gap-analysis/references/step-6-specreview-artifact.md
@@ -90,9 +90,10 @@ quire validate --scope <project_root> "reviews/**/*.md"
 
 **Always pass `--scope <project_root>` explicitly, as above.** A relative glob resolves
 under `--scope` only in scoped mode (no `--module`); with `--module` it resolves against
-the process working directory, and an omitted `--scope` defaults to `.` — either way a
-sweep launched from a parent directory silently validates the wrong tree (or nothing)
-while exiting 0 for whatever it did match.
+the process working directory, and an omitted `--scope` defaults to `.`. A sweep launched
+from a parent directory therefore validates the **wrong tree** and exits 0 for whatever
+it did match — that is the trap. (A glob matching *nothing* is not silent: the CLI exits
+1 with `document glob matched no files`. Only the wrong-tree half is quiet.)
 
 Fix any validation error (frontmatter pattern, `analysis` enum, findings headers/ids/severity)
 before reporting completion. Then tell the user the artifact path and the Verdict.

--- a/skills/spec-correctness/references/step-6-review-artifact.md
+++ b/skills/spec-correctness/references/step-6-review-artifact.md
@@ -110,6 +110,19 @@ real run — not this skill's to pre-empt with a marker.
 quire validate --scope <project_root> "reviews/**/*.md"
 ```
 
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
+
 Fix any validation error — frontmatter pattern, the `analysis` enum, findings
 headers/ids/severity — before reporting completion. Then tell the user the artifact path.
 

--- a/skills/spec-correctness/references/step-7-report-and-handoff.md
+++ b/skills/spec-correctness/references/step-7-report-and-handoff.md
@@ -75,9 +75,22 @@ Then confirm, as before:
 - no matrix row this run added is `✅` while its test is skipped;
 - no emitted tag names a `row_id` absent from the `quire properties` output.
 
-If `quire coverage` reports `no rows matched`, the module in scope declares no traceability
-model for this repo's layout — that is an environment gap, not a clean run. Say so rather
-than reporting the run as reconciled.
+Check `quire --version` ≥ 0.16.0 first: the two-root semantics this step assumes are
+unenforced, and an older build silently walks the whole repository instead.
+
+Two distinct states get conflated here; keep them apart (they have different causes and
+different fixes — `gap-analysis` step 3 has the same reading):
+
+- **A zero denominator.** Under the `--json` invocation this step prescribes the signal is
+  `"totals": {"total": 0}`. `no rows matched` is a **human-format-only** marker and never
+  appears in the JSON, so do not look for it there. It means the declared model matched
+  nothing in this scope — no minting document was found. Not full coverage, not a clean
+  run: report it as **no data**.
+- **No model at all.** `quire coverage` exits **non-zero** with a distinct diagnostic when
+  no active module declares a `traceability:` model (quire-rs FR-050-AC-9). That is an
+  environment gap — the module set, not the repo's rows.
+
+Say which one happened rather than reporting the run as reconciled.
 
 A mismatch here is a bug in this run, not in `gap-analysis`.
 

--- a/skills/spec-ears-analysis/SKILL.md
+++ b/skills/spec-ears-analysis/SKILL.md
@@ -22,6 +22,19 @@ form the lens.
     quire validate --scope . "spec/**/*.md" --summary
     ```
 
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
+
     Read the `[ears:<check>]` warnings and the `GrammarSummary` line. The engine
     flags, per statement:
     -   `non-singular` — more than one `shall` (can't map cleanly to one AC).

--- a/skills/spec-matrix/SKILL.md
+++ b/skills/spec-matrix/SKILL.md
@@ -27,6 +27,19 @@ matrix, run the EARS requirement-grammar check:
 quire validate --scope . "spec/**/*.md" --summary
 ```
 
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
+
 Treat these `[ears:…]` findings as **un-mappable requirements to fix first**,
 not coverage you can claim:
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -52,6 +52,19 @@ The seven analyses:
         `low`/`medium`/`high`).
 4.  Validate + record:
     -   Run `quire validate --scope <repo> "spec/**/*.md"` and fix any errors.
+
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
     -   The docs sync into filament-core as `SpecReview` artifacts; do not proceed to
         implementation until reviewed.
 

--- a/skills/spec-to-plan/SKILL.md
+++ b/skills/spec-to-plan/SKILL.md
@@ -67,6 +67,19 @@ This skill produces or updates a **plan bundle** at `<project_root>/plan/<Plan-i
 Validate the bundle with:
 `quire validate --scope <project_root> "plan/**/*.md"`
 
+> **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
+> v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
+> interchanges them: spec documents are read from `<repo>/spec` only, trace tags from
+> the source tree at `<repo>` excluding `spec/`. A repo with no `spec/` exits with a
+> diagnostic naming the missing document root rather than scanning the whole tree, and a
+> matrix outside `spec/` (a fixture, a `plan/` copy) mints nothing. A relative glob
+> resolves under `--scope` only in scoped mode (no `--module`); with `--module` it
+> resolves against the process working directory, and an omitted `--scope` defaults to
+> `.` — so a run launched from a parent directory validates the **wrong tree** and exits
+> 0 for whatever it matched. Check `quire --version` ≥ 0.16.0 before relying on any of
+> this; ≤ 0.15.0 has the pre-split traversal semantics.
+
+
 ## Open in the review cockpit
 
 After the bundle validates, run `filament open <plan-bundle>/plan.md` to open the


### PR DESCRIPTION
Refs #84 (umbrella agent-ix/quire-rs#106, from SR-006).

**The v0.14.0 manifest bump and tag are deliberately not here** — the release is user-gated and I stopped short of it. This PR is the doc corrections only.

## 1. A false claim, verified against the code

`step-6-specreview-artifact.md` said a relative glob matching nothing "exits 0". It does not: the CLI bails **exit 1** with `document glob matched no files` (`quire-cli src/commands/validate.rs:569-571`).

The wrong-tree half of the warning *is* correct and is the trap worth having — a sweep launched from a parent directory validates the wrong tree and exits 0 for whatever it matched. The overstatement is dropped and the real distinction stated.

## 2. Six unwarned invocation sites

The CWD-trap and two-root notes were each added at exactly one site in #83. Backported to the other six: `gap-analysis/SKILL.md`, `spec-correctness/step-6`, `spec-to-plan`, `spec-review`, `spec-matrix`, `spec-ears-analysis`.

## 3. Two states that are not the same state

`spec-correctness/step-7` conflated:

- **a zero denominator** — under the `--json` invocation *the same step prescribes*, the signal is `"totals": {"total": 0}`. `no rows matched` is a **human-format-only** marker that never appears in that JSON, so a reader following the step literally would look for a string that cannot be there.
- **no model at all** — a non-zero exit with its own diagnostic (quire-rs FR-050-AC-9).

Different causes, different fixes. `gap-analysis` step-3 already had this right; its reading is backported.

## 4. The field table omitted the field that changes verdicts

`step-3-matrix-verification.md` listed `unbacked_rows`, `status_lies`, `untracked_symbols`, `groups`, `totals` — and not **`no_symbol_rows`**, the CR-041 exemption for rows whose declared verification method *cannot* mint a source symbol. A reader following only the listed fields reports exempted eval rows as unbacked-row high findings, which asserts something impossible.

Added, with an explicit "read this before triaging `unbacked_rows`", plus `criteria` (CR-028) and the new `diagnostics` field (CR-054, released in quire-rs v0.26.0) whose non-empty state means the numbers below it are measuring less than the reader thinks.

## 5. An unenforced premise

"Since quire-cli v0.16.0" was asserted and never checked. A user on ≤ 0.15.0 silently gets pre-split traversal — the whole repository walked, a matrix outside `spec/` minting. A `quire --version` check is now stated at every site that depends on it.