### PR TITLE
review(SR-007): Waves D and E code review, and the three findings it produced

### DIFF
--- a/reviews/26-08-19-waves-de-code-review.md
+++ b/reviews/26-08-19-waves-de-code-review.md
@@ -1,0 +1,111 @@
+---
+id: SR-007
+title: "Code review — ADR-0011 Phase 2 Waves D and E (FR-036..FR-041)"
+type: SpecReview
+analysis: code-review
+scope: "src/completeness/, src/assurance/, src/evidence/adapters/, src/auditor/audit.ts, src/commands/, src/advisor/advise.ts, skills/spec-fuzz/, evals/lib/, evals/scenarios/"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/FR-040"
+    type: "reviews"
+---
+
+## Summary
+
+Reviewed Waves D and E as one diff — `984e970..51d0069`, 61 files, +5401 — covering FR-036
+(architecture conformance), FR-037 (declared-vocabulary completeness), FR-038 (`spec-fuzz`), FR-039
+(mutation threshold), FR-040 (assurance case) and FR-041 (SBOM inventories).
+
+**Three findings, two of them high, and both highs are the same failure the code they live in was
+written to prevent.** All three are fixed in this change with regression tests.
+
+## Verdict
+
+**FAIL** — two `high` findings. Both fixed; the verdict records what the review found, not what was
+left behind.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                        | Refs                       |
+| ------- | -------- | ---------------------------------------------------------------------------------------------- | -------------------------- |
+| FND-001 | high     | A requirement refining two claims appeared under one, and the other reported a false statement | src/assurance/graph.ts:160 |
+| FND-002 | high     | A mutation floor with no catalog reported every obligation unmeasured, including scored ones   | src/auditor/audit.ts:487   |
+| FND-003 | medium   | The completeness sweep re-read the whole bundle once per declaration, against NFR-011-M-2      | src/completeness/run.ts:60 |
+
+## Detail
+
+### FND-001 — the assurance case did the thing it forbids
+
+`nodeFor` shared one `reached` set across every claim, using it both to prevent cycles and to mark
+"already rendered". Those are different questions.
+
+Probed rather than reasoned about, with `FR-001` tracing to both `StR-001` and `StR-002`:
+
+```
+StR-001 children: [ 'FR-001' ]
+StR-002 children: []
+unreachable: []
+```
+
+`StR-002` rendered as an **open goal with the reason "no sub-claim and no obligation traces to this
+claim"** — a statement that is false, in an assurance case, about the very edge its author wrote. And
+`unreachable` stayed empty, so nothing anywhere reported it.
+
+FR-040's whole contract is that a case must not narrow silently. It narrowed, and then misreported
+why.
+
+**Fixed** by separating the two questions: a per-path `ancestors` set prevents cycles, `reached`
+remains global for the unreachable calculation. `TC-237`/`TC-238` pin both halves — a shared child
+appears under both parents, and a genuine `A refines B refines A` cycle still terminates.
+
+### FND-002 — the documented behaviour was the opposite of the actual one
+
+`mutationFinding`'s own doc comment, written hours earlier:
+
+> With no such catalog entry, nothing is in scope and the check says nothing rather than something
+> wrong.
+
+It said something wrong. `scoresFor` returned `[]` when no catalog declared `mutation-testing`, and
+an empty score list falls through to `unmeasured-mutation-score` — so **every obligation carrying a
+declared floor was reported unmeasured, including one holding a real `0.95` from `cargo-mutants`**:
+
+```
+no-catalog findings: ["unmeasured-mutation-score"]
+```
+
+Worth recording how it survived: the tests added with FR-039 all supply a catalog, because the
+tool-scoping fix made them, and the no-catalog path had no case. The comment describing the intended
+behaviour was written and never executed.
+
+**Fixed**: the check returns `null` when no catalog declares a mutation method, because the question
+cannot be asked. `TC-239` pins it.
+
+### FND-003 — one pass, stated and not kept
+
+`assessBundle` called `readBundleClaims` per declaration, and each call walked the bundle and read
+every file. N declarations meant N full passes.
+
+`NFR-011-M-2` states the budget as **1 full pass per command invocation**, target and threshold both.
+The repository declares one vocabulary today, so nothing was slow and no timing would have moved —
+which is the only reason this needed reading rather than measuring.
+
+**Fixed**: `readBundleFrontmatter` is called once and `claimsFor` projects the already-read documents
+onto each declaration. `readBundleClaims` remains as the single-declaration convenience.
+
+## Coverage
+
+`make build` ✅ 0 type errors · `make test` ✅ **437 passed** (426 before the fixes, +3 regressions
+and the pre-existing suite) · `make lint` ✅ · `quire validate` ✅ clean on every document in the
+change · `quire coverage` ✅ every new matrix row binds, no status lie.
+
+The Python-shaped sections of this skill — Test Standards, Mock Compliance, both Completeness
+sections, Edge Case & Logic Review — were **not** run as written. This change is TypeScript and
+markdown; transliterating them produces false findings that bury real ones. Their language-independent
+equivalents were run: Integrity, Spec-Code Faithfulness, Code-Test Alignment and Gap Analysis.
+
+## Method note
+
+Both high findings were found by **writing a probe and running it**, not by reading. Each looked
+correct on the page — the diamond case needs three documents to expose, and the no-catalog case
+contradicts a comment sitting two lines above it. FND-003 is the reverse: invisible to any
+measurement, because the condition that makes it cost anything does not exist in this repository yet.

--- a/spec/functional/FR-039-mutation-score-threshold.md
+++ b/spec/functional/FR-039-mutation-score-threshold.md
@@ -65,6 +65,11 @@ percentage, a measured latency"*. Reading every scored entry bound to an obligat
 latency in milliseconds against a floor of `0.8` and reports the obligation as failing, with a
 plausible summary and no way for a reader to tell. The first draft of this check did exactly that.
 
+Where **no** catalog declares a mutation method the question cannot be asked at all, and the check
+says nothing. Returning `unmeasured` there reported every obligation with a declared floor —
+including ones holding a real score — which was the opposite of the documented behaviour (`SR-007`
+FND-002).
+
 Scores are therefore scoped to runs whose `tool` is one the catalog declares for mutation testing,
 matched on the leading name because adapters report `cargo-mutants 25.0.0`. That names a method id
 inside the engine, which is a compromise: the durable fix is a metric discriminator on the entry
@@ -95,6 +100,7 @@ apply is worse than no floor**, because it reads as a passing gate.
 | FR-039-AC-9 | A score outside `[0, 1]`, or a malformed pair, is refused rather than ignored. | Test (TC-220) |
 | FR-039-AC-10 | A score a mutation tool did not produce — a latency, a coverage percentage — is not compared against the floor. | Test (TC-219) |
 | FR-039-AC-11 | A versioned tool string is matched on its leading name. | Test (TC-219) |
+| FR-039-AC-12 | With no catalog declaring a mutation method, the check says nothing at all. | Test (TC-239) |
 
 ## Constraints
 

--- a/spec/functional/FR-040-assurance-case-view.md
+++ b/spec/functional/FR-040-assurance-case-view.md
@@ -66,6 +66,14 @@ for it would be a second thing to keep in agreement.
 **threat**, and that vocabulary is module data — a built-in `StR` would make this view useless to
 exactly the bundles that need an assurance case most.
 
+### A shared sub-claim belongs to both claims
+
+Cycle prevention and "already rendered somewhere" are different questions, and one visited-set cannot
+answer both. Sharing it put a requirement refining two claims under the first only, and made the
+second report *"no sub-claim and no obligation traces to this claim"* — false, in an assurance case,
+about the edge its author had written (`SR-007` FND-001). Cycles are prevented per **path**; being
+rendered elsewhere is not a reason to omit.
+
 ### Deterministic, because it is a view
 
 Re-rendering unchanged inputs produces byte-identical output, so a diff means the evidence moved and
@@ -96,6 +104,8 @@ does not expose. `agent-ix/quire-rs#179` is where this stops being necessary.
 | FR-040-AC-8 | Rendering unchanged inputs is byte-identical. | Test (TC-228) |
 | FR-040-AC-9 | Mermaid output survives punctuation in a statement — parentheses, quotes and semicolons. | Test (TC-229) |
 | FR-040-AC-10 | A bundle declaring no claim says so, rather than rendering an empty case. | Test (TC-230) |
+| FR-040-AC-11 | A requirement refining two claims appears under both. | Test (TC-237) |
+| FR-040-AC-12 | A cycle terminates without dropping a legitimately shared child. | Test (TC-238) |
 
 ## Constraints
 

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -366,6 +366,9 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-234 | A document that is neither format is refused — zero entries is a real finding and an unreadable file must not masquerade as one | Unit | P0 | FR-041-AC-4 | ✅ |
 | TC-235 | A component with neither purl nor name is dropped, not given an invented identity that binds to nothing and inflates the count | Unit | P0 | FR-041-AC-5 | ✅ |
 | TC-236 | The adapter is selected by `--adapter sbom` and by the tools emitting these formats | Unit | P0 | FR-041-AC-6 | ✅ |
+| TC-237 | A requirement refining two claims appears under both — one visited-set answered cycles and "rendered elsewhere" at once, and the second claim reported a statement that was false | Unit | P0 | FR-040-AC-11 | ✅ |
+| TC-238 | A cycle terminates without dropping a legitimately shared child, so the FND-001 fix cannot regress into an infinite walk | Unit | P0 | FR-040-AC-12 | ✅ |
+| TC-239 | With no catalog declaring a mutation method the check says nothing — reporting `unmeasured` fired on every obligation with a floor, including ones holding a real score | Unit | P0 | FR-039-AC-12 | ✅ |
 | TC-129 | The merged catalog carries every declared method with its rules intact, merges first-wins, reports a colliding id rather than absorbing it, and treats an undeclared catalog as empty | Unit | P0 | FR-031-AC-1 | ✅ |
 | TC-130 | An `attack_surface` object reaches DAST, SAST and negative/abuse testing — recommendations that were unreachable while the method table was skill-local prose | Unit | P0 | FR-031-AC-2 | ✅ |
 | TC-131 | Temporal phrasing reaches runtime monitoring and model checking — the methods a single execution cannot discharge | Unit | P0 | FR-031-AC-3 | ✅ |

--- a/src/assurance/graph.ts
+++ b/src/assurance/graph.ts
@@ -130,8 +130,22 @@ export function buildCase(input: CaseInput): AssuranceCase {
   const reached = new Set<string>();
   for (const [id, doc] of byId) {
     if (!claimTypes.has(String(doc.frontmatter.type ?? ""))) continue;
+    // A fresh `ancestors` set per claim. Sharing one across claims made a
+    // requirement that refines TWO claims appear under only the first, while
+    // the second reported "no sub-claim traces to this claim" — a statement
+    // that was false, in an assurance case, about the very edge the author had
+    // written. Cycle prevention and "already rendered somewhere" are different
+    // questions and now have different sets.
     claims.push(
-      nodeFor(id, byId, children, obligationsFor, findingFor, reached),
+      nodeFor(
+        id,
+        byId,
+        children,
+        obligationsFor,
+        findingFor,
+        reached,
+        new Set(),
+      ),
     );
   }
   claims.sort((a, b) => a.id.localeCompare(b.id));
@@ -150,16 +164,29 @@ function nodeFor(
   obligationsFor: Map<string, Obligation[]>,
   findingFor: Map<string, Finding>,
   reached: Set<string>,
+  ancestors: Set<string>,
 ): CaseNode {
   reached.add(id);
+  ancestors.add(id);
   const doc = byId.get(id);
   const title = String(doc?.frontmatter.title ?? id);
 
+  // `ancestors`, not `reached`: a child already rendered under a DIFFERENT
+  // claim must still appear here, and only a child on this path would be a
+  // cycle.
   const sub = (children.get(id) ?? [])
-    .filter((child) => !reached.has(child))
+    .filter((child) => !ancestors.has(child))
     .sort()
     .map((child) =>
-      nodeFor(child, byId, children, obligationsFor, findingFor, reached),
+      nodeFor(
+        child,
+        byId,
+        children,
+        obligationsFor,
+        findingFor,
+        reached,
+        new Set(ancestors),
+      ),
     );
 
   const evidence = (obligationsFor.get(id) ?? [])

--- a/src/auditor/audit.ts
+++ b/src/auditor/audit.ts
@@ -484,6 +484,14 @@ function mutationFinding(
   const floor = floors[obligation.criticality];
   if (floor === undefined) return null;
 
+  if (!mutationToolsIn(input.catalog)) {
+    // No catalog entry declares a mutation method, so "did a mutation tool
+    // produce this number" cannot be asked. Reporting `unmeasured` here fired
+    // on every obligation with a floor — including ones holding a real score —
+    // which is the documented behaviour's exact opposite.
+    return null;
+  }
+
   const scores = scoresFor(bindings, runs, input.catalog);
   if (scores.length === 0) {
     // Distinct from `undischarged`: this obligation may be thoroughly tested and
@@ -530,18 +538,23 @@ function mutationFinding(
  * `agent-ix/quoin#138`. With no such catalog entry, nothing is in scope and the
  * check says nothing rather than something wrong.
  */
-function scoresFor(
-  bindings: Binding[],
-  runs: RunRecord[],
-  catalog: AuditInput["catalog"],
-): number[] {
-  const bound = new Set(bindings.map((b) => b.suite));
+function mutationToolsIn(catalog: AuditInput["catalog"]): Set<string> | null {
   const tools = new Set(
     (catalog?.methods ?? [])
       .filter((m) => m.id === "mutation-testing")
       .flatMap((m) => m.tooling)
       .map((t) => t.toLowerCase()),
   );
+  return tools.size > 0 ? tools : null;
+}
+
+function scoresFor(
+  bindings: Binding[],
+  runs: RunRecord[],
+  catalog: AuditInput["catalog"],
+): number[] {
+  const bound = new Set(bindings.map((b) => b.suite));
+  const tools = mutationToolsIn(catalog) ?? new Set<string>();
   const out: number[] = [];
   for (const run of runs) {
     if (!bound.has(run.suite)) continue;

--- a/src/completeness/bundle.ts
+++ b/src/completeness/bundle.ts
@@ -47,9 +47,22 @@ export function readBundleClaims(
   bundleRoot: string,
   declaration: VocabularyDeclaration,
 ): BundleRead {
-  const documents: DocumentClaims[] = [];
-  const { documents: read, unreadable } = readBundleFrontmatter(bundleRoot);
+  const { documents, unreadable } = readBundleFrontmatter(bundleRoot);
+  return { documents: claimsFor(documents, declaration), unreadable };
+}
 
+/**
+ * Project already-read documents onto one declaration.
+ *
+ * Split out from {@link readBundleClaims} so a caller with several declarations
+ * walks the bundle **once**. The combined form re-read every file per
+ * declaration, which NFR-011-M-2 budgets at one pass per invocation.
+ */
+export function claimsFor(
+  read: BundleDocument[],
+  declaration: VocabularyDeclaration,
+): DocumentClaims[] {
+  const documents: DocumentClaims[] = [];
   for (const doc of read) {
     const { path: rel, frontmatter } = doc;
     const claims = stringsAt(frontmatter[declaration.field]);
@@ -60,8 +73,7 @@ export function readBundleClaims(
 
     documents.push({ path: rel, claims, excuses, body: doc.body });
   }
-
-  return { documents, unreadable };
+  return documents;
 }
 
 /** One document's frontmatter and body, as read from the bundle. */

--- a/src/completeness/index.ts
+++ b/src/completeness/index.ts
@@ -23,6 +23,7 @@ export {
   type VocabularyDeclarations,
 } from "./declarations.js";
 export {
+  claimsFor,
   readBundleClaims,
   readBundleFrontmatter,
   type BundleDocument,

--- a/src/completeness/run.ts
+++ b/src/completeness/run.ts
@@ -13,7 +13,7 @@ import {
   type CompletenessReport,
   type VocabularyRollup,
 } from "./assess.js";
-import { readBundleClaims } from "./bundle.js";
+import { claimsFor, readBundleFrontmatter } from "./bundle.js";
 import {
   loadVocabularyCoverage,
   type VocabularyDeclaration,
@@ -56,15 +56,23 @@ export function assessBundle(options: AssessOptions): BundleAssessment {
   const unreadable: Array<{ path: string; reason: string }> = [];
   const seen = new Set<string>();
 
+  // ONE walk, whatever the declaration count. `readBundleClaims` re-read the
+  // whole bundle per declaration, so N declarations meant N full passes — and
+  // NFR-011-M-2 states the budget as one pass per invocation. Latent at one
+  // declaration, which is why it needed catching by reading rather than by a
+  // timing that would not have moved.
+  const bundle = readBundleFrontmatter(options.bundleRoot);
+  for (const entry of bundle.unreadable) {
+    if (seen.has(entry.path)) continue;
+    seen.add(entry.path);
+    unreadable.push(entry);
+  }
+
   for (const declaration of declarations as VocabularyDeclaration[]) {
-    const read = readBundleClaims(options.bundleRoot, declaration);
-    for (const entry of read.unreadable) {
-      // The same document is unreadable once per declaration; report it once.
-      if (seen.has(entry.path)) continue;
-      seen.add(entry.path);
-      unreadable.push(entry);
-    }
-    const assessed = assessVocabulary(declaration, read.documents);
+    const assessed = assessVocabulary(
+      declaration,
+      claimsFor(bundle.documents, declaration),
+    );
     rollups.push(assessed.rollup);
     findings.push(...assessed.findings);
   }

--- a/tests/assurance.test.ts
+++ b/tests/assurance.test.ts
@@ -1,5 +1,5 @@
 /**
- * FR-040 — the assurance-case view (TC-221..TC-230).
+ * FR-040 — the assurance-case view (TC-221..TC-230, TC-237, TC-238).
  */
 
 import { describe, expect, it } from "vitest";
@@ -127,6 +127,49 @@ describe("building the case", () => {
       findings: [],
     });
     expect(result.unreachable).toEqual(["FR-009"]);
+  });
+
+  // Trace: FR-040-AC-11
+  it("shows a requirement that refines two claims under both", () => {
+    // Sharing one visited-set across claims put it under the first only, and
+    // the second reported "no sub-claim traces to this claim" — a FALSE
+    // statement, in an assurance case, about the very edge its author wrote.
+    // Cycle prevention and "already rendered somewhere" are different questions.
+    const documents = [
+      doc("StR-001", "StR", "One"),
+      doc("StR-002", "StR", "Two"),
+      doc("FR-001", "FR", "Shared", [
+        ["StR-001", "traces_to"],
+        ["StR-002", "traces_to"],
+      ]),
+    ];
+    const result = buildCase({
+      documents,
+      obligations: [obligation("FR-001-AC-1")],
+      findings: [],
+    });
+    expect(result.claims.map((c) => c.children.map((x) => x.id))).toEqual([
+      ["FR-001"],
+      ["FR-001"],
+    ]);
+    expect(result.claims.every((c) => c.because === undefined)).toBe(true);
+  });
+
+  // Trace: FR-040-AC-12
+  it("stops at a cycle without dropping a legitimately shared child", () => {
+    // A refines B refines A. The recursion must terminate, and it must do so by
+    // path and not by "seen anywhere", or the fix above regresses.
+    const documents = [
+      doc("StR-001", "StR", "Root"),
+      doc("FR-001", "FR", "A", [
+        ["StR-001", "traces_to"],
+        ["FR-002", "refines"],
+      ]),
+      doc("FR-002", "FR", "B", [["FR-001", "refines"]]),
+    ];
+    const result = buildCase({ documents, obligations: [], findings: [] });
+    expect(result.claims).toHaveLength(1);
+    expect(JSON.stringify(result.claims[0]).length).toBeLessThan(4000);
   });
 
   // Trace: FR-040-AC-6

--- a/tests/auditor.test.ts
+++ b/tests/auditor.test.ts
@@ -698,6 +698,25 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
     ).toContain("0.4");
   });
 
+  // Trace: FR-039-AC-12
+  it("says nothing when no catalog declares a mutation method", () => {
+    // The question "did a mutation tool produce this number" cannot be asked
+    // without a catalog. Reporting `unmeasured` fired on every obligation with
+    // a floor — INCLUDING ones holding a real score — which is the documented
+    // behaviour's exact opposite.
+    const report = audit(
+      input({
+        obligations: [obligation({ criticality: "P0" })],
+        runs: [scored(0.95)],
+        mutationFloor: { P0: 0.8 },
+      }),
+    );
+    expect(report.findings.filter((f) => f.kind.includes("mutation"))).toEqual(
+      [],
+    );
+    expect(report.healthy).toEqual(["FR-001-AC-1"]);
+  });
+
   // Trace: FR-039-AC-7
   it("applies only to the criticality the floor names", () => {
     const report = audit(


### PR DESCRIPTION
The goal's review gate, run on `984e970..51d0069` (61 files, +5401) — FR-036 through FR-041. **It had not been run on Waves D and E.**

Three findings, two high, all fixed here with regression tests.

## FND-001 (high) — the assurance case did the thing it forbids

`nodeFor` shared one `reached` set across every claim, using it both to prevent cycles and to mark "already rendered". Those are different questions.

Probed rather than reasoned about, with `FR-001` tracing to **both** `StR-001` and `StR-002`:

```
StR-001 children: [ 'FR-001' ]
StR-002 children: []
unreachable: []
```

`StR-002` rendered as an open goal reading **"no sub-claim and no obligation traces to this claim"** — false, in an assurance case, about the very edge its author had written. And `unreachable` stayed empty, so nothing reported it anywhere.

FR-040's entire contract is that a case must not narrow silently. It narrowed, and then misreported why.

**Fixed** by separating the questions: a per-path `ancestors` set prevents cycles; `reached` stays global for the unreachable calculation. `TC-237` pins the shared child, `TC-238` pins that a genuine `A refines B refines A` cycle still terminates.

## FND-002 (high) — the documented behaviour was the opposite of the actual one

`mutationFinding`'s own doc comment, written hours earlier in #139:

> With no such catalog entry, nothing is in scope and **the check says nothing rather than something wrong**.

It said something wrong:

```
no-catalog findings: ["unmeasured-mutation-score"]
```

With no catalog declaring `mutation-testing`, **every** obligation carrying a declared floor was reported unmeasured — including one holding a real `0.95` from `cargo-mutants`.

Worth recording how it survived: every FR-039 test supplies a catalog, because the tool-scoping fix made them do so, and the no-catalog path had no case. The comment describing the intended behaviour was written and never executed.

**Fixed**: the check returns `null` when the question cannot be asked. `TC-239`.

## FND-003 (medium) — one pass, stated and not kept

`assessBundle` called `readBundleClaims` per declaration, and each call walked the bundle and read every file. N declarations meant **N full passes**.

`NFR-011-M-2` states the budget as **1 full pass per invocation** — target and threshold both.

One vocabulary is declared today, so nothing was slow and **no timing would have moved**. That is the only reason this needed reading rather than measuring.

**Fixed**: `readBundleFrontmatter` runs once; `claimsFor` projects the already-read documents onto each declaration.

## Method note

Both highs were found by **writing a probe and running it**. Each looked correct on the page — the diamond case needs three documents to expose, and the no-catalog case contradicts a comment sitting two lines above it. FND-003 is the reverse: invisible to any measurement, because the condition that makes it cost anything does not exist in this repository yet.

## Artifact

`reviews/26-08-19-waves-de-code-review.md` — **SR-007, FAIL** (two highs). The verdict records what the review found, not what was left behind.

## Gates

- `make build` ✅ 0 type errors
- `make test` ✅ **437 passed** (426 before)
- `make lint` ✅
- `quire validate` ✅ clean, including the review itself
- `quire coverage` ✅ TC-237..239 bind, no status lie

🤖 Generated with [Claude Code](https://claude.com/claude-code)