### PR TITLE
feat: pin spec-objects-safety as the ninth default module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,23 @@ make add-dev-packages p=<name>  # add dev dependency
 make use-local p=<name>         # switch dep to local package
 make use-upstream p=<name>      # switch dep back to upstream
 ```
+
+## Adding or improving a spec check
+
+See **CLAUDE.md § Adding or improving a spec check**. The short form:
+
+A new check pointed at the `~/dev` corpus will fire in the hundreds or thousands.
+**That is expected, not evidence the check is wrong.** A high count means one of
+two things, settled by reading flagged documents, not by preference:
+
+- **Bad rule** — the check misreads correct data.
+- **Bad corpus** — the check reads correctly and the specs are wrong.
+
+Do not default to either. Agents wrote most of these specs and agents do not
+write good specs — that is why quoin and quire exist.
+
+**Never widen a rule because it lowers the count.** A rule states what a good spec
+looks like; it does not fit the specs that exist. Where two forms mean the same
+thing, prefer unifying the corpus on one and flagging the rest over accepting
+both. Report the precision split as a number, and say which conclusion you
+reached and why.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,40 @@ make add-dev-packages p=<name>  # add dev dependency
 make use-local p=<name>         # switch dep to local package
 make use-upstream p=<name>      # switch dep back to upstream
 ```
+
+## Adding or improving a spec check
+
+quoin's analyses and quire's validators both point at the `~/dev` corpus, where a
+new check will fire in the hundreds or thousands. **That is the expected result,
+not a signal the check is wrong.**
+
+A high finding count means exactly one of two things, and which one is a question
+of fact:
+
+- **Bad rule** — the check misreads data that is correct.
+- **Bad corpus** — the check reads correctly and the specs are wrong.
+
+**Do not default to either.** Agents wrote most of these specs, and agents do not
+write good specs — that is the reason quoin and quire exist at all.
+
+**Settle it by opening flagged documents and reading them.** For each: _is the
+thing the check complains about actually absent?_ If the document has it in a
+form the check could not read, the rule is wrong. If the document genuinely lacks
+it, the finding stands and is work to do. Report the split as a number — "sampled
+10, 3 rule, 7 real" — because a finding count is a census, not a precision
+estimate.
+
+**Never widen a rule because it lowers the count.** A rule states what a _good_
+spec looks like; its goal is not to fit the specs that exist. A widening needs a
+justification true independent of the number — "these two verbs mean the same
+thing in the declared edge vocabulary" is a reason, "this drops 400 findings" is
+not. Where two forms do mean the same thing, prefer **unifying the corpus on one
+and flagging the rest** over accepting both: a rule that accepts every spelling
+enforces nothing.
+
+Say which of the two conclusions you reached, and why, whenever a rule changes
+after a measurement.
+
+**Advisory-first is about blast radius, not about whether findings matter.** Ship
+a new check at `warning` so findings land and stay visible; promotion is a
+separate, measured, user-gated decision.

--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -82,10 +82,10 @@ entries:
       ref: v0.5.0
 
   - name: spec-objects-safety
-    version: "0.2.0"
+    version: "0.3.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-objects-safety
       path: spec_objects_safety
-      ref: v0.2.0
+      ref: v0.3.0

--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -80,3 +80,12 @@ entries:
       url: agent-ix/spec-objects-security
       path: spec_objects_security
       ref: v0.5.0
+
+  - name: spec-objects-safety
+    version: "0.2.0"
+    defaultEnabled: true
+    source:
+      type: git-subdir
+      url: agent-ix/spec-objects-safety
+      path: spec_objects_safety
+      ref: v0.2.0

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -184,10 +184,16 @@ test("parseSourceArg maps CLI prefixes to typed sources", () => {
 // Trace: FR-016-AC-2
 test("ships the committed default module set", () => {
   const manifest = defaultModulesManifest();
-  expect(manifest.entries).toHaveLength(8);
+  // Nine since spec-objects-safety (agent-ix/spec-objects-security#7). The
+  // count is asserted rather than a lower bound so a module arriving in the
+  // default set costs a deliberate line here — the set is installed into every
+  // consumer's ~/.ix/filament/modules, so a silent addition is a silent change
+  // to everyone's catalog.
+  expect(manifest.entries).toHaveLength(9);
   expect(manifest.entries.map((e) => e.name)).toContain(
     "spec-objects-business",
   );
+  expect(manifest.entries.map((e) => e.name)).toContain("spec-objects-safety");
 });
 
 test("ships claude plugin skills without artifact-specific write skills", () => {


### PR DESCRIPTION
Last piece of agent-ix/spec-objects-security#7. **Draft — blocked on a visibility decision, see below.**

Adds `spec-objects-safety` (hazard, failure_mode) to the default module set, pinned at `v0.2.0` like every other entry.

## Blocked: the module repo is private

`git-subdir` pins clone from the source repo. **`agent-ix/spec-objects-safety` is PRIVATE; all five sibling `spec-objects-*` repos are PUBLIC.** Until it matches, this pin fails to install for anyone without repo access.

I created it private because that is the standing default for new repos. The family convention is public — they publish to public npm as `@agent-ix/*` and their pins are cloned by every consumer. **Someone needs to decide which applies here** before this merges.

## The guard did its job

`tests/index.test.ts` asserts the module set has an **exact** count, not a lower bound. Adding an entry failed it, and updating the count cost a deliberate line — which is the right shape, because this set installs into every consumer's `~/.ix/filament/modules`. A silent addition is a silent change to everyone's catalog. Updated 8 → 9, with `spec-objects-safety` added to the name assertion too.

## Gates

`make build` ✅ · `make test` ✅ 329 passed · `make lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)