### PR TITLE
review(SR-008): Waves D and E gap analysis — eval evidence is invisible

### DIFF
--- a/reviews/26-08-19-waves-de-gap-analysis.md
+++ b/reviews/26-08-19-waves-de-gap-analysis.md
@@ -1,0 +1,102 @@
+---
+id: SR-008
+title: "Gap analysis — ADR-0011 Phase 2 Waves D and E (FR-036..FR-041)"
+type: SpecReview
+analysis: gap-analysis
+scope: "spec/matrix.md, spec/evals.md, src/completeness/, src/assurance/, src/evidence/adapters/, src/auditor/, src/commands/"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/FR-038"
+    type: "reviews"
+  - target: "ix://agent-ix/quoin/FR-041"
+    type: "references"
+---
+
+## Summary
+
+Verified Waves D and E — FR-036 through FR-041 — against the Test Matrix and the source tree, with
+the optional semantic review skipped.
+
+**Every vitest-backed row binds.** The gap is entirely in the eval-verified half: 9 of FR-038's
+criteria are unbacked, because eval evidence is structurally invisible to the reconciler and nothing
+records that the evals ran. They did — TC-EV-054..057, 4/4, live — and the repository has no way to
+know that.
+
+## Verdict
+
+**FAIL** — nine matrix criteria have no backing tagged test. Structural and pre-existing (71 such rows
+repo-wide, FR-028 among them), and FR-038 added nine to the pile rather than creating the problem.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                     | Refs                                              |
+| ------- | -------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| FND-001 | medium   | Nine FR-038 criteria are unbacked: eval runs mint no symbol and are recorded as no evidence | spec/functional/FR-038-generate-fuzz-harnesses.md |
+| FND-002 | medium   | `Eval` is not a declared verification method, so 19 rows have no dischargeable meaning      | spec/evals.md                                     |
+| FND-003 | low      | The FR-036 adapter did not name FR-036, and the `FR-003` it names is another repo's         | src/evidence/adapters/audit-script.ts:34          |
+
+## Detail
+
+### FND-001 — the strongest verification leaves the least trace
+
+`quire coverage` reconciles matrix rows against **test symbols in code**. Eval scenarios are data in
+`evals/scenarios/index.mjs`; they mint no symbol and can never back a row.
+
+| Document        | Unbacked rows targeting `TC-EV-*` |
+| --------------- | --------------------------------- |
+| `spec/evals.md` | 52                                |
+| `FR-028`        | 10                                |
+| `FR-038`        | 9                                 |
+| **total**       | **71**                            |
+
+FR-038 is consistent with the pattern FR-028 established, so this is not a regression. What makes it
+worth a finding rather than a note is the asymmetry: **the evals for FR-038 were actually run** — a
+real agent, through the real CLI, four scenarios, 4/4, and two earlier failures that were genuine and
+fixed. That run produced `evals/reports/latest.json` and the repository dropped it.
+
+So the matrix's ✅ on those nine rows rests on a fact recorded nowhere. That is the same shape as
+1,014 trace tags binding to nothing, arriving through a verification method the evidence store cannot
+hold.
+
+### FND-002 — a method nobody can discharge
+
+```
+'Eval' is neither a declared verification_catalog method id nor a declared class,
+so nothing can say what discharging it means (19 rows, first in FR-028)
+```
+
+An eval **is** a verification method, and arguably the most convincing one here. It has no catalog
+entry, so `quoin advise` cannot recommend it, `method-conformance` cannot evaluate it, and
+`unknown-method` has nothing to compare against. (`Review` shares the problem on one NFR-005 row.)
+
+FND-001 and FND-002 are one gap seen from two ends, and are filed together as
+`agent-ix/quoin#142` with a proposed shape: a catalog entry, plus an adapter over the eval report so
+a scenario becomes a recorded run like any other suite.
+
+### FND-003 — a traceability slip, fixed here
+
+`src/evidence/adapters/audit-script.ts` implements FR-036's evidence intake and named FR-034 and
+FR-003 but not FR-036. Worse, the `FR-003` it named is **quire-rs's** — it appears inside a quoted
+example of a real audit script's output — and quoin has its own FR-003 (_Print usage and
+command-scoped help_), so a reader or a grep-based tool resolves it to the wrong requirement.
+
+Fixed: the module header now names FR-036, and both cross-repo references read `quire-rs FR-003-AC-4`.
+
+## Coverage
+
+**Plan completion** — `plan/PLAN-001-spec-correctness` is the only plan bundle and predates this work;
+Waves D and E were executed from the epic's ticket list rather than a plan bundle, so step 1 has no
+target and is recorded as not applicable rather than passed.
+
+**Matrix verification** — `quire coverage --scope .`: 211 backed of 567, 284 criteria. Every row added
+by Waves D and E binds except the nine in FND-001. **No status lies and no untracked symbols** among
+them; the one untracked symbol repo-wide (`tests/catalog.test.ts :: aborts (strict) …`) predates this
+work.
+
+**Underspecified code** — every source file added by Waves D and E names its owning FR:
+`src/completeness/` → FR-037, `src/assurance/` → FR-040, `sbom.ts` → FR-041, `audit-script.ts` →
+FR-036 (after FND-003). No reverse gap; no stubs, no placeholder returns.
+
+**Semantic review** — skipped, as requested. Intent↔test↔code agreement was not judged; the two
+`high` findings in `SR-007` were found by probing behaviour, which is the closest this pass came to
+that question.

--- a/src/evidence/adapters/audit-script.ts
+++ b/src/evidence/adapters/audit-script.ts
@@ -16,7 +16,7 @@ const LINE = /^([A-Za-z0-9._-]+):\s*(OK|FAIL)\b\s*(?:[—-]\s*)?(.*)$/;
  *
  * Trailing punctuation is allowed after the closing paren because the real
  * scripts write one: `check_no_schemars: FAIL — 'schemars' present in
- * Cargo.lock (FR-003-AC-4).` An anchor demanding end-of-line found nothing,
+ * Cargo.lock (quire-rs FR-003-AC-4).` An anchor demanding end-of-line found nothing,
  * and the finding lost the very criterion that makes it a discharge rather
  * than a complaint.
  */
@@ -31,7 +31,7 @@ function traceIdsOf(message: string): string[] | undefined {
 }
 
 /**
- * Architecture-conformance audit scripts → findings.
+ * Architecture-conformance audit scripts → findings (FR-036).
  *
  * **Why this is the format worth reading for architecture conformance.**
  * Specs and ADRs declare boundaries — "engine/surfaces split", "no solver dep
@@ -43,7 +43,7 @@ function traceIdsOf(message: string): string[] | undefined {
  * **The join is literal here, which it is not for most scanners.** FR-034
  * described a scanner rule id ⇄ obligation id as *"a verification method, not a
  * generic scan"*. An audit script already prints the criterion in its failure
- * line — `check_no_schemars: FAIL — 'schemars' present (FR-003-AC-4)` — so the
+ * line — `check_no_schemars: FAIL — 'schemars' present (quire-rs FR-003-AC-4)` — so the
  * obligation it discharges is stated by the tool rather than mapped after the
  * fact.
  *


### PR DESCRIPTION
The second half of the goal's review gate, after `SR-007` (code review, #141).

**Every vitest-backed row added by Waves D and E binds.** No status lies, no untracked symbols, no reverse gap. The gap is entirely in the eval-verified half.

## FND-001 (medium) — the strongest verification leaves the least trace

`quire coverage` reconciles matrix rows against **test symbols in code**. Eval scenarios are data in `evals/scenarios/index.mjs` — they mint no symbol and can never back a row.

| Document | Unbacked rows targeting `TC-EV-*` |
|---|---|
| `spec/evals.md` | 52 |
| `FR-028` | 10 |
| `FR-038` | 9 |
| **total** | **71** |

FR-038 follows the pattern FR-028 established, so this is **not a regression**. What makes it a finding rather than a note is the asymmetry:

**The FR-038 evals were actually run.** A real agent, through the real CLI, four scenarios, 4/4 — with two earlier failures that were genuine and got fixed. That run produced `evals/reports/latest.json`, and the repository dropped it.

So the matrix's ✅ on those nine rows rests on a fact recorded nowhere. Same shape as 1,014 trace tags binding to nothing, arriving through a verification method the evidence store cannot hold.

## FND-002 (medium) — a method nobody can discharge

```
'Eval' is neither a declared verification_catalog method id nor a declared class,
so nothing can say what discharging it means (19 rows, first in FR-028)
```

An eval **is** a verification method — arguably the most convincing one in this project. It has no catalog entry, so `quoin advise` cannot recommend it, `method-conformance` cannot evaluate it, and `unknown-method` has nothing to compare against.

FND-001 and FND-002 are one gap seen from two ends. Filed together as **#142** with a proposed shape: a catalog entry, plus an adapter over the eval report so a scenario becomes a recorded run like any other suite. The adapter is small — the family (#91) is closed and the registry takes new entries as data.

## FND-003 (low) — fixed in this PR

`audit-script.ts` implements FR-036's evidence intake and named FR-034 and FR-003, but **not FR-036**.

Worse: the `FR-003` it named is **quire-rs's**, appearing inside a quoted example of real audit-script output — and quoin has its own FR-003 (*Print usage and command-scoped help*). A reader or a grep-based tool resolves it to the wrong requirement.

Header now names FR-036; both cross-repo references read `quire-rs FR-003-AC-4`.

## Verdict

**FAIL** — nine matrix criteria have no backing tagged test. Structural and pre-existing; FR-038 added nine to a pile of 71 rather than creating the problem.

## Coverage

- **Plan completion** — n/a. Waves D and E ran from the epic's ticket list, not a plan bundle; recorded as not applicable rather than passed.
- **Matrix** — 211 backed of 567, 284 criteria. Every Wave D/E row binds except FND-001's nine.
- **Underspecified code** — every new source file names its owning FR. No stubs, no placeholder returns.
- **Semantic review** — skipped as requested.

Artifact: `reviews/26-08-19-waves-de-gap-analysis.md` (**SR-008**).

Gates: build ✅ · **437 tests** ✅ · lint ✅ · `quire validate` clean incl. the review ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)