### PR TITLE
Release v0.15.0 — the ADR-0011 P1 quoin surface

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
Releases the quoin half of the ADR-0011 P1 track (epic agent-ix/quire-rs#81).

| FR | Ticket | What |
|---|---|---|
| **FR-029** | #88 | validate the published quire JSON contract; enforce the version premise |
| **FR-030** | #79 | the evidence store as the artifact of record |
| **FR-031** | #89 | catalog-driven verification-method advisor |
| **FR-032** | #80 | suspect-link / freshness / vacuity auditor |

New verbs: `quoin evidence record | affirm | gc | audit`, and `quoin catalog methods`.

The plugin manifests are staged **before** the tag, because a frozen manifest leaves installers stuck on the first tag's tree.

301 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)