### PR TITLE
fix(spec): verification cells name a method, not an evidence kind (CR-022, #142)

### DIFF
--- a/spec/functional/FR-028-generate-property-tests-from-criteria.md
+++ b/spec/functional/FR-028-generate-property-tests-from-criteria.md
@@ -121,23 +121,23 @@ wrong, so the second pass can afford recall the deterministic pass cannot.
 
 | ID | Constraint | Type | Validation |
 |----|------------|------|------------|
-| FR-028-CON-1 | The skill SHALL NOT invent an output format. Everything it writes to the tree is either a test in the repository's own harness or an artifact type the module catalog declares; a review is a `SpecReview`. | Architecture | Eval (TC-EV-053) |
+| FR-028-CON-1 | The skill SHALL NOT invent an output format. Everything it writes to the tree is either a test in the repository's own harness or an artifact type the module catalog declares; a review is a `SpecReview`. | Architecture | agent-behaviour-eval (TC-EV-053) |
 
 ## Acceptance Criteria
 
 | ID           | Criteria                                                                                                               | Verification    |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------- | --------------- |
-| FR-028-AC-1  | A record with `extraction` of `extractable` yields a test emitted unattended                                            | Eval (TC-EV-050)   |
-| FR-028-AC-2  | A record with `extraction` of `candidate` yields a test and a finding in the review artifact naming it as requiring review | Eval (TC-EV-051)   |
-| FR-028-AC-3  | Any record whose `property` is `example` or `unclassified` yields no unattended test                                    | Eval (TC-EV-050)   |
-| FR-028-AC-4  | Every emitted tracking tag names a `row_id` present in the classification output                                        | Eval (TC-EV-050)   |
-| FR-028-AC-5  | Every emitted tracking tag is reported as backed by `quire coverage`, not merely present in the file                     | Eval (TC-EV-052)   |
-| FR-028-AC-6  | Every test the skill emits runs in the repository's runner — no skip, ignore, or disabled marker is written             | Eval (TC-EV-051)   |
-| FR-028-AC-7  | The run writes exactly one `SpecReview` at `reviews/YY-MM-DD-<slug>.md` with `analysis: spec-correctness`, and it passes `quire validate` | Eval (TC-EV-051)   |
-| FR-028-AC-8  | A criterion whose domain, precondition, or oracle cannot be cited yields a recorded reason and no test                  | Eval (TC-EV-053)   |
-| FR-028-AC-9  | The census output carries no threshold, no verdict, and no rewording suggestion                                         | Eval (TC-EV-053)   |
+| FR-028-AC-1  | A record with `extraction` of `extractable` yields a test emitted unattended                                            | agent-behaviour-eval (TC-EV-050)   |
+| FR-028-AC-2  | A record with `extraction` of `candidate` yields a test and a finding in the review artifact naming it as requiring review | agent-behaviour-eval (TC-EV-051)   |
+| FR-028-AC-3  | Any record whose `property` is `example` or `unclassified` yields no unattended test                                    | agent-behaviour-eval (TC-EV-050)   |
+| FR-028-AC-4  | Every emitted tracking tag names a `row_id` present in the classification output                                        | agent-behaviour-eval (TC-EV-050)   |
+| FR-028-AC-5  | Every emitted tracking tag is reported as backed by `quire coverage`, not merely present in the file                     | agent-behaviour-eval (TC-EV-052)   |
+| FR-028-AC-6  | Every test the skill emits runs in the repository's runner — no skip, ignore, or disabled marker is written             | agent-behaviour-eval (TC-EV-051)   |
+| FR-028-AC-7  | The run writes exactly one `SpecReview` at `reviews/YY-MM-DD-<slug>.md` with `analysis: spec-correctness`, and it passes `quire validate` | agent-behaviour-eval (TC-EV-051)   |
+| FR-028-AC-8  | A criterion whose domain, precondition, or oracle cannot be cited yields a recorded reason and no test                  | agent-behaviour-eval (TC-EV-053)   |
+| FR-028-AC-9  | The census output carries no threshold, no verdict, and no rewording suggestion                                         | agent-behaviour-eval (TC-EV-053)   |
 | FR-028-AC-10 | No specification artifact the skill writes names a test framework, harness, or generator library                        | Inspection      |
-| FR-028-AC-11 | A repository whose manifest names no generator library yields findings naming it and a reported remedy, not an install and not a test | Eval (TC-EV-053)   |
+| FR-028-AC-11 | A repository whose manifest names no generator library yields findings naming it and a reported remedy, not an install and not a test | agent-behaviour-eval (TC-EV-053)   |
 | FR-028-AC-12 | Strategy selection reads `property` and is unchanged by any `shape` value                                               | Inspection      |
 
 > **CR-001 note (2026-08-13):** This requirement shipped in

--- a/spec/functional/FR-038-generate-fuzz-harnesses.md
+++ b/spec/functional/FR-038-generate-fuzz-harnesses.md
@@ -91,24 +91,24 @@ header.
 
 | ID | Criteria | Verification |
 |----|----------|--------------|
-| FR-038-AC-1 | Obligations are selected by their method's `evidence_kind: Fuzz`, read from the catalog. | Eval (TC-EV-054) |
-| FR-038-AC-2 | An emitted target calls an entry point that exists in the repository's source. | Eval (TC-EV-054) |
-| FR-038-AC-3 | An obligation whose entry point cannot be grounded yields a finding and no file. | Eval (TC-EV-055) |
-| FR-038-AC-4 | Absent fuzz tooling yields one finding per obligation and no file, and nothing is installed. | Eval (TC-EV-055) |
-| FR-038-AC-5 | Every emitted target carries both trace carriers and a provenance line. | Eval (TC-EV-054) |
-| FR-038-AC-6 | A re-run with unchanged inputs rewrites nothing. | Eval (TC-EV-056) |
-| FR-038-AC-7 | The harness is chosen from the repository's manifest, never from the requirement's language. | Eval (TC-EV-056) |
-| FR-038-AC-8 | Generated targets are reported as undischarged until a run is recorded. | Eval (TC-EV-057) |
-| FR-038-AC-9 | The skill emits no verdict, grade or threshold, and never rewords a requirement. | Eval (TC-EV-057) |
+| FR-038-AC-1 | Obligations are selected by their method's `evidence_kind: Fuzz`, read from the catalog. | agent-behaviour-eval (TC-EV-054) |
+| FR-038-AC-2 | An emitted target calls an entry point that exists in the repository's source. | agent-behaviour-eval (TC-EV-054) |
+| FR-038-AC-3 | An obligation whose entry point cannot be grounded yields a finding and no file. | agent-behaviour-eval (TC-EV-055) |
+| FR-038-AC-4 | Absent fuzz tooling yields one finding per obligation and no file, and nothing is installed. | agent-behaviour-eval (TC-EV-055) |
+| FR-038-AC-5 | Every emitted target carries both trace carriers and a provenance line. | agent-behaviour-eval (TC-EV-054) |
+| FR-038-AC-6 | A re-run with unchanged inputs rewrites nothing. | agent-behaviour-eval (TC-EV-056) |
+| FR-038-AC-7 | The harness is chosen from the repository's manifest, never from the requirement's language. | agent-behaviour-eval (TC-EV-056) |
+| FR-038-AC-8 | Generated targets are reported as undischarged until a run is recorded. | agent-behaviour-eval (TC-EV-057) |
+| FR-038-AC-9 | The skill emits no verdict, grade or threshold, and never rewords a requirement. | agent-behaviour-eval (TC-EV-057) |
 
 ## Constraints
 
 | ID | Constraint | Type | Validation |
 |----|-----------|------|------------|
-| FR-038-CON-1 | The skill SHALL NOT declare which methods are fuzz methods. That is the catalog's, read at run time. | Design | Eval (TC-EV-054) |
-| FR-038-CON-2 | The skill SHALL NOT install tooling, add a dependency, or scaffold a fuzz workspace. | Design | Eval (TC-EV-055) |
-| FR-038-CON-3 | The skill SHALL NOT treat an emitted target as evidence. Discharge requires a recorded run. | Design | Eval (TC-EV-057) |
-| FR-038-CON-4 | The skill SHALL NOT write a framework name into `spec/**` (inherited, FR-028-CON-2). | Design | Eval (TC-EV-056) |
+| FR-038-CON-1 | The skill SHALL NOT declare which methods are fuzz methods. That is the catalog's, read at run time. | Design | agent-behaviour-eval (TC-EV-054) |
+| FR-038-CON-2 | The skill SHALL NOT install tooling, add a dependency, or scaffold a fuzz workspace. | Design | agent-behaviour-eval (TC-EV-055) |
+| FR-038-CON-3 | The skill SHALL NOT treat an emitted target as evidence. Discharge requires a recorded run. | Design | agent-behaviour-eval (TC-EV-057) |
+| FR-038-CON-4 | The skill SHALL NOT write a framework name into `spec/**` (inherited, FR-028-CON-2). | Design | agent-behaviour-eval (TC-EV-056) |
 
 ## Dependencies
 

--- a/spec/log.md
+++ b/spec/log.md
@@ -8,6 +8,15 @@ description: "Chronological log of structural changes to this bundle."
 
 ## History
 
+* **2026-08-19** — **CR-022**: the verification cells name a **method**, not an evidence kind — closing `SR-008` FND-002 (agent-ix/quoin#142).
+
+  `quire coverage` reported *"'Eval' is neither a declared verification_catalog method id nor a declared class, so nothing can say what discharging it means"* over **19 rows**, and the finding was filed proposing a new catalog entry. Checking before building it showed the proposal was wrong: `spec-artifacts-process` **already declares** `agent-behaviour-eval` — *"Drive a real agent through a scenario and score the transcript against the criterion"* — with `evidence_kind: Eval`.
+
+  So `Eval` is an evidence **kind**, and the criteria tables were writing a kind where a method or class belongs. `Eval` remains correct in the matrix's `Type` column, which is the `test_type` vocabulary; the slip was only in `Verification`. FR-028's eleven cells and FR-038's thirteen now read `agent-behaviour-eval (TC-EV-nnn)`, and NFR-005's one `Review` metric reads `Inspection`, which is the declared class.
+
+  **Coverage diagnostics: 20 → 0.** Nothing was added to any module; the vocabulary was already there and the specs were not using it. Worth recording as the third time this program has found a "missing capability" that turned out to be a capability nobody was reaching — after quire-cli lagging five releases and `vocabulary_coverage` being declared nowhere.
+
+
 * **2026-08-19** — **CR-021**: new [FR-042](./functional/FR-042-agent-eval-evidence.md) — **agent-eval reports as run evidence**, closing the first half of `SR-008` FND-001 (agent-ix/quoin#142).
 
   An eval drives the real agent through the real CLI, which makes it the most convincing verification this project has and, until now, the least recorded. `quire coverage` reconciles matrix rows against test symbols in code; eval scenarios are data and mint none, so **71 rows** across `spec/evals.md`, `FR-028` and `FR-038` were unbacked. For FR-038 the evals had been run — four scenarios, 4/4, live, with two genuine failures found and fixed — and the harness's report was written to disk and dropped.

--- a/spec/non-functional/NFR-005-catalog-driven-workflows.md
+++ b/spec/non-functional/NFR-005-catalog-driven-workflows.md
@@ -32,7 +32,7 @@ catalog keeps the vocabulary singular and maintainable.
 
 | Metric                                                              | Target | Threshold | Method |
 | ------------------------------------------------------------------- | ------ | --------- | ------ |
-| Workflow-defined doc/object types that duplicate catalog vocabulary | 0      | 0         | Review |
+| Workflow-defined doc/object types that duplicate catalog vocabulary | 0      | 0         | Inspection |
 
 ## Verification
 


### PR DESCRIPTION
Closes `SR-008` FND-002. **Coverage diagnostics: 20 → 0.**

## The finding, and why my proposed fix was wrong

`quire coverage` reported:

```
'Eval' is neither a declared verification_catalog method id nor a declared class,
so nothing can say what discharging it means (19 rows, first in FR-028)
```

I filed #142 proposing **a new catalog entry** for agent evaluation. Checking before building it showed that was wrong.

`spec-artifacts-process` **already declares** it:

```yaml
agent-behaviour-eval:
  name: Agent-behaviour evaluation
  class: Demonstration
  definition: >-
    Drive a real agent through a scenario and score the transcript against the
    criterion, for a requirement whose subject is an agent's behaviour.
  evidence_kind: Eval
```

So `Eval` is an evidence **kind**, and the criteria tables were writing a kind where a method or class belongs. Nothing was missing — the vocabulary was there and the specs were not using it.

## The change

| File | Was | Now |
|---|---|---|
| FR-028 | 11 cells `Eval (TC-EV-nnn)` | `agent-behaviour-eval (TC-EV-nnn)` |
| FR-038 | 13 cells `Eval (TC-EV-nnn)` | `agent-behaviour-eval (TC-EV-nnn)` |
| NFR-005 | one metric `Review` | `Inspection` — the declared class |

`Eval` stays correct in the matrix's **Type** column: that is the `test_type` vocabulary, a different thing. The slip was only in `Verification`.

## Why this is worth recording

Third time in this program that a "missing capability" turned out to be a capability nobody was reaching:

1. `quire-cli` five releases behind, so FR-057..061 were unreachable from any command line
2. `vocabulary_coverage` shipped in the engine and declared by no module
3. `agent-behaviour-eval` declared in the catalog and named by no spec

Each presented as absence. Each was a join nobody had made.

## Gates

- `make build` ✅ 0 type errors
- `make test` ✅ **442 passed**
- `make lint` ✅
- `quire validate` ✅ clean
- `quire coverage` ✅ **zero diagnostics** (the key is absent entirely)

Log: CR-022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)