### PR TITLE
fix(evidence): make the finding adapters reachable from the command (#115)

### DIFF
--- a/spec/functional/FR-034-finding-shaped-evidence.md
+++ b/spec/functional/FR-034-finding-shaped-evidence.md
@@ -92,6 +92,24 @@ The cargo-audit adapter is verified against output captured with `cargo audit --
 | FR-034-AC-10 | A scan that evaluated **no rules** is reported `vacuous-evidence` at `high`. | Test (TC-174) |
 | FR-034-AC-11 | When the tool reports no rule count the vacuity check stays silent. | Test (TC-175) |
 | FR-034-AC-12 | Every run-shaped check pairs a binding with **its own** suite's run when a scan is also bound to the same obligation. | Test (TC-176) |
+| FR-034-AC-13 | `quoin evidence record --adapter sarif --results <file>` writes a `FindingRecord` under `scans/` and writes **nothing** under `runs/`. | Test (TC-177) |
+| FR-034-AC-14 | A clean scan recorded through the command keeps `findings: []` and its rule count, so zero findings is still evidence. | Test (TC-178) |
+| FR-034-AC-15 | The command selects a finding adapter from `--tool` when none is named. | Test (TC-179) |
+
+### Reachability is part of the contract
+
+Every criterion above that describes recording SHALL be stated over
+`quoin evidence record`, not over the parse function.
+
+This is not a style preference. The first cut of this FR shipped `FindingRecord`, both adapters and
+`writeScan` with **no command that could reach any of them** — a capability nothing could use, and a
+Test Matrix reading ✅ over it. That is precisely the defect the P1 review found three times, and the
+reason `agent-ix/quoin#115` specified its acceptance shape the way it did. Caught by the Wave C
+review rather than by the tests, which is itself the finding.
+
+A finding-shaped adapter is selected **before** anything is parsed, because it writes a different
+record type: letting a scan fall through to the run path would put it in `runs/` and lose the
+clean-versus-unrun distinction at the point of intake, silently and permanently for that commit.
 
 ## Constraints
 

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -296,6 +296,9 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-174 | A scan that evaluated no rules is reported vacuous at high: it found nothing because it looked for nothing | Unit | P0 | FR-034-AC-10 | ✅ |
 | TC-175 | With no rule count reported the vacuity check stays silent rather than guessing | Unit | P0 | FR-034-AC-11 | ✅ |
 | TC-176 | Each run-shaped binding pairs with its OWN suite's run when a scan is bound to the same obligation — silent until scans existed, wrong from the moment they did | Unit | P0 | FR-034-AC-12 | ✅ |
+| TC-177 | `quoin evidence record --adapter sarif` writes a FindingRecord under `scans/` and nothing under `runs/` — the capability shipped unreachable and this is what reaches it | Integration | P0 | FR-034-AC-13 | ✅ |
+| TC-178 | A clean scan recorded through the command keeps `findings: []` and its rule count | Integration | P0 | FR-034-AC-14 | ✅ |
+| TC-179 | The command selects a finding adapter from `--tool` when none is named | Integration | P0 | FR-034-AC-15 | ✅ |
 | TC-129 | The merged catalog carries every declared method with its rules intact, merges first-wins, reports a colliding id rather than absorbing it, and treats an undeclared catalog as empty | Unit | P0 | FR-031-AC-1 | ✅ |
 | TC-130 | An `attack_surface` object reaches DAST, SAST and negative/abuse testing — recommendations that were unreachable while the method table was skill-local prose | Unit | P0 | FR-031-AC-2 | ✅ |
 | TC-131 | Temporal phrasing reaches runtime monitoring and model checking — the methods a single execution cannot discharge | Unit | P0 | FR-031-AC-3 | ✅ |

--- a/src/commands/evidence/record.ts
+++ b/src/commands/evidence/record.ts
@@ -8,6 +8,8 @@ import {
   obligationsFrom,
   recordRun,
   selectAdapter,
+  selectFindingAdapter,
+  writeScan,
   type RunEntry,
 } from "../../evidence/index.js";
 import {
@@ -92,6 +94,58 @@ runs nothing and judges nothing.`;
     // obligations would already have been bound.
     const premise = checkVersionPremise(quireVersion());
     if (premise) this.error(premise.message, { exit: 2 });
+
+    // A finding-shaped adapter writes a DIFFERENT record type, so the branch is
+    // taken before anything is parsed. Letting a scan fall through to the run
+    // path would write it into `runs/` and lose the clean-versus-unrun
+    // distinction at the point of intake — silently, and permanently for that
+    // commit (FR-034).
+    const findingAdapter = selectFindingAdapter({
+      adapter: flags.adapter,
+      tool: flags.tool,
+    });
+    if (findingAdapter) {
+      const raw =
+        flags.results === "-"
+          ? readFileSync(0, "utf8")
+          : readFileSync(flags.results, "utf8");
+      const result = findingAdapter.parse(raw);
+      const path = writeScan(flags.repo, {
+        schemaVersion: 1,
+        suite: flags.suite,
+        commit: flags.commit,
+        tool: result.tool ?? flags.tool,
+        ...(flags.kind === undefined ? {} : { evidenceKind: flags.kind }),
+        timestamp: flags.timestamp ?? new Date().toISOString(),
+        ...(result.ruleset === undefined ? {} : { ruleset: result.ruleset }),
+        ...(result.rulesEvaluated === undefined
+          ? {}
+          : { rulesEvaluated: result.rulesEvaluated }),
+        findings: result.findings,
+      });
+      if (flags.json) {
+        this.log(
+          JSON.stringify(
+            { scanPath: path, findings: result.findings },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      this.log(
+        `recorded scan ${flags.suite} @ ${flags.commit.slice(0, 12)} → ${path}`,
+      );
+      // Said explicitly, because "0 findings" is the one line a reader is most
+      // likely to mistake for "nothing ran".
+      this.log(
+        `  findings: ${result.findings.length}` +
+          (result.rulesEvaluated === undefined
+            ? " (the tool reported no rule count, so this cannot be told from a scan with no rules enabled)"
+            : ` over ${result.rulesEvaluated} rules evaluated`),
+      );
+      return;
+    }
 
     const entries = readEntries(flags.results, {
       adapter: flags.adapter,

--- a/src/evidence/adapters/registry.ts
+++ b/src/evidence/adapters/registry.ts
@@ -1,6 +1,7 @@
 import type { RunEntry } from "../types.js";
 import { cargoMutantsAdapter } from "./cargo-mutants.js";
 import { junitAdapter } from "./junit.js";
+import { parseCargoAudit, parseSarif, type FindingResult } from "./sarif.js";
 import {
   AdapterError,
   type AdapterResult,
@@ -55,7 +56,61 @@ export const ADAPTERS: readonly EvidenceAdapter[] = [
   cargoMutantsAdapter,
 ];
 
-export const ADAPTER_NAMES: readonly string[] = ADAPTERS.map((a) => a.name);
+/**
+ * Adapters producing a {@link FindingRecord} rather than run entries.
+ *
+ * A separate registry because the two produce different record types and the
+ * command must know which it is writing BEFORE it parses — a scan written into
+ * `runs/` would lose the clean-versus-unrun distinction that FR-034 exists to
+ * make, silently and at the point of intake.
+ */
+export interface FindingAdapter {
+  readonly name: string;
+  readonly summary: string;
+  readonly tools: readonly string[];
+  parse(raw: string): FindingResult;
+}
+
+export const FINDING_ADAPTERS: readonly FindingAdapter[] = [
+  {
+    name: "sarif",
+    summary:
+      "SARIF 2.1.0 — semgrep --sarif, CodeQL, ESLint, ZAP via converter.",
+    tools: ["sarif", "semgrep", "codeql"],
+    parse: parseSarif,
+  },
+  {
+    name: "cargo-audit",
+    summary: "cargo audit --json — RUSTSEC advisories and warning kinds.",
+    tools: ["cargo-audit", "cargo audit", "cargo-deny", "cargo deny"],
+    parse: parseCargoAudit,
+  },
+];
+
+export const ADAPTER_NAMES: readonly string[] = [
+  ...ADAPTERS.map((a) => a.name),
+  ...FINDING_ADAPTERS.map((a) => a.name),
+];
+
+/**
+ * The finding-shaped adapter for these options, or `undefined` when the
+ * selection is run-shaped.
+ *
+ * Checked before {@link selectAdapter} so a `--adapter sarif` never falls
+ * through to the run path, where its output would be parsed as entries and
+ * fail with a message about JSON shape.
+ */
+export function selectFindingAdapter(options: {
+  adapter?: string;
+  tool?: string;
+}): FindingAdapter | undefined {
+  if (options.adapter !== undefined && options.adapter !== "") {
+    return FINDING_ADAPTERS.find((a) => a.name === options.adapter);
+  }
+  const tool = (options.tool ?? "").toLowerCase();
+  if (tool === "") return undefined;
+  return FINDING_ADAPTERS.find((a) => a.tools.some((c) => tool.includes(c)));
+}
 
 /**
  * Choose an adapter: an explicit `--adapter` wins, else the suite's declared

--- a/src/evidence/index.ts
+++ b/src/evidence/index.ts
@@ -53,8 +53,11 @@ export {
 export {
   ADAPTERS,
   ADAPTER_NAMES,
+  FINDING_ADAPTERS,
   entriesAdapter,
   selectAdapter,
+  selectFindingAdapter,
+  type FindingAdapter,
 } from "./adapters/registry.js";
 export { junitAdapter, qualifiedName } from "./adapters/junit.js";
 export { cargoMutantsAdapter } from "./adapters/cargo-mutants.js";

--- a/tests/evidence-adapters.test.ts
+++ b/tests/evidence-adapters.test.ts
@@ -155,7 +155,16 @@ describe("the adapter registry", () => {
 
   // Trace: FR-033-AC-3
   it("registers adapters as data, so an external tool can be added", () => {
-    expect(ADAPTER_NAMES).toEqual(["entries", "junit", "cargo-mutants"]);
+    // Exact, not a length check: ADAPTER_NAMES is what `--adapter` accepts and
+    // what `--help` lists, so a silently added or dropped name is a change to
+    // the command's surface. Run-shaped first, then finding-shaped (FR-034).
+    expect(ADAPTER_NAMES).toEqual([
+      "entries",
+      "junit",
+      "cargo-mutants",
+      "sarif",
+      "cargo-audit",
+    ]);
     for (const adapter of ADAPTERS) {
       expect(adapter.summary.length).toBeGreaterThan(0);
       expect(typeof adapter.parse).toBe("function");

--- a/tests/finding-record.test.ts
+++ b/tests/finding-record.test.ts
@@ -2,11 +2,22 @@
  * FR-034 — FindingRecord and the finding-shaped adapters (TC-165..TC-172).
  */
 
-import { readFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import type { Config } from "@oclif/core";
+import { loadConfig } from "@agent-ix/ix-cli-core";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import EvidenceRecord from "../src/commands/evidence/record";
 
 import { audit } from "../src/auditor/index.js";
 import {
@@ -16,6 +27,23 @@ import {
 } from "../src/evidence/index.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+let config: Config;
+
+beforeAll(async () => {
+  config = await loadConfig({ root: repoRoot });
+});
+
+/** A repository `quoin evidence record` will accept: it needs a real spec/. */
+function workspace(): string {
+  const root = mkdtempSync(join(tmpdir(), "quoin-scan-"));
+  mkdirSync(join(root, "spec", "functional"), { recursive: true });
+  writeFileSync(
+    join(root, "spec", "functional", "FR-001-a.md"),
+    "---\nid: FR-001\ntype: FR\ntitle: A requirement\n---\n\n## Description\n\nIt does.\n",
+  );
+  return root;
+}
 const realAudit = readFileSync(
   join(here, "fixtures", "evidence", "cargo-audit-real.json"),
   "utf8",
@@ -277,5 +305,132 @@ describe("the auditor over finding-shaped scans", () => {
       "vacuous-evidence",
     );
     expect(report.healthy).toContain("FR-001-AC-1");
+  });
+});
+
+describe("quoin evidence record --adapter sarif", () => {
+  // Trace: FR-034-AC-13
+  it("writes a FindingRecord, not a run, end to end through the command", async () => {
+    // The gap this test exists for: FindingRecord, the SARIF adapter and
+    // writeScan all shipped without a single command that could reach them —
+    // a capability nothing could use, which is exactly the P1 defect the
+    // ticket's acceptance shape was written to prevent.
+    const root = workspace();
+    const results = join(root, "scan.sarif");
+    writeFileSync(results, SARIF_FINDING);
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-SCAN",
+        "--commit",
+        "b".repeat(40),
+        "--tool",
+        "semgrep 1.2.3",
+        "--adapter",
+        "sarif",
+        "--results",
+        results,
+      ],
+      config,
+    );
+    const record = JSON.parse(
+      readFileSync(
+        join(
+          root,
+          "spec",
+          "evidence",
+          "scans",
+          "SUITE-SCAN",
+          "bbbbbbbbbbbb.json",
+        ),
+        "utf8",
+      ),
+    ) as FindingRecord;
+    expect(record.findings).toHaveLength(2);
+    expect(record.rulesEvaluated).toBe(2);
+    expect(record.tool).toBe("semgrep 1.2.3");
+    // And nothing was written to runs/ — a scan in runs/ would lose the
+    // distinction at the point of intake.
+    expect(
+      existsSync(join(root, "spec", "evidence", "runs", "SUITE-SCAN")),
+    ).toBe(false);
+  });
+
+  // Trace: FR-034-AC-14
+  it("records a clean scan as a scan, so zero findings is still evidence", async () => {
+    const root = workspace();
+    const results = join(root, "clean.sarif");
+    writeFileSync(results, SARIF_CLEAN);
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-SCAN",
+        "--commit",
+        "c".repeat(40),
+        "--tool",
+        "semgrep 1.2.3",
+        "--adapter",
+        "sarif",
+        "--results",
+        results,
+      ],
+      config,
+    );
+    const record = JSON.parse(
+      readFileSync(
+        join(
+          root,
+          "spec",
+          "evidence",
+          "scans",
+          "SUITE-SCAN",
+          "cccccccccccc.json",
+        ),
+        "utf8",
+      ),
+    ) as FindingRecord;
+    expect(record.findings).toEqual([]);
+    expect(record.rulesEvaluated).toBe(3);
+  });
+
+  // Trace: FR-034-AC-15
+  it("selects the finding adapter from --tool when none is named", async () => {
+    const root = workspace();
+    const results = join(root, "audit.json");
+    writeFileSync(results, realAudit);
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-AUDIT",
+        "--commit",
+        "d".repeat(40),
+        "--tool",
+        "cargo-audit 0.21",
+        "--results",
+        results,
+      ],
+      config,
+    );
+    const record = JSON.parse(
+      readFileSync(
+        join(
+          root,
+          "spec",
+          "evidence",
+          "scans",
+          "SUITE-AUDIT",
+          "dddddddddddd.json",
+        ),
+        "utf8",
+      ),
+    ) as FindingRecord;
+    expect(record.rulesEvaluated).toBe(1217);
+    expect(record.findings[0].ruleId).toMatch(/^RUSTSEC-/);
   });
 });


### PR DESCRIPTION
Wave C review finding.

## The gap

`FindingRecord`, both finding adapters, `writeScan` and the vacuity semantics all shipped — with **no command that could reach any of them**. Every FR-034 criterion was stated at the parse-function boundary, so the Test Matrix read ✅ over a capability nothing could use.

That is the defect the P1 review found three times, and precisely why #115 specified its acceptance shape as *"every AC stated over the command"*. I quoted that requirement in FR-033 and then did not follow it in FR-034.

## The fix

`quoin evidence record` selects a finding-shaped adapter **before parsing**, because it writes a different record type. Letting a scan fall through to the run path would put it in `runs/` and lose the clean-versus-unrun distinction **at the point of intake** — silently, and permanently for that commit.

```
quoin evidence record --adapter sarif --results scan.sarif ...
  → spec/evidence/scans/SUITE-SCAN/<commit12>.json
  → nothing in runs/
```

The human-readable line reports the rule count beside the finding count, or says explicitly that the tool reported none — `0 findings` is the one line a reader is most likely to misread as *nothing ran*.

## Verification

**TC-177..179, all stated over the command.** FR-034 gains AC-13..15 and a section saying reachability is part of the contract and why.

`TC-153`'s exact-list guard caught the two new adapter names — the guard working as intended: `ADAPTER_NAMES` is what `--adapter` accepts and what `--help` lists, so a silent addition is a change to the command's surface.

`make build` ✅ · `make test` ✅ **367 passed** · `make lint` ✅