### PR TITLE
feat(evidence): bind through an obligation's declared test cases (CR-023, #144)

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -10,13 +10,13 @@ schemaVersion: 1
 name: quoin-default-modules
 entries:
   - name: spec-artifacts-iso
-    version: "0.15.0"
+    version: "0.16.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-iso
       path: spec_artifacts_iso
-      ref: v0.15.0
+      ref: v0.16.0
 
   - name: spec-artifacts-app
     version: "0.5.0"
@@ -28,13 +28,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.18.0"
+    version: "0.19.0"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: v0.18.0
+      ref: v0.19.0
 
   - name: spec-objects-business
     version: "0.6.0"

--- a/reviews/26-08-19-iso-24495-adoption-report.md
+++ b/reviews/26-08-19-iso-24495-adoption-report.md
@@ -1,0 +1,248 @@
+---
+id: SR-009
+title: "Adoption report — ISO 24495 plain-language tooling"
+type: Review
+analysis: adoption-analysis
+scope: "GaZmagik/iso-24495, quire-rs lint and grammar surfaces, quire-cli lint, spec-artifacts-iso module"
+review_set: full
+---
+
+## Summary
+
+`iso-24495` is worth adopting as a source of language-quality rules, parser fixtures,
+and audit workflow ideas. It should not become a second document engine in the Quoin
+ecosystem.
+
+Its executable engine is TypeScript run with Bun. It is a deterministic, hard-coded
+plain-language audit over reader-visible Markdown blocks. It is not Rust, does not
+understand Quire archetypes or extraction contracts, and does not provide Quire's
+module-driven rule extension model.
+
+The recommended architecture is:
+
+```text
+quire-rs Markdown parser and AST
+        ↓
+reader-prose block view
+        ↓
+typed language rules + module language profile
+        ↓
+existing Quire lint findings and corpus reports
+        ↓
+quire-cli, Quoin review skills, and ISO module authoring guidance
+```
+
+## What the external repository contains
+
+The repository ships six agent skills. Parts 1–3 provide core, legal, and technical
+writing guidance. Part 4 provides a provisional organisational implementation audit.
+Part 5 provides provisional document-design guidance. The text-audit skill is an
+explicitly invoked audit over selected Markdown or text paths.
+
+The implementation worth studying is the shared Part 4/text-audit engine:
+
+- a custom reader-oriented Markdown block parser;
+- exclusions for front matter, fenced or indented code, tables, task markers, and
+  alert labels;
+- deterministic rules for sentence length and averages, paragraph density, headings,
+  undefined acronyms, legalese, doublets, wordy phrases, complex words, double
+  negatives, filler openings, link text, image alternative text, and prose lists;
+- project-specific acronym configuration;
+- stable `{rule, line, detail}` findings, per-rule totals, skipped-entry reporting,
+  and a configuration hash;
+- a substantial CommonMark-shaped fixture corpus and robustness tests.
+
+The project itself labels its quantitative thresholds as proxies rather than ISO
+clauses. Parts 4 and 5 are provisional drafts, and the repository makes no ISO
+conformance claim. See the [upstream README](https://github.com/GaZmagik/iso-24495)
+and the [Part 4 skill](https://raw.githubusercontent.com/GaZmagik/iso-24495/main/skills/iso-24495-4/SKILL.md).
+
+## Current integration points
+
+Quire already has the right boundaries:
+
+| Existing surface                | Evidence                                              | Integration use                                                         |
+| ------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| Markdown parser and section AST | `quire-rs/src/parser/`, `quire-rs/src/ast.rs`         | Supply structural context and source locations.                         |
+| Declarative advisory lint       | `quire-rs/src/lint.rs`                                | Add typed prose rules without changing validation semantics.            |
+| Requirement grammar             | `quire-rs/src/grammar/`                               | Keep EARS and requirement-quality checks separate from reader prose.    |
+| Module registry                 | `quire-rs/src/registry.rs`                            | Merge language profiles, vocabulary, and severity once per registry.    |
+| CLI lint command                | `quire-cli/src/commands/lint.rs`                      | Expose per-document findings through the existing stderr/JSON contract. |
+| ISO module manifest             | `spec-artifacts-iso/spec_artifacts_iso/manifest.yaml` | Declare artifact scope, vocabulary, thresholds, and default severity.   |
+| Quoin workflows                 | `quoin/skills/`                                       | Apply authoring and review guidance; aggregate corpus findings.         |
+
+The ISO module already declares advisory lint rules for verification-method values,
+forbidden user-story sections, and normative wording. Its manifest also carries
+`lexicon`, `grammar_severity`, `property_idioms`, `observable_verbs`,
+`vacuous_predicates`, and `ambiguity_terms`. A language profile is a natural extension
+of this existing model.
+
+## Adoption matrix
+
+| Feature                                           | Decision                                                         | Owner                   | Priority |
+| ------------------------------------------------- | ---------------------------------------------------------------- | ----------------------- | -------- |
+| Reader-prose block view                           | Adopt the design and representative fixtures; implement in Rust  | `quire-rs`              | P1       |
+| Sentence, paragraph, and heading rules            | Adopt as warning-level typed rules                               | `quire-rs` + ISO module | P1       |
+| Acronym and terminology handling                  | Adopt; merge with module lexicon and project glossary            | `quire-rs` + modules    | P1       |
+| Wordy phrases, doublets, filler, double negatives | Adopt selectively after corpus precision sampling                | `quire-rs`              | P2       |
+| Link text and image alternative text              | Adopt for rendered/public documents                              | `quire-rs` + Quoin      | P2       |
+| Document-design checks                            | Adopt as Quoin authoring/review guidance first                   | `quoin`                 | P2       |
+| Part 4 evidence sweep and maturity model          | Adapt for Quoin organisational review, not core Quire validation | `quoin`                 | P3       |
+| External TypeScript engine                        | Do not embed or invoke as a Quire dependency                     | —                       | —        |
+| Fixed ISO 24495 thresholds                        | Do not make global or normative                                  | —                       | —        |
+| Legal profile's banned `shall` rule               | Do not apply to ISO requirement artifacts                        | —                       | —        |
+
+## Proposed Quire language profile
+
+The profile should be typed data, not a collection of arbitrary regular expressions.
+The existing generic `lint_rules` list can remain for local table and section rules.
+Language rules need a separate manifest block because they operate on prose blocks,
+headings, links, and vocabulary rather than one section/table locator.
+
+Illustrative shape:
+
+```yaml
+language_profile:
+  locale: en
+  rules:
+    sentence_length:
+      max_words: 30
+      severity: warning
+    sentence_average:
+      min_sentences: 10
+      max_words: 20
+      severity: warning
+    heading_skip:
+      severity: warning
+    undefined_acronym:
+      severity: warning
+  acronyms: [API, CLI, EARS, ISO, NFR]
+```
+
+The exact key can change. The important properties are typed rule identifiers,
+explicit thresholds, module merge semantics, and severity keys that follow the
+existing `off`/`warning`/`error` model.
+
+The engine should expose a narrow API similar to:
+
+```text
+language_lint(document, profile, scope) -> Vec<LintFinding>
+```
+
+Each finding should carry at least:
+
+```text
+rule, severity, line, column?, section?, message, replacement_hint?
+```
+
+`replacement_hint` should remain optional and advisory. The first version should not
+rewrite prose automatically.
+
+## Scope rules for ISO artifacts
+
+The external engine audits general reader prose. ISO artifacts need more precise
+scope:
+
+- audit `Description`, `Statement`, `Stakeholder Need`, `Rationale`, explanatory
+  sections, and prose-bearing acceptance-criteria cells;
+- audit headings for depth and skips, but preserve artifact identifiers and exact
+  section names;
+- preserve front matter, code blocks, commands, logs, IDs, verification-method cells,
+  and exact protocol or API names;
+- treat table cells as optional prose targets rather than blindly excluding every
+  table, because acceptance criteria are often authored there;
+- use the project glossary and module vocabulary to suppress known technical terms;
+- keep `shall` valid for ISO/IEC/IEEE 29148 normative requirements;
+- keep legalese rules opt-in and scoped to legal/compliance document types;
+- keep English-only rules disabled or explicitly reported for other locales.
+
+This prevents a language rule from contradicting the ISO module's existing
+`fr-shall-language` and `nfr-shall-language` advisories.
+
+## Division of responsibility
+
+### `quire-rs`
+
+Implement the reader-prose view, typed rule evaluators, source locations, and
+deterministic findings. Compile module vocabulary and rule configuration once in the
+registry, as the current grammar and lexicon matchers do.
+
+Do not put plain-language heuristics into the EARS grammar. Requirement grammar asks
+whether a normative statement is checkable. Language lint asks whether a reader can
+find, understand, and act on it. The findings have different meanings and should
+remain independently configurable.
+
+### `quire-cli`
+
+Keep `quire lint <DOC> --module <PATH>` as the per-document entry point. Prose rules
+should appear through the same diagnostic stream and JSON format, with warning-level
+defaults. A later corpus mode can aggregate the same findings without introducing a
+second parser or output schema.
+
+Structural validation must remain independent. A language finding must never make a
+document unextractable or alter writeback behavior.
+
+### `spec-artifacts-iso`
+
+Declare the first language profile for FR, NFR, StR, and US. Start with rules that
+have clear artifact value: heading skips, sentence-length advisories, undefined
+acronyms, and selected wordy phrases. Keep all new rules at `warning` until a corpus
+baseline and sampled precision review support promotion.
+
+Use the existing module lexicon and glossary machinery rather than introducing an
+unrelated acronym file format. If acronym definitions need richer metadata, add a
+typed vocabulary registry rather than a list of exceptions.
+
+### `quoin`
+
+Add language quality to `spec-review` and authoring guidance. The review workflow
+should report findings with file, line, rule, and reader impact. It should distinguish
+mechanical proxy findings from semantic review and never call zero findings “ISO
+compliant.”
+
+Adapt the Part 4 evidence and trend concepts for repository-level review: record the
+profile version, configuration hash, corpus denominator, finding totals, and trend
+over time. Do not make organisational maturity a hidden side effect of `quire lint`.
+
+## Validation and rollout gates
+
+The local Quire guidance already requires measurement before changing a check. Apply
+that discipline here:
+
+1. Port the reader-prose fixtures and add Rust parser parity tests.
+2. Run the initial rules against the local specification corpus.
+3. Sample flagged documents and classify each finding as rule error or real corpus
+   debt.
+4. Record the configuration hash, denominator, counts, and precision split.
+5. Ship findings as warnings.
+6. Unify the corpus or tune the rule for semantic reasons, never merely to reduce
+   the count.
+7. Promote a rule only after explicit user or module-owner sign-off.
+
+The external project's deterministic output, skipped-entry reporting, and append-only
+trend state are useful models. Quire should express them through its existing typed
+diagnostics and corpus reports rather than copying the external JSON format wholesale.
+
+## Recommended first slice
+
+The first implementation should be one vertical slice:
+
+1. Add a Rust reader-prose block view with code/front matter/list/quote handling.
+2. Add `sentence_length`, `heading_skip`, and `undefined_acronym` typed rules.
+3. Add the ISO module's language profile with warning severity and project acronyms.
+4. Run it through `quire lint` and JSON diagnostics.
+5. Add a Quoin review adapter that groups findings by document and rule.
+6. Measure the corpus before adding legalese, complex-word, or automated rewrite rules.
+
+This slice proves the extension boundary and reporting contract. It does not commit
+the ecosystem to every heuristic in `iso-24495`.
+
+## Final recommendation
+
+Adopt `iso-24495` as a design and fixture source for a Quire-native language-lint
+pack. Adopt its reader-aware parsing boundary, deterministic audit contract,
+project vocabulary, explicit limitations, and evidence-based rollout. Keep the
+implementation in Rust, the policy in modules, and the workflow/reporting in Quoin.
+
+Do not install the external Bun engine inside Quire, do not treat its thresholds as
+ISO requirements, and do not apply its legal-writing rules to ISO requirement prose.

--- a/spec/functional/FR-030-evidence-store.md
+++ b/spec/functional/FR-030-evidence-store.md
@@ -111,6 +111,31 @@ clear itself on the next CI run and the detector would never fire.
 | FR-030-CON-2 | The store SHALL NOT persist an obligation's statement, document or method — only its id and hash. Anything re-derivable is re-derived, so the store cannot disagree with the spec. | Architecture | Test |
 | FR-030-CON-3 | The store SHALL NOT contain a database or a derived index. Files only. | Architecture | Inspection |
 
+### A tool reports the id it knows
+
+A unit test carries the criterion's own id, because the tag is written in the
+test. An **agent-eval report — and any tool keyed on the Test Matrix — carries
+the test case id**: `TC-EV-057`, not `FR-038-AC-8`.
+
+Both are stated by the same criteria row (`Eval (TC-EV-057)`), and quire-rs
+FR-053-AC-11 carries that join on the obligation. The store resolves it rather
+than re-parsing the criteria table, which is the duplication FR-050 exists to
+prevent.
+
+Before this, `quoin evidence record --adapter agent-eval` reported `bound: 0`
+and `unmatched trace ids … TC-EV-057` while the join sat in the FR's own table
+(agent-ix/quoin#144). 71 matrix rows across `spec/evals.md`, FR-028 and FR-038
+were unbacked for want of it.
+
+**A direct obligation id wins.** If a criterion's cell named a sibling
+criterion's id, binding through the indirect route would report a discharge
+nobody stated directly, so the indirect route is not registered for an id that
+is itself an obligation.
+
+**A test case discharging several criteria binds all of them.** The row says
+each is verified by that test case; binding only the first would leave the rest
+undischarged with the evidence sitting right there.
+
 ## Acceptance Criteria
 
 | ID | Criteria | Verification |
@@ -129,6 +154,7 @@ clear itself on the next CI run and the detector would never fire.
 | FR-030-AC-12 | The **latest** run of a suite is the newest by `timestamp`, never the lexicographically last filename: a run filename is a commit prefix, which carries no time. `gc` retains that run, and the auditor reads it. Two runs sharing a timestamp order by commit, so a tie resolves the same way on every machine. | Test (TC-130) |
 | FR-030-AC-13 | A store file that exists and is not readable JSON raises a diagnostic naming the file and the cause, never a bare `SyntaxError`. One unreadable **run** file is skipped and reported rather than fatal; the binding graph and the baseline are not, because reading an empty graph would report every obligation as undischarged. | Test (TC-131) |
 | FR-030-AC-14 | Store ordering is locale-independent: written bytes are pinned by test, so a runtime's collation data cannot change the diff of a checked-in file. | Test (TC-132) |
+| FR-030-AC-15 | A run's trace id binds through an obligation's declared test cases as well as its own id, so a tool keyed on the Test Matrix discharges the criteria that name it. A direct obligation id wins over the indirect route, and an id no obligation states by either route is still reported unmatched. | Test (TC-245) |
 
 ## Dependencies
 

--- a/spec/log.md
+++ b/spec/log.md
@@ -8,6 +8,14 @@ description: "Chronological log of structural changes to this bundle."
 
 ## History
 
+* **2026-08-19** — **CR-023**: a run binds through an obligation's declared **test cases**, not only its own id (FR-030-AC-15, TC-245). Closes agent-ix/quoin#144.
+
+  A tool reports the id it knows. A unit test carries the criterion's own id because the tag is written in the test; an **agent-eval report — and any tool keyed on the Test Matrix — carries the test-case id**. Both are stated by the same criteria row, `Eval (TC-EV-057)`, and quire-rs FR-053-AC-11 (v0.35.0) now carries that join on the obligation, so the store resolves it rather than re-parsing the criteria table — the duplication FR-050 exists to prevent.
+
+  Before this, `quoin evidence record --adapter agent-eval` reported `bound: 0` and `unmatched trace ids … TC-EV-057` while the join sat in the FR's own table. 71 matrix rows across `spec/evals.md`, FR-028 and FR-038 were unbacked for want of it.
+
+  Two rules the tests pin rather than leave implied. **A direct obligation id wins**: if a criterion's cell named a sibling criterion's id, the indirect route would report a discharge nobody stated directly. **A test case discharging several criteria binds all of them**, because the row says each is verified by that test case and binding only the first leaves the rest undischarged with the evidence sitting right there.
+
 * **2026-08-19** — **CR-022**: the verification cells name a **method**, not an evidence kind — closing `SR-008` FND-002 (agent-ix/quoin#142).
 
   `quire coverage` reported *"'Eval' is neither a declared verification_catalog method id nor a declared class, so nothing can say what discharging it means"* over **19 rows**, and the finding was filed proposing a new catalog entry. Checking before building it showed the proposal was wrong: `spec-artifacts-process` **already declares** `agent-behaviour-eval` — *"Drive a real agent through a scenario and score the transcript against the criterion"* — with `evidence_kind: Eval`.

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -375,6 +375,7 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-242 | The outcome is the harness's `ok` over `repeats`, and `passRate` is kept because flaky and failing are different facts | Unit | P0 | FR-042-AC-3 | ✅ |
 | TC-243 | A report with no scenario results is refused — it proves only that the harness started | Unit | P0 | FR-042-AC-4 | ✅ |
 | TC-244 | The adapter is selected by `--adapter agent-eval` and by the harness name | Unit | P0 | FR-042-AC-5 | ✅ |
+| TC-245 | A run's trace id binds through an obligation's declared test cases — several criteria per case, a direct id winning over the indirect route, and an id nobody states still reported unmatched | Unit | P0 | FR-030-AC-15 | ✅ |
 | TC-129 | The merged catalog carries every declared method with its rules intact, merges first-wins, reports a colliding id rather than absorbing it, and treats an undeclared catalog as empty | Unit | P0 | FR-031-AC-1 | ✅ |
 | TC-130 | An `attack_surface` object reaches DAST, SAST and negative/abuse testing — recommendations that were unreachable while the method table was skill-local prose | Unit | P0 | FR-031-AC-2 | ✅ |
 | TC-131 | Temporal phrasing reaches runtime monitoring and model checking — the methods a single execution cannot discharge | Unit | P0 | FR-031-AC-3 | ✅ |

--- a/src/evidence/record.ts
+++ b/src/evidence/record.ts
@@ -72,6 +72,31 @@ export function recordRun(request: RecordRequest): RecordOutcome {
   });
 
   const byId = new Map(request.obligations.map((o) => [o.id, o]));
+  /**
+   * Test-case id → the obligations whose method cell names it.
+   *
+   * A tool reports the id it knows. A unit test carries the criterion's own id
+   * because the tag is written in the test; an agent-eval report and any other
+   * tool keyed on the Test Matrix carries the **test case** id. Both are stated
+   * by the same criteria row — `Eval (TC-EV-057)` — and quire-rs FR-053-AC-11
+   * carries that join on the obligation, so this resolves it rather than
+   * re-parsing the table (agent-ix/quoin#144).
+   *
+   * A test case may discharge several criteria, so the value is a list. Binding
+   * one run to all of them is correct: the row says each of those criteria is
+   * verified by that test case.
+   */
+  const byTarget = new Map<string, Obligation[]>();
+  for (const obligation of request.obligations) {
+    for (const target of obligation.target_ids ?? []) {
+      // An id that is ALSO an obligation id stays an obligation id. Otherwise a
+      // criterion naming a sibling criterion would silently bind through the
+      // indirect route and report a discharge nobody stated directly.
+      if (byId.has(target)) continue;
+      byTarget.set(target, [...(byTarget.get(target) ?? []), obligation]);
+    }
+  }
+
   /** Obligation id → the symbols in this run that carry it. */
   const discharged = new Map<string, string[]>();
   const unmatched = new Set<string>();
@@ -82,14 +107,19 @@ export function recordRun(request: RecordRequest): RecordOutcome {
     // evidence that the obligation holds, and binding on it would make the
     // store agree with a red build.
     for (const id of entry.traceIds ?? []) {
-      if (!byId.has(id)) {
+      const matched = byId.has(id)
+        ? [byId.get(id) as Obligation]
+        : (byTarget.get(id) ?? []);
+      if (matched.length === 0) {
         unmatched.add(id);
         continue;
       }
       if (entry.outcome !== "pass") continue;
-      const symbols = discharged.get(id) ?? [];
-      symbols.push(entry.symbol);
-      discharged.set(id, symbols);
+      for (const obligation of matched) {
+        const symbols = discharged.get(obligation.id) ?? [];
+        symbols.push(entry.symbol);
+        discharged.set(obligation.id, symbols);
+      }
     }
   }
 

--- a/src/quire/types.ts
+++ b/src/quire/types.ts
@@ -89,6 +89,17 @@ export interface Obligation {
   method?: string | null;
   parameters?: Record<string, string>;
   criticality?: string | null;
+  /**
+   * Test-case ids the criterion's method cell names — `Test (TC-707)` yields
+   * `["TC-707"]` (quire-rs FR-053-AC-11, v0.35.0).
+   *
+   * Optional because an engine before v0.35.0 emits none, and because a cell
+   * naming no test case carries none. Treat absent and empty alike: both mean
+   * "this obligation names no test case", never "the engine is old" — a
+   * consumer that branched on the difference would report a version as a
+   * finding.
+   */
+  target_ids?: string[];
 }
 
 /** Bundle-wide totals. The criteria pair is all-or-nothing. */

--- a/tests/evidence-store.test.ts
+++ b/tests/evidence-store.test.ts
@@ -613,3 +613,93 @@ describe("TC-132 the store's byte order does not depend on the locale (FR-030-AC
     expect(written.endsWith("\n")).toBe(true);
   });
 });
+
+describe("TC-245 a run binds through an obligation's declared test cases", () => {
+  // A tool reports the id it knows. A unit test carries the criterion's own id
+  // because the tag is written in the test; an agent-eval report — and any tool
+  // keyed on the Test Matrix — carries the TEST CASE id. Both are stated by the
+  // same criteria row, and quire-rs FR-053-AC-11 carries that join on the
+  // obligation, so the store resolves it rather than re-parsing the table.
+  //
+  // Before this, `quoin evidence record --adapter agent-eval` reported
+  // `bound: 0` and `unmatched trace ids … TC-EV-057` while `FR-038-AC-8 →
+  // TC-EV-057` sat in the FR's own table (agent-ix/quoin#144).
+  it("binds a test-case id to the criterion whose cell names it", () => {
+    const outcome = recordRun({
+      repo,
+      suite: "EVAL-001",
+      commit: COMMIT,
+      tool: "cli-agent-evals",
+      timestamp: "2026-08-17T00:00:00Z",
+      entries: [
+        { symbol: "TC-EV-057", outcome: "pass", traceIds: ["TC-EV-057"] },
+      ],
+      obligations: [
+        { ...obligation("FR-038-AC-8", HASH_A), target_ids: ["TC-EV-057"] },
+      ],
+    });
+    expect(outcome.bound).toEqual(["FR-038-AC-8"]);
+    expect(outcome.unmatched).toEqual([]);
+    expect(readBindings(repo).bindings[0].symbols).toEqual(["TC-EV-057"]);
+  });
+
+  it("binds every criterion the same test case discharges", () => {
+    // A row says each of those criteria is verified by that test case, so one
+    // run discharging it discharges all of them. Reporting only the first would
+    // leave the rest undischarged with evidence sitting right there.
+    const outcome = recordRun({
+      repo,
+      suite: "EVAL-001",
+      commit: COMMIT,
+      tool: "cli-agent-evals",
+      timestamp: "2026-08-17T00:00:00Z",
+      entries: [
+        { symbol: "TC-EV-054", outcome: "pass", traceIds: ["TC-EV-054"] },
+      ],
+      obligations: [
+        { ...obligation("FR-038-AC-1", HASH_A), target_ids: ["TC-EV-054"] },
+        { ...obligation("FR-038-AC-2", HASH_A), target_ids: ["TC-EV-054"] },
+      ],
+    });
+    expect(outcome.bound.sort()).toEqual(["FR-038-AC-1", "FR-038-AC-2"]);
+  });
+
+  it("prefers a direct obligation id over the indirect route", () => {
+    // If a criterion's cell happened to name a SIBLING criterion's id, binding
+    // through the indirect route would report a discharge nobody stated
+    // directly. The direct match wins and the indirect one is not registered.
+    const outcome = recordRun({
+      repo,
+      suite: "SUITE-001",
+      commit: COMMIT,
+      tool: "cargo test",
+      timestamp: "2026-08-17T00:00:00Z",
+      entries: [
+        { symbol: "tests::tc001", outcome: "pass", traceIds: ["FR-001-AC-2"] },
+      ],
+      obligations: [
+        { ...obligation("FR-001-AC-1", HASH_A), target_ids: ["FR-001-AC-2"] },
+        obligation("FR-001-AC-2", HASH_A),
+      ],
+    });
+    expect(outcome.bound).toEqual(["FR-001-AC-2"]);
+  });
+
+  it("still reports a trace id no obligation states, by either route", () => {
+    const outcome = recordRun({
+      repo,
+      suite: "EVAL-001",
+      commit: COMMIT,
+      tool: "cli-agent-evals",
+      timestamp: "2026-08-17T00:00:00Z",
+      entries: [
+        { symbol: "TC-EV-999", outcome: "pass", traceIds: ["TC-EV-999"] },
+      ],
+      obligations: [
+        { ...obligation("FR-038-AC-8", HASH_A), target_ids: ["TC-EV-057"] },
+      ],
+    });
+    expect(outcome.bound).toEqual([]);
+    expect(outcome.unmatched).toEqual(["TC-EV-999"]);
+  });
+});


### PR DESCRIPTION
Closes #144. Needs quire-rs **v0.35.0** (FR-053-AC-11), which carries the join.

## A tool reports the id it knows

A unit test carries the **criterion's** own id, because the tag is written in the test. An agent-eval report — and any tool keyed on the Test Matrix — carries the **test case** id.

Both are stated by the same criteria row:

```
| FR-038-AC-8 | Generated targets are reported as undischarged … | Eval (TC-EV-057) |
```

The store bound only on obligation ids, so:

```
recorded EVAL-001 @ d101c00703c6
  bound: 0
  unmatched trace ids (tagged in the suite, stated by no obligation): TC-EV-057
```

…while the join sat in the FR's own table. **71 matrix rows** across `spec/evals.md`, FR-028 and FR-038 were unbacked for want of it.

The engine now carries `target_ids` on the obligation, so this resolves the join rather than re-parsing the criteria table — the duplication FR-050 exists to prevent.

## Two rules the tests pin rather than leave implied

**A direct obligation id wins.** If a criterion's cell named a *sibling* criterion's id, the indirect route would report a discharge nobody stated directly. The indirect route is not registered for an id that is itself an obligation.

**A test case discharging several criteria binds all of them.** The row says each is verified by that test case; binding only the first leaves the rest undischarged with the evidence sitting right there.

## Version tolerance

`target_ids` is optional on the type — an engine before v0.35.0 emits none, and a cell naming no test case carries none. **Absent and empty mean the same thing**: a consumer branching on the difference would report a version as a finding.

## Tests

`TC-245`, four cases: the eval join, several criteria per test case, direct-wins-over-indirect, and an id no obligation states by either route still reported unmatched.

## Gates

- `make build` ✅ 0 type errors
- `make test` ✅ **446 passed**
- `make lint` ✅
- `quire validate` ✅ (one pre-existing `ac:vague-response` on FR-030-AC-10, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)