### PR TITLE
fix(tests): materialize the default modules before the suite runs

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,46 @@
+/**
+ * Materialize the default module set before any test runs.
+ *
+ * **Why this exists.** Several tests exercise `quoin evidence record` and
+ * `quoin advise` end to end, which shell out to `quire coverage`. That needs a
+ * module declaring a `traceability:` model, and quire reads the installed set
+ * from `~/.ix/filament/modules`.
+ *
+ * On a developer machine those modules are already there, so the tests passed
+ * locally for months. In CI they are not, and every command-level test failed:
+ *
+ * ```
+ * quire coverage --scope /tmp/quoin-adapters-… --json exited 1:
+ * SearchPathMissing: /home/runner/.ix/filament/modules
+ * no module in scope declares a `traceability:` model
+ * ```
+ *
+ * That took `publish` down with it on v0.18.0 and v0.19.0 — the release gate had
+ * been red since the command-level tests landed, and nothing noticed because the
+ * suite runs on `workflow_dispatch` only.
+ *
+ * Installing here rather than in the workflow is deliberate: the release
+ * workflow is a reusable one in another repository, so a fix there would not
+ * travel with this repository's own tests. This makes the suite self-sufficient
+ * wherever it runs.
+ *
+ * Idempotent — `ensureDefaultModules` reconciles in `lazy` mode rather than
+ * reinstalling, so a developer's existing modules are left alone.
+ */
+
+import { ensureDefaultModules } from "../src/modules.js";
+
+export default async function setup(): Promise<void> {
+  try {
+    ensureDefaultModules();
+  } catch (cause) {
+    // Reported, never swallowed. A failure here means the command-level tests
+    // are about to fail for a reason that has nothing to do with the code under
+    // test, and the operator needs to see which.
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      `could not materialize the default module set, so the command-level ` +
+        `tests cannot run: ${reason}`,
+    );
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,10 @@ export default defineConfig(({ command }) => ({
   test: {
     globals: true,
     environment: "node",
+    // The command-level tests shell out to `quire coverage`, which needs an
+    // installed module declaring a `traceability:` model. Present on a
+    // developer machine, absent in CI — see tests/global-setup.ts.
+    globalSetup: ["tests/global-setup.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,js}"],


### PR DESCRIPTION
With quire installed (#148), CI got past *"no quire binary"* and hit the next layer:

```
quire coverage --scope /tmp/quoin-adapters-… --json exited 1:
SearchPathMissing: /home/runner/.ix/filament/modules
no module in scope declares a `traceability:` model
```

The command-level tests shell out to `quire coverage`, which needs an installed module declaring a traceability model. On a developer machine those are already there — **so the tests passed locally for months** and failed every time CI ran them.

## The fix

A vitest `globalSetup` reconciles the default set before anything runs.

Installing here rather than in the workflow is deliberate: the release workflow is a **reusable one in another repository**, so a fix there would not travel with this repository's own tests.

Idempotent — `ensureDefaultModules` reconciles in lazy mode, so a developer's existing modules are untouched. A failure is rethrown with what it was attempting, never swallowed: it means the command-level tests are about to fail for a reason unrelated to the code under test, and the operator needs to see which.

## Why it went unseen

The suite runs on `workflow_dispatch` only. The first time anyone saw it was a release — and **a release that fails looks a lot like a release nobody ran.**

Gates: build ✅ · 442 tests ✅ · lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)