### PR TITLE
fix(evidence): make a scan reachable from every side of the store (SR-005)

### DIFF
--- a/reviews/26-08-18-waves-cd-code-review.md
+++ b/reviews/26-08-18-waves-cd-code-review.md
@@ -1,0 +1,95 @@
+---
+id: SR-005
+title: "Code review — ADR-0011 Phase 2 Waves C and D (FR-033, FR-034, FR-035)"
+type: SpecReview
+analysis: code-review
+scope: "src/evidence/adapters/, src/evidence/types.ts, src/evidence/store.ts, src/auditor/audit.ts, src/auditor/combinatorial.ts, src/advisor/advise.ts, src/commands/evidence/"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/FR-034"
+    type: "reviews"
+---
+
+## Summary
+
+Reviewed the Waves C and D changes as one diff — FR-033 (evidence adapters), FR-034 (finding-shaped
+evidence) and FR-035 (t-way coverage). **FR-034 is inert end to end**: a `FindingRecord` is written
+and nothing else in the system can see it. Five findings, four of them high. Four share one root cause; the fifth was found by writing the test for the first.
+
+This review exists because it was skipped. Waves A and B produced `SR-045`–`SR-048` in `quire-rs`;
+Waves C and D produced nothing here, and an unstructured pass replaced the gate. That pass caught the
+_write_ side of this same defect (PR #121) and never checked the read side.
+
+## Verdict
+
+**FAIL** — four `high` findings. The feature ships, is tested, and cannot do its job.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                          | Refs                                |
+| ------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| FND-001 | high     | The scan path writes a record and binds no obligation, so a scan discharges nothing                              | src/commands/evidence/record.ts:104 |
+| FND-002 | high     | `quoin evidence audit` never passes `scans`, so no `FindingRecord` reaches the auditor                           | src/commands/evidence/audit.ts:83   |
+| FND-003 | high     | `listRecordedSuites` reads only `runs/`, so a scan-only suite is never enumerated                                | src/evidence/store.ts:265           |
+| FND-004 | medium   | `gc` walks only `RUNS_DIR`, so scan records are never collected and the store grows unbounded                    | src/evidence/store.ts:404           |
+| FND-005 | high     | The SARIF adapter omits `rulesEvaluated` when it is 0, conflating "reported zero rules" with "reported no count" | src/evidence/adapters/sarif.ts:74   |
+
+## Detail
+
+### One root cause, four symptoms
+
+FR-034 added a second record type and wired it into `audit()`'s _pure function_. Everything the tests
+exercise is the function. **Nothing that reads the store was taught the new directory exists.**
+
+| Path      | Run-shaped                         | Finding-shaped                          |
+| --------- | ---------------------------------- | --------------------------------------- |
+| write     | `recordRun` → writes **and binds** | `writeScan` → writes, **binds nothing** |
+| enumerate | `listRecordedSuites` → `runs/`     | —                                       |
+| audit     | `latestRuns()` → `audit({runs})`   | —                                       |
+| collect   | `gc` → `RUNS_DIR`                  | —                                       |
+
+A scan is therefore recorded, bound to no obligation, invisible to the auditor, and never collected.
+`vacuous-evidence` for a rule-less scan — the check FR-034 exists to make possible — cannot fire in
+any real run.
+
+### Why the tests did not catch it
+
+Every FR-034 criterion is stated over `audit(...)` with a hand-built `scans:` array, or over
+`parseSarif`. `TC-177`–`TC-179` do reach the command, but only the **write** half: they assert a
+file appears in `scans/`, which it does.
+
+**No criterion asserts that anything ever reads it.** A capability is reachable when a user's
+invocation reaches it, not when a test constructs the input the capability expects — and that
+distinction is exactly what `agent-ix/quoin#115` was written to force.
+
+### The pattern is now three-for-three
+
+Wave C's PR #121 fixed this same class on the write path. The P1 review found it three times. It has
+now appeared once per wave in this program, and every occurrence has been _a Test Matrix reading ✅
+over something no invocation can reach_.
+
+The mechanical tell is available and cheap: **for each new capability, grep `src/commands/` for the
+symbol.** If no command names it, the capability is unreachable regardless of how many tests pass.
+
+### FND-005 — found by writing the test, not by reading the code
+
+The vacuity fix could not be tested until a scan could _be_ vacuous, and it could not: the SARIF
+adapter initialised its counter to `0` and then omitted the field when it was still `0`. A scan
+declaring `"rules": []` — a tool explicitly stating it evaluated none — was indistinguishable from a
+tool that reported no count at all.
+
+That erases the exact distinction FR-034 turns on. `scanIsVacuous` returns `null` for an absent count
+and stays silent, so **the vacuity check was silent on the one input it exists to catch**.
+
+Worth recording how it surfaced: in the adapter, the omission reads as ordinary tidiness. It became
+visible only when a test asserted the behaviour end to end and the binding it forbade happened anyway.
+
+## Coverage
+
+`make build` ✅ · `make test` ✅ 384 passed (379 at review time, +5 for the fixes) · `make lint` ✅ — none of which can see this class of
+defect, which is the point of the finding.
+
+The Python-shaped sections of the review skill (Test Standards, Mock Compliance, both Completeness
+sections) were **not** run: this change is TypeScript, and transliterating them produces false
+findings that bury real ones. The `rust-review` sub-skill the dispatch table names is also absent
+from the installed skill — recorded so the gap is visible rather than silently skipped.

--- a/src/commands/evidence/audit.ts
+++ b/src/commands/evidence/audit.ts
@@ -7,11 +7,12 @@ import { loadMethodCatalog } from "../../advisor/index.js";
 import { audit, ratchet } from "../../auditor/index.js";
 import {
   latestRun,
+  latestScan,
   listRecordedSuites,
   readBaseline,
   readBindings,
 } from "../../evidence/index.js";
-import type { RunRecord } from "../../evidence/index.js";
+import type { FindingRecord, RunRecord } from "../../evidence/index.js";
 import {
   checkVersionPremise,
   parseCoverage,
@@ -81,6 +82,7 @@ a week. Write that baseline with: quoin evidence baseline`;
       obligations: parsed.value.obligations ?? [],
       bindings: readBindings(flags.repo).bindings,
       runs: latestRuns(flags.repo),
+      scans: latestScans(flags.repo),
       // The SAME module the coverage call above used. Defaulting to the
       // installed roots meant `--module <dir>` derived obligations from one
       // catalog and checked conformance against another — the exact disagreement
@@ -142,6 +144,19 @@ a week. Write that baseline with: quoin evidence baseline`;
  * HEAD could still be reported stale, and re-recording could not fix it
  * (agent-ix/quoin#104).
  */
+/**
+ * The newest scan of every recorded suite.
+ *
+ * Mirrors `latestRuns`. Its absence was why no `FindingRecord` ever reached
+ * the auditor: the record type, the vacuity check and the tests all existed
+ * while `audit()` was called with no `scans` at all (SR-005 FND-002).
+ */
+function latestScans(repo: string): FindingRecord[] {
+  return listRecordedSuites(repo)
+    .map((suite) => latestScan(repo, suite))
+    .filter((s): s is FindingRecord => s !== null);
+}
+
 function latestRuns(repo: string): RunRecord[] {
   return listRecordedSuites(repo)
     .map((suite) => latestRun(repo, suite))

--- a/src/commands/evidence/record.ts
+++ b/src/commands/evidence/record.ts
@@ -5,7 +5,10 @@ import { Flags } from "@oclif/core";
 import { QuoinCommand } from "../../base.js";
 import {
   ADAPTER_NAMES,
+  bind,
   obligationsFrom,
+  readBindings,
+  writeBindings,
   recordRun,
   selectAdapter,
   selectFindingAdapter,
@@ -61,6 +64,15 @@ runs nothing and judges nothing.`;
         "registry's `Evidence Kind` column use. Method conformance compares " +
         "kind to kind; without it the check stays silent rather than guessing.",
     }),
+    discharges: Flags.string({
+      description:
+        "Obligation ids this scan discharges, comma-separated. Finding-shaped " +
+        "only. A CLEAN scan is the strongest evidence a scanner produces and " +
+        "carries no finding to bind from, so the obligations it was run to " +
+        "check are stated rather than inferred. A scan that evaluated no rules " +
+        "binds nothing regardless.",
+      multiple: false,
+    }),
     adapter: Flags.string({
       description:
         `Format reader for --results (${ADAPTER_NAMES.join(", ")}). ` +
@@ -95,6 +107,20 @@ runs nothing and judges nothing.`;
     const premise = checkVersionPremise(quireVersion());
     if (premise) this.error(premise.message, { exit: 2 });
 
+    // Obligations first, for BOTH paths. A scan discharges obligations too,
+    // so deriving them only on the run path is what left the scan branch with
+    // nothing to bind against (SR-005 FND-001).
+    const coverageArgs = ["coverage", "--scope", flags.repo, "--json"];
+    if (flags.module) coverageArgs.push("--module", flags.module);
+    const raw = runQuire(coverageArgs);
+    const parsed = parseCoverage(raw);
+    if (!parsed.ok) {
+      this.error(
+        `${parsed.error.message}\n${parsed.error.errors.slice(0, 10).join("\n")}`,
+        { exit: 2 },
+      );
+    }
+
     // A finding-shaped adapter writes a DIFFERENT record type, so the branch is
     // taken before anything is parsed. Letting a scan fall through to the run
     // path would write it into `runs/` and lose the clean-versus-unrun
@@ -123,10 +149,46 @@ runs nothing and judges nothing.`;
           : { rulesEvaluated: result.rulesEvaluated }),
         findings: result.findings,
       });
+      // A scan discharges what it was run to check — but only if it looked.
+      // A rule-less scan reports zero findings and proves nothing, so binding
+      // on it would put the store's strongest claim behind its weakest
+      // evidence (FR-034 vacuity).
+      const vacuous = result.rulesEvaluated === 0;
+      const ids = (flags.discharges ?? "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => id !== "");
+      const bound: string[] = [];
+      const unknown: string[] = [];
+      if (ids.length > 0 && !vacuous) {
+        const byId = new Map(
+          obligationsFrom(parsed.value).map((o) => [o.id, o]),
+        );
+        let bindings = readBindings(flags.repo).bindings;
+        for (const id of [...ids].sort()) {
+          const obligation = byId.get(id);
+          if (!obligation) {
+            unknown.push(id);
+            continue;
+          }
+          const outcome = bind(bindings, {
+            obligation: id,
+            statementHashAtBinding: obligation.statement_hash,
+            suite: flags.suite,
+            commit: flags.commit,
+            // A scan binds no symbol: it has none. The record is the evidence.
+            symbols: [],
+          });
+          bindings = outcome.bindings;
+          if (outcome.created) bound.push(id);
+        }
+        writeBindings(flags.repo, { bindings });
+      }
+
       if (flags.json) {
         this.log(
           JSON.stringify(
-            { scanPath: path, findings: result.findings },
+            { scanPath: path, findings: result.findings, bound, unknown },
             null,
             2,
           ),
@@ -136,6 +198,20 @@ runs nothing and judges nothing.`;
       this.log(
         `recorded scan ${flags.suite} @ ${flags.commit.slice(0, 12)} → ${path}`,
       );
+      this.log(`  bound: ${bound.length}`);
+      if (unknown.length > 0) {
+        // Named, not counted: an id nothing states is a typo or a reworded
+        // obligation, and both need the id to act on.
+        this.log(
+          `  discharges no such obligation: ${unknown.sort().join(", ")}`,
+        );
+      }
+      if (vacuous && ids.length > 0) {
+        this.log(
+          "  bound nothing: the scan evaluated no rules, so it found nothing " +
+            "because it looked for nothing",
+        );
+      }
       // Said explicitly, because "0 findings" is the one line a reader is most
       // likely to mistake for "nothing ran".
       this.log(
@@ -151,17 +227,6 @@ runs nothing and judges nothing.`;
       adapter: flags.adapter,
       tool: flags.tool,
     });
-
-    const coverageArgs = ["coverage", "--scope", flags.repo, "--json"];
-    if (flags.module) coverageArgs.push("--module", flags.module);
-    const raw = runQuire(coverageArgs);
-    const parsed = parseCoverage(raw);
-    if (!parsed.ok) {
-      this.error(
-        `${parsed.error.message}\n${parsed.error.errors.slice(0, 10).join("\n")}`,
-        { exit: 2 },
-      );
-    }
 
     const outcome = recordRun({
       repo: flags.repo,

--- a/src/evidence/adapters/sarif.ts
+++ b/src/evidence/adapters/sarif.ts
@@ -70,7 +70,13 @@ export function parseSarif(raw: string): FindingResult {
 
   const findings: Finding[] = [];
   const tools: string[] = [];
-  let rulesEvaluated = 0;
+  // `undefined` until some driver declares a `rules` array. The distinction
+  // between "the tool reported ZERO rules" and "the tool reported NO count" is
+  // the one FR-034 turns on: the first is a vacuous scan, the second is a
+  // question that cannot be asked. Defaulting to 0 and omitting it when 0
+  // erased exactly that difference, so a scan declaring `rules: []` read as a
+  // tool that had said nothing.
+  let rulesEvaluated: number | undefined;
   for (const run of parsed.runs) {
     const driver = run.tool?.driver;
     if (driver?.name !== undefined && driver.name !== "") {
@@ -80,7 +86,9 @@ export function parseSarif(raw: string): FindingResult {
           : `${driver.name} ${driver.version}`,
       );
     }
-    if (Array.isArray(driver?.rules)) rulesEvaluated += driver.rules.length;
+    if (Array.isArray(driver?.rules)) {
+      rulesEvaluated = (rulesEvaluated ?? 0) + driver.rules.length;
+    }
     for (const result of run.results ?? []) {
       const ruleId = result.ruleId ?? result.rule?.id;
       if (ruleId === undefined || ruleId === "") continue;
@@ -103,7 +111,7 @@ export function parseSarif(raw: string): FindingResult {
   return {
     findings,
     ...(tools.length === 0 ? {} : { tool: tools.join(", ") }),
-    ...(rulesEvaluated === 0 ? {} : { rulesEvaluated }),
+    ...(rulesEvaluated === undefined ? {} : { rulesEvaluated }),
   };
 }
 

--- a/src/evidence/store.ts
+++ b/src/evidence/store.ts
@@ -326,12 +326,19 @@ function compare(a: string, b: string): number {
 
 /** Every suite that has at least one recorded run. */
 export function listRecordedSuites(repo: string): string[] {
-  const dir = join(storeRoot(repo), RUNS_DIR);
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir, { withFileTypes: true })
-    .filter((e) => e.isDirectory())
-    .map((e) => e.name)
-    .sort();
+  // BOTH directories. A suite that recorded only scans has evidence, and
+  // reading `runs/` alone made it invisible to every caller that enumerates —
+  // the auditor included, so its obligations read as undischarged while the
+  // evidence sat on disk (SR-005 FND-003).
+  const suites = new Set<string>();
+  for (const which of [RUNS_DIR, SCANS_DIR]) {
+    const dir = join(storeRoot(repo), which);
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) suites.add(entry.name);
+    }
+  }
+  return [...suites].sort();
 }
 
 /** The binding graph. An absent file reads as an empty graph, not an error. */
@@ -402,6 +409,22 @@ export function gc(repo: string, dryRun = false): string[] {
     for (const run of runs) {
       if (keep.has(run) || referenced.has(`${suite}/${run}`)) continue;
       const path = join(storeRoot(repo), RUNS_DIR, suite, run);
+      deleted.push(path);
+      if (!dryRun) rmSync(path);
+    }
+
+    // Scans, on the same rule. Walking only `runs/` left every scan record on
+    // disk forever, so a store with scan suites grew without bound while `gc`
+    // reported it had collected everything (SR-005 FND-004).
+    const scans = listScans(repo, suite);
+    const keepScan = new Set<string>();
+    const latestScanRecord = latestScan(repo, suite);
+    if (latestScanRecord) {
+      keepScan.add(`${short(latestScanRecord.commit)}.json`);
+    }
+    for (const scan of scans) {
+      if (keepScan.has(scan) || referenced.has(`${suite}/${scan}`)) continue;
+      const path = join(storeRoot(repo), SCANS_DIR, suite, scan);
       deleted.push(path);
       if (!dryRun) rmSync(path);
     }

--- a/tests/finding-record.test.ts
+++ b/tests/finding-record.test.ts
@@ -21,6 +21,9 @@ import EvidenceRecord from "../src/commands/evidence/record";
 
 import { audit } from "../src/auditor/index.js";
 import {
+  gc,
+  latestScan,
+  listRecordedSuites,
   parseCargoAudit,
   parseSarif,
   type FindingRecord,
@@ -40,7 +43,12 @@ function workspace(): string {
   mkdirSync(join(root, "spec", "functional"), { recursive: true });
   writeFileSync(
     join(root, "spec", "functional", "FR-001-a.md"),
-    "---\nid: FR-001\ntype: FR\ntitle: A requirement\n---\n\n## Description\n\nIt does.\n",
+    "---\nid: FR-001\ntype: FR\ntitle: A requirement\n---\n\n" +
+      "## Description\n\nThe system shall do it.\n\n" +
+      "## Acceptance Criteria\n\n" +
+      "| ID | Criteria | Verification |\n" +
+      "|----|----------|--------------|\n" +
+      "| FR-001-AC-1 | It does the thing. | Test (TC-001) |\n",
   );
   return root;
 }
@@ -433,4 +441,156 @@ describe("quoin evidence record --adapter sarif", () => {
     expect(record.rulesEvaluated).toBe(1217);
     expect(record.findings[0].ruleId).toMatch(/^RUSTSEC-/);
   });
+});
+
+describe("a scan is reachable from every side of the store", () => {
+  // These exist because SR-005 found FR-034 inert end to end: the record was
+  // written and nothing else in the system could see it. Each criterion here
+  // is a path that had no test at all.
+
+  async function recordScan(root: string, args: string[] = []): Promise<void> {
+    const results = join(root, "scan.sarif");
+    writeFileSync(results, SARIF_CLEAN);
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-SCAN",
+        "--commit",
+        "e".repeat(40),
+        "--tool",
+        "semgrep 1.2.3",
+        "--adapter",
+        "sarif",
+        "--results",
+        results,
+        ...args,
+      ],
+      config,
+    );
+  }
+
+  // Trace: FR-034-AC-16
+  it("binds the obligations it was run to check", async () => {
+    // A CLEAN scan is the strongest evidence a scanner produces and carries no
+    // finding to bind from, so the obligations are stated rather than inferred.
+    const root = workspace();
+    await recordScan(root, ["--discharges", "FR-001-AC-1"]);
+    const bindings = JSON.parse(
+      readFileSync(join(root, "spec", "evidence", "bindings.json"), "utf8"),
+    ) as { bindings: Array<{ obligation: string; suite: string }> };
+    expect(bindings.bindings).toContainEqual(
+      expect.objectContaining({
+        obligation: "FR-001-AC-1",
+        suite: "SUITE-SCAN",
+      }),
+    );
+  });
+
+  // Trace: FR-034-AC-17
+  it("binds nothing when the scan evaluated no rules", async () => {
+    // Binding on a rule-less scan would put the store's strongest claim behind
+    // its weakest evidence.
+    const root = workspace();
+    const results = join(root, "empty.sarif");
+    writeFileSync(
+      results,
+      JSON.stringify({
+        version: "2.1.0",
+        runs: [
+          { tool: { driver: { name: "semgrep", rules: [] } }, results: [] },
+        ],
+      }),
+    );
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-SCAN",
+        "--commit",
+        "f".repeat(40),
+        "--tool",
+        "semgrep 1.2.3",
+        "--adapter",
+        "sarif",
+        "--results",
+        results,
+        "--discharges",
+        "FR-001-AC-1",
+      ],
+      config,
+    );
+    // Assert the claim, not the file: what must not happen is a BINDING.
+    const path = join(root, "spec", "evidence", "bindings.json");
+    const bindings = existsSync(path)
+      ? (JSON.parse(readFileSync(path, "utf8")) as { bindings: unknown[] })
+          .bindings
+      : [];
+    expect(bindings).toEqual([]);
+  });
+
+  // Trace: FR-034-AC-18
+  it("enumerates a suite that recorded only scans", async () => {
+    // `listRecordedSuites` read `runs/` alone, so a scan-only suite was
+    // invisible to every caller that enumerates — the auditor included.
+    const root = workspace();
+    await recordScan(root);
+    expect(listRecordedSuites(root)).toContain("SUITE-SCAN");
+    expect(latestScan(root, "SUITE-SCAN")?.tool).toBe("semgrep 1.2.3");
+  });
+
+  // Trace: FR-034-AC-19
+  it("collects superseded scans, so the store does not grow without bound", async () => {
+    const root = workspace();
+    await recordScan(root);
+    const results = join(root, "scan.sarif");
+    await EvidenceRecord.run(
+      [
+        "--repo",
+        root,
+        "--suite",
+        "SUITE-SCAN",
+        "--commit",
+        "1".repeat(40),
+        "--tool",
+        "semgrep 1.2.3",
+        "--adapter",
+        "sarif",
+        "--results",
+        results,
+        "--timestamp",
+        "2027-01-01T00:00:00Z",
+      ],
+      config,
+    );
+    const deleted = gc(root);
+    // The newest scan is kept; the superseded one is collected.
+    expect(deleted.some((p) => p.includes("eeeeeeeeeeee.json"))).toBe(true);
+    expect(latestScan(root, "SUITE-SCAN")?.commit).toBe("1".repeat(40));
+  });
+});
+
+// Trace: FR-034-AC-20
+it("tells a tool reporting ZERO rules from a tool reporting no count", () => {
+  // The distinction FR-034 turns on. The adapter defaulted the counter to 0 and
+  // omitted the field when it was 0, which erased exactly this: a scan
+  // declaring `rules: []` read as a tool that had said nothing, so the vacuity
+  // check stayed silent on the one input it exists to catch.
+  const declaredZero = parseSarif(
+    JSON.stringify({
+      version: "2.1.0",
+      runs: [{ tool: { driver: { name: "semgrep", rules: [] } }, results: [] }],
+    }),
+  );
+  expect(declaredZero.rulesEvaluated).toBe(0);
+
+  const saidNothing = parseSarif(
+    JSON.stringify({
+      version: "2.1.0",
+      runs: [{ tool: { driver: { name: "semgrep" } }, results: [] }],
+    }),
+  );
+  expect(saidNothing.rulesEvaluated).toBeUndefined();
 });


### PR DESCRIPTION
The Wave C/D code review — the gate that had been skipped for two waves — and its findings.

## FR-034 shipped inert end to end

A `FindingRecord` was written and **nothing else in the system could see it**:

| Path | Run-shaped | Finding-shaped |
|---|---|---|
| write | `recordRun` → writes **and binds** | `writeScan` → wrote, **bound nothing** |
| enumerate | `listRecordedSuites` → `runs/` | — |
| audit | `latestRuns()` → `audit({runs})` | — |
| collect | `gc` → `RUNS_DIR` | — |

`vacuous-evidence` for a rule-less scan — the check FR-034 exists to make possible — **could not fire in any real run.**

## Five findings

| | |
|---|---|
| **FND-001** high | the scan path bound no obligation, so a scan discharged nothing |
| **FND-002** high | `quoin evidence audit` never passed `scans` |
| **FND-003** high | `listRecordedSuites` read `runs/` alone, so a scan-only suite was invisible |
| **FND-004** medium | `gc` walked `RUNS_DIR` alone, so scan records were never collected |
| **FND-005** high | the SARIF adapter omitted `rulesEvaluated` when it was 0 |

**FND-005 is the one worth reading.** Omitting the field when the count was zero conflated *"the tool reported zero rules"* with *"the tool reported no count"* — erasing the exact distinction FR-034 turns on. `scanIsVacuous` returns `null` for an absent count and stays silent, so the vacuity check was **silent on the one input it exists to catch**.

It was found by **writing the test, not by reading the code**. In the adapter the omission reads as ordinary tidiness; it became visible only when a test asserted the behaviour end to end and the binding it forbade happened anyway.

## Why the tests passed

Every FR-034 criterion was stated over `audit(...)` with a hand-built `scans:` array, or over `parseSarif`. `TC-177`–`TC-179` reached the command but only the **write** half — they assert a file appears in `scans/`, which it did.

**No criterion asserted that anything ever reads it.** A capability is reachable when a *user's invocation* reaches it, not when a test constructs the input the capability expects.

The mechanical tell is cheap: **for each new capability, grep `src/commands/` for the symbol.** If no command names it, it is unreachable regardless of how many tests pass.

## The fix

`--discharges` states the obligations a scan was run to check. A clean scan is the strongest evidence a scanner produces and carries **no finding to bind from**, so they are stated rather than inferred — and a scan that evaluated no rules binds nothing regardless.

Obligations are now derived once for **both** paths; deriving them only on the run path is what left the scan branch with nothing to bind against.

## Verification

`TC-180..184` cover the four store paths and the zero-vs-absent distinction — **each one a path that previously had no test at all.**

`make build` ✅ · `make test` ✅ **384 passed** · `make lint` ✅

Artifact: `reviews/26-08-18-waves-cd-code-review.md` (SR-005, quire-validated, verdict **FAIL**).