### PR TITLE
docs(review): SR-006 Wave C/D gap analysis; declare FR-034-AC-16..20

### DIFF
--- a/reviews/26-08-18-waves-cd-gap-analysis.md
+++ b/reviews/26-08-18-waves-cd-gap-analysis.md
@@ -1,0 +1,98 @@
+---
+id: SR-006
+title: "Gap analysis — ADR-0011 Phase 2 Waves C and D (FR-033, FR-034, FR-035)"
+type: SpecReview
+analysis: gap-analysis
+scope: "spec/matrix.md; FR-033, FR-034, FR-035; tests/evidence-adapters.test.ts, tests/finding-record.test.ts, tests/combinatorial-coverage.test.ts; src/evidence/, src/auditor/, src/advisor/"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/FR-034"
+    type: "reviews"
+---
+
+## Summary
+
+Verified Waves C and D against the Test Matrix and the source tree. **Every Wave C/D row is backed
+by a real test carrying a tracking tag — zero unbacked, zero status lies in range.** Two gaps were
+found inside the wave and fixed here; one large pre-existing gap is reported and deliberately not
+fixed.
+
+Both in-wave gaps were introduced by the previous turn's fixes and are exactly what this gate exists
+to catch: work that passes its own tests while tracing to requirements that do not exist.
+
+## Verdict
+
+**FAIL** — 41 matrix rows repo-wide are marked ✅ with no backing tagged test. None is in Waves C or
+D, and narrowing the scope to make this pass would be the same move the finding is about.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                                              | Refs                                                  |
+| ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| FND-001 | high     | 41 matrix rows read ✅ with no tagged test; the tests exist but use a `describe("TC-nnn …")` form the declared grammar does not bind | tests/auditor.test.ts:69                              |
+| FND-002 | high     | Five tests traced to `FR-034-AC-16..20`, which were never declared in the FR                                                         | spec/functional/FR-034-finding-shaped-evidence.md:118 |
+| FND-003 | medium   | The same five tests had no matrix rows, so five verified behaviours were invisible to the rollup                                     | spec/matrix.md:340                                    |
+| FND-004 | low      | A commit message claimed `TC-180..184` for those tests — ids already held by FR-035                                                  | (commit ff7a164)                                      |
+
+## Detail
+
+### FND-001 — two tag conventions, one of which binds
+
+quoin's tests use two forms:
+
+| Form                   | Example                                     | Binds   |
+| ---------------------- | ------------------------------------------- | ------- |
+| `// Trace: TC-nnn`     | `evidence-adapters.test.ts` (23 uses)       | **yes** |
+| `describe("TC-nnn …")` | `auditor.test.ts`, `evidence-store.test.ts` | **no**  |
+
+Measured: `TC-137`, `TC-119` and `TC-129` all report as status lies while `TC-151`, `TC-165` and
+`TC-180` bind cleanly. Eight test files carry **zero** `// Trace:` tags between them —
+`auditor.test.ts` alone holds 27 real tests.
+
+**The code is tested. The claim is unverifiable**, which is a different and quieter problem: quoin's
+own matrix asserts ✅ over rows the engine cannot confirm, and quoin is the tool that reports this
+class in other repositories.
+
+Not fixed here. It is 41 rows across eight files, predates this program, and belongs in a ticket of
+its own rather than inside a wave's gate — but it should not stay unrecorded, which is how it
+survived this long.
+
+### FND-002 / FND-003 — tests tracing to nothing
+
+`SR-005`'s fixes added five tests carrying `// Trace: FR-034-AC-16` … `AC-20`. **Those criteria did
+not exist.** FR-034 stopped at AC-15, so five tests referenced requirements no document stated, and
+no matrix row named them.
+
+This is the mirror of the defect `SR-005` found: there, a capability existed that nothing could
+reach; here, tests existed that nothing declared. Both pass every gate — `make test` was green with
+384 tests throughout — because neither is a property any gate inspects.
+
+Fixed: AC-16..20 declared, `TC-192..196` added, and each test now carries both ids. All five verify
+as backed.
+
+### FND-004 — a claim in a commit message
+
+The `SR-005` commit said the new tests were `TC-180..184`, which FR-035 already holds. The ids never
+reached the test file or the matrix, so no artifact is wrong and history is not being rewritten —
+recorded because the message is what a reader would consult first.
+
+## Coverage
+
+`quire coverage --scope .` over this repository:
+
+| Measure                                    | Value     |
+| ------------------------------------------ | --------- |
+| Backed rows / total reference rows         | 150 / 450 |
+| Unbacked rows                              | 184       |
+| **Status lies**                            | **41**    |
+| Untracked symbols                          | 6         |
+| **Status lies in Waves C/D (TC-165..196)** | **0**     |
+| **Unbacked rows in Waves C/D**             | **0**     |
+
+No Wave C/D source is unspecified: every module traces to an FR — `src/evidence/adapters/` and the
+registry to FR-033, `FindingRecord` with the store and auditor wiring to FR-034,
+`src/auditor/combinatorial.ts` with the advisor's structural signal to FR-035.
+
+Step 1 (plan completion) has nothing to assert against: this program is tracked in the GitHub epic
+`agent-ix/quire-rs#81`, not a `plan/` bundle. The optional semantic review was **skipped**, as
+requested.

--- a/spec/functional/FR-034-finding-shaped-evidence.md
+++ b/spec/functional/FR-034-finding-shaped-evidence.md
@@ -95,6 +95,11 @@ The cargo-audit adapter is verified against output captured with `cargo audit --
 | FR-034-AC-13 | `quoin evidence record --adapter sarif --results <file>` writes a `FindingRecord` under `scans/` and writes **nothing** under `runs/`. | Test (TC-177) |
 | FR-034-AC-14 | A clean scan recorded through the command keeps `findings: []` and its rule count, so zero findings is still evidence. | Test (TC-178) |
 | FR-034-AC-15 | The command selects a finding adapter from `--tool` when none is named. | Test (TC-179) |
+| FR-034-AC-16 | `--discharges` binds the obligations a scan was run to check. A clean scan carries no finding to bind from, so they are stated rather than inferred. | Test (TC-192) |
+| FR-034-AC-17 | A scan that evaluated **no rules** binds nothing, whatever `--discharges` names. | Test (TC-193) |
+| FR-034-AC-18 | A suite that recorded only scans is enumerated by `listRecordedSuites`. | Test (TC-194) |
+| FR-034-AC-19 | `gc` collects superseded scans, keeping the newest by timestamp. | Test (TC-195) |
+| FR-034-AC-20 | A tool reporting **zero** rules is distinguishable from a tool reporting **no** rule count. | Test (TC-196) |
 
 ### Reachability is part of the contract
 
@@ -110,6 +115,19 @@ review rather than by the tests, which is itself the finding.
 A finding-shaped adapter is selected **before** anything is parsed, because it writes a different
 record type: letting a scan fall through to the run path would put it in `runs/` and lose the
 clean-versus-unrun distinction at the point of intake, silently and permanently for that commit.
+
+### Reachable from every side, not only the write side
+
+A record type is not integrated when it can be written. It is integrated when everything that reads
+the store knows it exists.
+
+`SR-005` found FR-034 **inert end to end**: `writeScan` wrote a record that bound no obligation, the
+audit command never passed `scans`, `listRecordedSuites` read only `runs/`, and `gc` collected only
+`runs/`. The record was written and nothing else in the system could see it, so
+`vacuous-evidence` — the check this FR exists to make possible — could not fire in any real run.
+
+AC-16..20 exist because each of those paths had **no criterion at all**. The write half was stated
+over the command and passed; no criterion asked whether anything ever read what it wrote.
 
 ## Constraints
 

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -312,6 +312,11 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-189 | An obligation whose demanded combinations all ran is healthy | Unit | P0 | FR-035-AC-10 | ✅ |
 | TC-190 | An obligation declaring no configuration space produces no combinatorial finding | Unit | P0 | FR-035-AC-11 | ✅ |
 | TC-191 | A declared space advises the combinatorial method structurally; the prose regex would miss it and ordinary prose must not match | Unit | P0 | FR-035-AC-12 | ✅ |
+| TC-192 | `--discharges` binds the obligations a scan was run to check — a clean scan is the strongest evidence a scanner produces and carries no finding to bind from | Integration | P0 | FR-034-AC-16 | ✅ |
+| TC-193 | A scan that evaluated no rules binds nothing, whatever `--discharges` names | Integration | P0 | FR-034-AC-17 | ✅ |
+| TC-194 | A suite that recorded only scans is enumerated — reading `runs/` alone made it invisible to every caller that enumerates, the auditor included | Integration | P0 | FR-034-AC-18 | ✅ |
+| TC-195 | `gc` collects superseded scans, keeping the newest by timestamp, so a scan store does not grow without bound | Integration | P1 | FR-034-AC-19 | ✅ |
+| TC-196 | A tool reporting ZERO rules is distinguishable from one reporting NO count — the distinction FR-034 turns on, erased by omitting the field when it was 0 | Unit | P0 | FR-034-AC-20 | ✅ |
 | TC-129 | The merged catalog carries every declared method with its rules intact, merges first-wins, reports a colliding id rather than absorbing it, and treats an undeclared catalog as empty | Unit | P0 | FR-031-AC-1 | ✅ |
 | TC-130 | An `attack_surface` object reaches DAST, SAST and negative/abuse testing — recommendations that were unreachable while the method table was skill-local prose | Unit | P0 | FR-031-AC-2 | ✅ |
 | TC-131 | Temporal phrasing reaches runtime monitoring and model checking — the methods a single execution cannot discharge | Unit | P0 | FR-031-AC-3 | ✅ |

--- a/tests/finding-record.test.ts
+++ b/tests/finding-record.test.ts
@@ -471,7 +471,7 @@ describe("a scan is reachable from every side of the store", () => {
     );
   }
 
-  // Trace: FR-034-AC-16
+  // Trace: FR-034-AC-16, TC-192
   it("binds the obligations it was run to check", async () => {
     // A CLEAN scan is the strongest evidence a scanner produces and carries no
     // finding to bind from, so the obligations are stated rather than inferred.
@@ -488,7 +488,7 @@ describe("a scan is reachable from every side of the store", () => {
     );
   });
 
-  // Trace: FR-034-AC-17
+  // Trace: FR-034-AC-17, TC-193
   it("binds nothing when the scan evaluated no rules", async () => {
     // Binding on a rule-less scan would put the store's strongest claim behind
     // its weakest evidence.
@@ -531,7 +531,7 @@ describe("a scan is reachable from every side of the store", () => {
     expect(bindings).toEqual([]);
   });
 
-  // Trace: FR-034-AC-18
+  // Trace: FR-034-AC-18, TC-194
   it("enumerates a suite that recorded only scans", async () => {
     // `listRecordedSuites` read `runs/` alone, so a scan-only suite was
     // invisible to every caller that enumerates — the auditor included.
@@ -541,7 +541,7 @@ describe("a scan is reachable from every side of the store", () => {
     expect(latestScan(root, "SUITE-SCAN")?.tool).toBe("semgrep 1.2.3");
   });
 
-  // Trace: FR-034-AC-19
+  // Trace: FR-034-AC-19, TC-195
   it("collects superseded scans, so the store does not grow without bound", async () => {
     const root = workspace();
     await recordScan(root);
@@ -572,7 +572,7 @@ describe("a scan is reachable from every side of the store", () => {
   });
 });
 
-// Trace: FR-034-AC-20
+// Trace: FR-034-AC-20, TC-196
 it("tells a tool reporting ZERO rules from a tool reporting no count", () => {
   // The distinction FR-034 turns on. The adapter defaulted the counter to 0 and
   // omitted the field when it was 0, which erased exactly this: a scan


### PR DESCRIPTION
The gap-analysis half of the gate skipped for two waves. Artifact: `reviews/26-08-18-waves-cd-gap-analysis.md` (quire-validated, verdict **FAIL**).

## Waves C and D are clean in range

**Zero unbacked rows, zero status lies** across TC-165..196. Every module traces to an FR.

## Two gaps inside the wave, fixed here

`SR-005`'s five fix-tests traced to `FR-034-AC-16..20` — **criteria that did not exist.** FR-034 stopped at AC-15, so five tests referenced requirements no document stated, and no matrix row named them.

That is the **mirror** of what SR-005 found: there, a capability existed that nothing could reach; here, tests existed that nothing declared. Both pass every gate — `make test` was green at 384 throughout — because neither is a property any gate inspects.

Fixed: AC-16..20 declared, `TC-192..196` added, each test carries both ids, all five verify as backed.

## One pre-existing gap, filed not fixed (#124)

**41 matrix rows read ✅ with no tagged test.** The code *is* tested — `auditor.test.ts` alone holds 27 real tests — but quoin uses two conventions and only one binds:

| Form | Binds |
|---|---|
| `// Trace: TC-nnn` | **yes** |
| `describe("TC-nnn …")` | **no** |

Measured: `TC-137`/`119`/`129` are status lies; `TC-151`/`165`/`180` bind. Eight files carry zero `// Trace:` tags.

quoin's own matrix asserts coverage the engine cannot confirm — the green-matrix-over-dead-links defect, in the repo built to detect it. 41 rows across 8 files predating this program is its own ticket.

## Verdict

**FAIL**, on those 41. Narrowing the scope to make it pass would be the same move the finding is about.

`make build` ✅ · `make test` ✅ **384 passed** · `make lint` ✅