### PR TITLE
Release v0.15.1 — the ADR-0011 P1 quoin surface (CI-clean)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
v0.15.0's release CI failed on six advisor tests reading the ecosystem catalog from a hardcoded `~/dev` path — green locally, empty catalog everywhere else. Fixed in #100; the tag stays (tags are never deleted), and **0.15.1 is the version that actually ships** the ADR-0011 P1 quoin surface.

| FR | Ticket |
|---|---|
| FR-029 | #88 — validate the published quire JSON contract |
| FR-030 | #79 — the evidence store |
| FR-031 | #89 — catalog-driven advisor |
| FR-032 | #80 — the auditor |

301 tests pass, and now they pass anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)