### PR TITLE
chore: stage 0.14.0 in both plugin manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
Refs #84 (umbrella agent-ix/quire-rs#106, from SR-006).

Both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` declared **0.13.0** while main carried the CR-045 two-root skill docs (#83) and this program's corrections (#86). Since `release-drift.yml` is dispatch-only, installed-plugin consumers were still being served the **pre-CR-045** docs — including the `exit 0` claim that is false against the CLI's code.

Both now declare **0.14.0**.

## The tag is not pushed

Deliberately, at the user's direction. main declares 0.14.0 ahead of its tag; cutting `v0.14.0` from the merge commit is the only remaining step, and nothing reaches installers until it happens.

#84 stays open for that reason.