### PR TITLE
fix(auditor): a latency is not a mutation score (FR-039-AC-10)

### DIFF
--- a/spec/functional/FR-039-mutation-score-threshold.md
+++ b/spec/functional/FR-039-mutation-score-threshold.md
@@ -58,6 +58,18 @@ report is the number to act on.
 Treating it as zero fails the obligation for a test **nobody ran**, rather than for a test that failed
 to discriminate. Those have different remedies, and `vacuous-evidence` already reports the first.
 
+### Only a mutation tool's number counts
+
+`RunEntry.score` is deliberately generic — its own contract says *"a mutation score, a coverage
+percentage, a measured latency"*. Reading every scored entry bound to an obligation compares a p95
+latency in milliseconds against a floor of `0.8` and reports the obligation as failing, with a
+plausible summary and no way for a reader to tell. The first draft of this check did exactly that.
+
+Scores are therefore scoped to runs whose `tool` is one the catalog declares for mutation testing,
+matched on the leading name because adapters report `cargo-mutants 25.0.0`. That names a method id
+inside the engine, which is a compromise: the durable fix is a metric discriminator on the entry
+itself, so the adapter that knows what it measured says so. Filed as `agent-ix/quoin#138`.
+
 ### A percentage is refused, not accepted
 
 `--mutation-floor P0=80` is the natural thing to type and is a floor nothing can reach. Accepted
@@ -81,6 +93,8 @@ apply is worse than no floor**, because it reads as a passing gate.
 | FR-039-AC-7 | A floor applies only to the criticality it names. | Test (TC-219) |
 | FR-039-AC-8 | `quoin evidence audit --mutation-floor P0=0.8` parses the pair and applies it. | Test (TC-220) |
 | FR-039-AC-9 | A score outside `[0, 1]`, or a malformed pair, is refused rather than ignored. | Test (TC-220) |
+| FR-039-AC-10 | A score a mutation tool did not produce — a latency, a coverage percentage — is not compared against the floor. | Test (TC-219) |
+| FR-039-AC-11 | A versioned tool string is matched on its leading name. | Test (TC-219) |
 
 ## Constraints
 

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -347,7 +347,7 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-216 | `quoin completeness --strict` exits non-zero on gaps alone — same bundle, both ways round, so `--strict` is a policy and not a second code path | Integration | P0 | FR-037-AC-11 | ✅ |
 | TC-217 | A bundle whose modules declare no vocabulary reports `UNCHECKED`, never `PASS` — nothing checked is not nothing wrong | Integration | P0 | FR-037-AC-12 | ✅ |
 | TC-218 | The unowned set quoin reports equals the one the bundle read yields for the same declaration | Unit | P0 | FR-037-AC-13 | ✅ |
-| TC-219 | The mutation-score policy: silent until a floor is declared, judged on the weakest symbol not the mean, a skipped symbol's absent score is not zero, and a demanded-but-unmeasured floor is its own finding | Unit | P0 | FR-039-AC-1, FR-039-AC-2, FR-039-AC-3, FR-039-AC-4, FR-039-AC-5, FR-039-AC-6, FR-039-AC-7 | ✅ |
+| TC-219 | The mutation-score policy: silent until a floor is declared, judged on the weakest symbol not the mean, a skipped symbol's absent score is not zero, and a demanded-but-unmeasured floor is its own finding, and a latency is not a mutation score | Unit | P0 | FR-039-AC-1, FR-039-AC-2, FR-039-AC-3, FR-039-AC-4, FR-039-AC-5, FR-039-AC-6, FR-039-AC-7, FR-039-AC-10, FR-039-AC-11 | ✅ |
 | TC-220 | `--mutation-floor` parses `<criticality>=<ratio>` and refuses a percentage or a malformed pair — an ignored floor reads as a passing gate | Unit | P0 | FR-039-AC-8, FR-039-AC-9 | ✅ |
 | TC-221 | The case argues from a claim through its requirements down to their obligations | Unit | P0 | FR-040-AC-1 | ✅ |
 | TC-222 | An obligation with a finding stays in the tree as an open node carrying the auditor's reason, rather than being dropped | Unit | P0 | FR-040-AC-2 | ✅ |

--- a/src/auditor/audit.ts
+++ b/src/auditor/audit.ts
@@ -484,7 +484,7 @@ function mutationFinding(
   const floor = floors[obligation.criticality];
   if (floor === undefined) return null;
 
-  const scores = scoresFor(bindings, runs);
+  const scores = scoresFor(bindings, runs, input.catalog);
   if (scores.length === 0) {
     // Distinct from `undischarged`: this obligation may be thoroughly tested and
     // still have nothing saying the tests detect anything. A demanded threshold
@@ -514,12 +514,39 @@ function mutationFinding(
   };
 }
 
-/** Every numeric score the runs bound to this obligation recorded. */
-function scoresFor(bindings: Binding[], runs: RunRecord[]): number[] {
+/**
+ * Mutation scores among the runs bound to this obligation.
+ *
+ * **Scoped by tool, and that scoping is load-bearing.** `RunEntry.score` is
+ * deliberately generic — its own contract says "a mutation score, a coverage
+ * percentage, a measured latency" — so reading every scored entry would compare
+ * a p95 latency in milliseconds against a floor of `0.8` and report the
+ * obligation as failing. The first draft did exactly that.
+ *
+ * The tool names come from the catalog's `mutation-testing` entry (`cargo-mutants`,
+ * `mutmut`, `stryker`), which is module data. Naming that one method id here is
+ * the narrowest way to ask "did a mutation tool produce this number"; the
+ * durable fix is a metric discriminator on the entry itself, filed as
+ * `agent-ix/quoin#138`. With no such catalog entry, nothing is in scope and the
+ * check says nothing rather than something wrong.
+ */
+function scoresFor(
+  bindings: Binding[],
+  runs: RunRecord[],
+  catalog: AuditInput["catalog"],
+): number[] {
   const bound = new Set(bindings.map((b) => b.suite));
+  const tools = new Set(
+    (catalog?.methods ?? [])
+      .filter((m) => m.id === "mutation-testing")
+      .flatMap((m) => m.tooling)
+      .map((t) => t.toLowerCase()),
+  );
   const out: number[] = [];
   for (const run of runs) {
     if (!bound.has(run.suite)) continue;
+    // A tool string is `cargo-mutants 25.0.0`; match on the leading name.
+    if (![...tools].some((t) => run.tool.toLowerCase().startsWith(t))) continue;
     for (const entry of run.entries) {
       // `skip` carries no measurement: a skipped symbol's absent score is not a
       // zero, and treating it as one would fail an obligation for a test nobody

--- a/tests/auditor.test.ts
+++ b/tests/auditor.test.ts
@@ -500,6 +500,28 @@ describe("TC-147 every finding kind can be baselined (FR-032-AC-11)", () => {
 });
 
 describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
+  // The tool names are the CATALOG's, not this test's. `RunEntry.score` is
+  // generic — "a mutation score, a coverage percentage, a measured latency" —
+  // so the auditor scopes by tool, and a fixture with no catalog puts nothing
+  // in scope. That is the correct behaviour and this fixture is what makes the
+  // dependency visible rather than incidental.
+  const mutationCatalog: MethodCatalog = {
+    methods: [
+      {
+        id: "mutation-testing",
+        name: "Mutation testing",
+        class: "Test",
+        definition: "d",
+        evidenceKind: "Static",
+        applicability: {},
+        tooling: ["cargo-mutants", "mutmut", "stryker"],
+        moduleName: "m",
+      },
+    ],
+    collisions: [],
+    unreadable: [],
+  };
+
   const scored = (score: number, over: Partial<RunRecord> = {}) =>
     run({
       tool: "cargo-mutants",
@@ -516,6 +538,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
       input({
         obligations: [obligation({ criticality: "P0" })],
         runs: [scored(0.1)],
+        catalog: mutationCatalog,
       }),
     );
     expect(
@@ -531,6 +554,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
         obligations: [obligation({ criticality: "P0" })],
         runs: [scored(0.55)],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     const finding = report.findings.find(
@@ -549,6 +573,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
         obligations: [obligation({ criticality: "P0" })],
         runs: [scored(0.8)],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     expect(report.healthy).toEqual(["FR-001-AC-1"]);
@@ -571,6 +596,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
           }),
         ],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     expect(
@@ -588,6 +614,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
       input({
         obligations: [obligation({ criticality: "P0" })],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     const finding = report.findings.find(
@@ -614,9 +641,61 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
           }),
         ],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     expect(report.healthy).toEqual(["FR-001-AC-1"]);
+  });
+
+  // Trace: FR-039-AC-10
+  it("does not read a latency or a coverage percentage as a mutation score", () => {
+    // `RunEntry.score` is deliberately generic. Reading every scored entry
+    // compares a p95 latency in milliseconds against a floor of 0.8 and reports
+    // the obligation as failing — which the first draft of this check did.
+    const report = audit(
+      input({
+        obligations: [obligation({ criticality: "P0" })],
+        runs: [
+          run({
+            tool: "criterion",
+            // The BOUND symbol, so the binding is satisfied and the only
+            // open question is what its score means.
+            entries: [{ symbol: "tests::tc001", outcome: "pass", score: 4.2 }],
+          }),
+        ],
+        mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
+      }),
+    );
+    // Not `insufficient` — nothing a MUTATION tool produced was measured.
+    expect(
+      report.findings.find((f) => f.kind.startsWith("insufficient-mutation")),
+    ).toBeUndefined();
+    expect(
+      report.findings.find((f) => f.kind === "unmeasured-mutation-score"),
+    ).toBeDefined();
+  });
+
+  // Trace: FR-039-AC-11
+  it("matches a versioned tool string", () => {
+    // Adapters report `cargo-mutants 25.0.0`, not a bare name.
+    const report = audit(
+      input({
+        obligations: [obligation({ criticality: "P0" })],
+        runs: [
+          run({
+            tool: "cargo-mutants 25.0.0",
+            entries: [{ symbol: "tests::tc001", outcome: "pass", score: 0.4 }],
+          }),
+        ],
+        mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
+      }),
+    );
+    expect(
+      report.findings.find((f) => f.kind === "insufficient-mutation-score")
+        ?.summary,
+    ).toContain("0.4");
   });
 
   // Trace: FR-039-AC-7
@@ -626,6 +705,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
         obligations: [obligation({ criticality: "P2" })],
         runs: [scored(0.1)],
         mutationFloor: { P0: 0.8 },
+        catalog: mutationCatalog,
       }),
     );
     expect(report.healthy).toEqual(["FR-001-AC-1"]);


### PR DESCRIPTION
Bug in FR-039, shipped an hour ago in #137. Found by reading the contract of the field the check depends on, not by a failing test.

## The bug

`RunEntry.score` is deliberately generic. Its own doc comment:

> A numeric result where the method produces one — **a mutation score, a coverage percentage, a measured latency**.

`--mutation-floor P0=0.8` compares a score against a ratio in `[0, 1]`, and `scoresFor` read **every** scored entry bound to the obligation.

So a p95 latency of `4.2` — milliseconds — compared against `0.8` reported:

```
[medium] insufficient-mutation-score: FR-001-AC-1 is criticality P0, which demands a
mutation score of at least 0.8; its weakest bound symbol scores 4.2.
```

Wrong finding, entirely plausible summary, and nothing a reader could use to tell.

## The fix

Scores are scoped to runs whose `tool` is one the catalog declares for `mutation-testing`, matched on the **leading name** because adapters report `cargo-mutants 25.0.0`. With no such catalog entry, nothing is in scope and the check says nothing rather than something wrong.

## The compromise, recorded as one

This names a method id inside the engine — `mutation-testing` is module data everywhere else in this codebase. It is the narrowest thing available today and it has three weaknesses:

1. a method id in `src/auditor/audit.ts`
2. a tool allowlist by another name — a consumer using an unlisted mutation tool gets `unmeasured-mutation-score` while holding a real score
3. it does not generalize — a coverage floor or a latency ceiling will need the same scoping and invent its own

The durable fix is a `metric` discriminator on the entry, set by the adapter that knows what it measured. Filed as **#138**.

## Tests

The four existing TC-219 cases now supply the catalog explicitly, which makes the dependency **visible rather than incidental** — with no catalog they silently stopped finding anything, which is how I confirmed the scoping was load-bearing.

Two new cases pin the bug:

- a `criterion` latency does not fire the floor — and **does** fire `unmeasured-mutation-score`, because a demanded threshold that nothing measured is still not met
- a versioned tool string matches

## Gates

- `make build` ✅ 0 type errors
- `make test` ✅ **428 passed**
- `make lint` ✅
- `quire validate` ✅ · `quire coverage` ✅ no status lie on TC-219

Matrix: FR-039-AC-10, FR-039-AC-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)