### PR TITLE
chore: stage v0.19.1 — the release gate can run

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
v0.19.0 was tagged before the CI fix (#148) and would fail at `ci / test` the same way. Tags are never moved, so this bumps.

Plugin manifests follow the new tag, so installers are not left keyed to a version that never published — the freeze #147 fixed.

- `make test` ✅ 442 passed against quire 0.23.0 from `node_modules`
- `release-drift pins` ✅ 9 current, 0 behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)