### PR TITLE
chore: stage v0.19.0 — ADR-0011 Phase 2 waves D and E

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
Two landing failures, both caught by `release-drift`.

## The plugin manifests were stale by a whole release

```
.claude-plugin/plugin.json declares version 0.17.0 but the latest tag is v0.18.0
.codex-plugin/plugin.json  declares version 0.17.0 but the latest tag is v0.18.0
```

Hosts key their plugin cache on that number. **Every installer has been sitting on the 0.17.0 tree** — none of waves B, C or D reached anyone who installed the plugin, tag or no tag.

This is precisely the freeze the plugin-manifest rule exists to prevent, and v0.18.0 shipped straight past it. Both files now read `0.19.0`.

## Eleven commits were unreleased

Waves D and E have been on `main` and in no tag:

| | |
|---|---|
| FR-036 | architecture conformance as a declared method |
| FR-037 | declared-vocabulary completeness + `quoin completeness` |
| FR-038 | the `spec-fuzz` skill |
| FR-039 | mutation score as a declared threshold |
| FR-040 | assurance-case view + `quoin assurance` |
| FR-041 | SBOM inventories as run evidence |
| FR-042 | agent-eval reports as run evidence |

Plus both review gates (`SR-007`, `SR-008`) and their fixes, and CR-022 clearing the last coverage diagnostics.

## Verification

- module pins: **9 current, 0 behind, 0 unresolved**
- `make build` ✅ 0 type errors
- `make test` ✅ **442 passed**
- `make lint` ✅
- `quire validate` ✅ · `quire coverage` ✅ zero diagnostics
- no local/snapshot dependency pins — all upstream ranges

Tag and `release.yml` dispatch follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)