### PR TITLE
fix(ci): install the engine under test, so the release gate can run

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "zod": ">=4.4.3"
   },
   "devDependencies": {
+    "@agent-ix/quire-cli": "^0.23.0",
     "@types/node": "26.1.2",
     "@typescript-eslint/eslint-plugin": "8.66.0",
     "@typescript-eslint/parser": "8.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: '>=4.4.3'
         version: 4.4.3
     devDependencies:
+      '@agent-ix/quire-cli':
+        specifier: ^0.23.0
+        version: 0.23.0
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -89,6 +92,31 @@ packages:
 
   '@agent-ix/ix-ui-semantic@0.4.10':
     resolution: {integrity: sha512-kjDiorrEnWRJlSrQvLiNC+wblBwwZtXcesBD/9KhtOAMGt6WBHMjTr2Ae8iepzcZ6lqsPk1m3EY5YQmoOeVurw==}
+
+  '@agent-ix/quire-cli-darwin-arm64@0.23.0':
+    resolution: {integrity: sha512-JrKG1QHWy1+DZtX5nRMBuB70oOiQCgTFXrATSJSLOd76+QFEOEbPDNt8DsCMOBTUH5uDIfyvdop32ti5wFB7GA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@agent-ix/quire-cli-linux-arm64@0.23.0':
+    resolution: {integrity: sha512-Nr3L8ebB5MCR4cGW0fdRtk5VPo2NqRk8Pbr1lk3YFJ17pzGRyMf0jtjmCrAPGyaA0GVWLorpHkNSYnJfy6KFog==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@agent-ix/quire-cli-linux-x64@0.23.0':
+    resolution: {integrity: sha512-sPavCi5vSA14/nwf9k6/Bd9R773z9/rrVr7L9BtVwWxKn6ZkSKvsGJTODlJFokQ43fhANmY2r8lFgijJIoN4hg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@agent-ix/quire-cli-win32-x64@0.23.0':
+    resolution: {integrity: sha512-2r07VAE0TGDPt0xU35E/nySeq+ri+1NAcflGMl0mURwXgoymEPjRQboPsV1fbR0GwWBxTerpvw9ZISrNFsiY9Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@agent-ix/quire-cli@0.23.0':
+    resolution: {integrity: sha512-DPq8taCybz0LHdcg0UppUKVIU7cIhL9OCpvvZoYxX0k4nZ8JarBZWlIq8m1yZh+zWr067H0BrSxnPqz1mMfxMw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   '@agent-ix/ts-plugin-kit@0.2.0':
     resolution: {integrity: sha512-ujqG/CnzyGxP1AAbqutb5OZnDcQbKDjXtPaiZPzLAZv7Kf8NWRA6H5FdHpebJy37vLatG0+tZDO4vjIR19INNw==}
@@ -1804,6 +1832,25 @@ snapshots:
       - utf-8-validate
 
   '@agent-ix/ix-ui-semantic@0.4.10': {}
+
+  '@agent-ix/quire-cli-darwin-arm64@0.23.0':
+    optional: true
+
+  '@agent-ix/quire-cli-linux-arm64@0.23.0':
+    optional: true
+
+  '@agent-ix/quire-cli-linux-x64@0.23.0':
+    optional: true
+
+  '@agent-ix/quire-cli-win32-x64@0.23.0':
+    optional: true
+
+  '@agent-ix/quire-cli@0.23.0':
+    optionalDependencies:
+      '@agent-ix/quire-cli-darwin-arm64': 0.23.0
+      '@agent-ix/quire-cli-linux-arm64': 0.23.0
+      '@agent-ix/quire-cli-linux-x64': 0.23.0
+      '@agent-ix/quire-cli-win32-x64': 0.23.0
 
   '@agent-ix/ts-plugin-kit@0.2.0': {}
 


### PR DESCRIPTION
quoin's release CI has been red since the command-level tests landed. **`publish` was skipped on both v0.18.0 and v0.19.0.**

```
Error: could not determine the quire CLI version (expected >= 0.21.0).
Install or update quire-cli: the JSON contract quoin reads is only emitted from 0.21.0 onward.
```

CI had **no `quire` binary at all**, so every test that reaches the engine — the command-level ones the P1 review demanded, which are the entire point of that review — could not run there. They passed locally only because quire is on my PATH.

## The fix

`@agent-ix/quire-cli` is now a devDependency. CI gets the real engine from the lockfile rather than from whatever happens to be installed, and the local run becomes deterministic too: `node_modules/.bin/quire` shadows PATH, so a developer and CI test the same binary.

## Why `^0.23.0` and not `>=0.22.0`

TC-118 caught the difference. It validates a payload from the **installed** quire against the pinned schema, and against 0.22.0 it failed:

```
FAIL tests/quire-contract.test.ts > TC-118 the contract holds against the installed quire
  > a real `quire properties --json` payload validates against the pinned schema
```

0.22.0 predates the FR-055 contract quoin reads. **The test was right — the published engine really was too old.**

## What it took to get 0.23.0 published

`quire-cli` v0.23.0 was tagged, its workflow reported **success**, and nothing reached npm:

```
built @agent-ix/quire-cli-linux-x64@0.23.0
synced launcher @agent-ix/quire-cli@0.23.0
Post job cleanup.
```

`npm publish` is gated on `if: inputs.publish`, **default false**. A dispatch without it builds all four platform packages, syncs the launcher, and reports green having published nothing — a release that is indistinguishable from a real one and does nothing.

The workflow's own header comments describe this exact failure happening before. `0.23.0` is now on npm.

## Gates

- `make build` ✅
- `make test` ✅ **442 passed**, against quire 0.23.0 resolved from `node_modules`
- `make lint` ✅

Once this merges, quoin's v0.19.0 release can be re-dispatched and will actually publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)