### PR TITLE
chore: bump the spec-artifacts-iso pin to v0.14.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.13.0"
+    version: "0.14.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.13.0
+      ref: v0.14.0
 
   - name: spec-artifacts-app
     version: "0.5.0"


### PR DESCRIPTION
`drift:pins` caught it before tagging:

```
spec-artifacts-iso   v0.13.0   v0.14.0   behind
```

iso released **v0.14.0** (FR-001 CR-007 — the `vocabulary_coverage` schema keys) and `default-modules.yaml` still said v0.13.0.

The check **reports rather than fails by design**, which is exactly how a pin sat four releases behind before v0.17.0. Running it before tagging is the point.

Now `9 current, 0 behind, 0 unresolved`.

`make build` ✅ · `make test` ✅ 384 passed · `make lint` ✅