### PR TITLE
chore: bump the spec-artifacts-iso pin to v0.15.0

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.14.0"
+    version: "0.15.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.14.0
+      ref: v0.15.0
 
   - name: spec-artifacts-app
     version: "0.5.0"


### PR DESCRIPTION
Prerequisite for #81. iso **v0.15.0** declares `traceability.vocabulary_coverage` — the quality-characteristics projection quire-rs FR-059 reads.

## Why this is not cosmetic

Without the bump the check has nothing declared to walk and reports **nothing** — which reads as a clean bundle rather than as an absent data source. #81's whole scope is verdict policy over these findings, and there were no findings to apply a verdict to.

## Verified reachable from the command line

Two things had to be true, and only one of them was:

1. the module must declare the projection → **fixed by this bump**
2. the installed `quire` must carry FR-059 → the local binary was **0.22.0**, which predates it; quire-cli v0.23.0 is the release that pins quire-rs v0.33.0

After both:

```
$ quire validate --okf --scope .
warning: no document claims 'availability' for 'quality_attribute' — declared by
  'quality-characteristics', and nothing records it under
  'quality_attributes_not_applicable' [unowned-quality-characteristic]
… 7 findings
```

**What the 7 counts:** distinct values of the `quality_attribute` enum (12 declared by iso's NFR frontmatter schema) that no document in `quoin/spec` claims and no document excuses via `quality_attributes_not_applicable`. Population is quoin's own bundle. So quoin owns 5 of 12 characteristics and has said nothing about the other 7.

Those 7 are a real finding about this repo, not noise, and #81 decides what verdict they carry.

## Gates

- `make test` ✅ 393 passed
- `release-drift pins` ✅ 9 current, 0 behind, 0 unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)