### PR TITLE
chore: bump the Wave B module pins

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.12.0"
+    version: "0.13.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.12.0
+      ref: v0.13.0
 
   - name: spec-artifacts-app
     version: "0.5.0"
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.17.0"
+    version: "0.18.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.17.0
+      ref: v0.18.0
 
   - name: spec-objects-business
     version: "0.6.0"
@@ -73,19 +73,19 @@ entries:
       ref: v0.6.0
 
   - name: spec-objects-security
-    version: "0.5.0"
+    version: "0.7.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-objects-security
       path: spec_objects_security
-      ref: v0.5.0
+      ref: v0.7.0
 
   - name: spec-objects-safety
-    version: "0.3.0"
+    version: "0.4.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-objects-safety
       path: spec_objects_safety
-      ref: v0.3.0
+      ref: v0.4.0


### PR DESCRIPTION
Four pins, one chain.

| Module | From | To | Carries |
|---|---|---|---|
| `spec-artifacts-iso` | 0.12.0 | **0.13.0** | FR-001 CR-005 — `required_relations` + `acyclic_edges` in the FR-035 schema |
| `spec-artifacts-process` | 0.17.0 | **0.18.0** | FR-008 escape cause; FR-007 CR-007 hazard → fault-injection signal |
| `spec-objects-security` | 0.5.0 | **0.7.0** | FR-035 gate; threat/risk coverage declarations |
| `spec-objects-safety` | 0.3.0 | **0.4.0** | hazard / failure-mode coverage declarations |

Without them the default module set still rejects the `required_relations` key that quire-rs **v0.31.0** executes, so the upward-trace checks are declared nowhere a default install can see — the engine ships the capability and nothing uses it.

`make build` ✅ · `make test` ✅ 329 passed / 30 files · `make lint` ✅

**Not in this PR:** `CONTRACT.sourceTag` is still `v0.29.0`. That records which quire-rs tag the *vendored schemas* were copied from and is hash-checked against them, so refreshing it means re-vendoring rather than editing a string. Handled separately.