### PR TITLE
chore: stage v0.19.2 — past both CI blockers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",


### PR DESCRIPTION
v0.19.1 predates the module-setup fix (#150) and would fail at `ci / test` the same way. Tags are never moved, so this bumps.

Both CI blockers are now on main: quire installed as a devDependency (#148), default modules materialized by vitest globalSetup (#150).