### PR TITLE
Release v0.17.0 — bump the module pins to the P1 releases

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",

--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.9.0"
+    version: "0.12.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.9.0
+      ref: v0.12.0
 
   - name: spec-artifacts-app
     version: "0.5.0"
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.13.0"
+    version: "0.17.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.13.0
+      ref: v0.17.0
 
   - name: spec-objects-business
     version: "0.6.0"


### PR DESCRIPTION
`default-modules.yaml` is the source of truth for what every quoin install gets, and it had drifted behind **the entire ADR-0011 P1 module wave**.

```
spec-artifacts-iso      v0.9.0  -> v0.12.0
spec-artifacts-process  v0.13.0 -> v0.17.0
```

process **v0.14.0 / v0.15.0 / v0.16.0 / v0.17.0** carry CR-062 archetype-only trace binding, the FR-006 evidence archetypes, the FR-007 verification-method catalog, the obligation sources, and CR-005's two catalog entries. iso **v0.10.0..v0.12.0** carry the FR-035 manifest-schema gate.

**None of it reached an install.** `pnpm drift:pins` reported both entries `behind` — and by design it reports rather than fails ("pinning behind latest is sometimes deliberate, and the value is knowing rather than being forced"), so nothing forced the bump.

That is why scoped `quire coverage` answered *"no module in scope declares a `traceability:` model"*: the machinery shipped and the module data that makes it do anything did not.

### Blast radius — deliberate, and not fresh-installs-only

`ensureDefaultModules` runs `reconcile` in **lazy** mode, which skips only when `entry.ref === manifest.ref` (`ts-plugin-kit`'s `ne()`). A changed ref reinstalls, so **existing users pick both modules up on their next catalog read**.

Two behaviour changes ride along, both intended P1 outcomes:
- iso's FR-035 gate means a malformed module manifest that used to load now fails loudly.
- process ≥ v0.14.0 means a module still declaring `document:` on a trace target no longer loads (CR-062).

The engine floor that makes this safe (quire-rs ≥ v0.28.0) is met by the already-published quire-cli **0.20.0**; quire-cli **0.22.0** is published alongside this release so quoin's own `minimumCli: 0.21.0` premise holds for npm installs.

### Verified

```
pnpm drift:pins -> 8 current, 0 behind, 0 unresolved
```

`make test` (30 files, 329 tests) and `make lint` green. Both plugin manifests staged at 0.17.0 so `drift:manifests` passes against the tag.