### PR TITLE
Release v0.16.0 — the ADR-0011 P1 review follow-ups (CR-006..CR-010)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
Cuts the five post-merge review follow-ups for the ADR-0011 P1 wave (epic agent-ix/quire-rs#81).

| | |
|---|---|
| #102 | **CR-006** — a binding is keyed on `(obligation, suite)`; every auditor check folds over the group |
| #104 | **CR-007** — the latest run is the newest by `timestamp`, not the highest filename |
| #105 | **CR-008** — conformance compares kind to kind, an uncatalogued method is reported, the ratchet can baseline every kind |
| #106 | **CR-009** — the store and the quire bridge guard their inputs and keep quire's stderr |
| #103 | **CR-010** — the advisor gets a command |

### New verbs

- **`quoin advise`** — the FR-031 advisor, reachable at last. Over quire-rs' 583
  obligations: 536 with a recommendation, 47 inconclusive (was 224 / 359).
- **`quoin evidence baseline`** — writes the ratchet baseline `--ratchet` reads.
  It had no writer before, so `--ratchet` read a file no verb produced.

### Engine

Tested against **quire-cli 0.22.0 / quire-rs v0.30.0**. The published output
schemas are **byte-identical** between v0.29.0 and v0.30.0 (verified by `diff`),
so the vendored copies, their hashes and `minimumCli: 0.21.0` are unchanged — an
0.21.0 binary still emits the contract quoin reads, and raising the floor would
refuse a version that works.

### Verified

`make test` — 30 files, **329** tests. `make lint` clean.