### PR TITLE
fix(matrix): bind the rows that read green with no tagged test (CR-024)

### DIFF
--- a/spec/log.md
+++ b/spec/log.md
@@ -8,6 +8,16 @@ description: "Chronological log of structural changes to this bundle."
 
 ## History
 
+* **2026-08-19** — **CR-024**: quoin's own matrix rows **bind to the tests that back them** (agent-ix/quoin#124). **What the number counts:** rows in `spec/matrix.md` marked ✅ that `quire coverage --scope .` cannot confirm, because no symbol carries their id — quire calls these *status lies*. **48 before, 0 after**; rows the engine confirms as backed went **216 → 266** of 579.
+
+  The cause was one convention, uniformly applied and uniformly dead: `describe("TC-nnn …")`. **`describe(…)` registers no symbol at all** — the TypeScript extractor treats it as a grouping construct and only `it(…)`/`test(…)` become bindable symbols — so an id in a describe title names nothing however carefully it was written. The tests were always real; 448 of them pass. It was the binding that did not exist.
+
+  **Fixed by unifying on the form that binds, not by teaching the engine a second spelling.** quire-rs's `TraceTagGrammar` can model a trace-embedding test name, and declaring one would have bound the corpus without touching a file — but this repo's own standing rule is that a rule accepting every spelling enforces nothing, so 47 tags moved onto the registrations instead.
+
+  Two rows were not a tagging problem and are worth separating. **TC-146** ("kind-to-kind conformance; `unknown-method` reported") was tested under TC-142's describe — real coverage, wrong id. **TC-148** (`--module` supplies the audit catalog) had **no test at all** and read ✅ on the strength of its `Static` verification type; this repo deliberately does not exempt `Static` from status lies, precisely so an overclaim like that surfaces. It now has both halves: a behavioural test that `loadMethodCatalog([root])` returns a method the installed roots do not carry, and a source assertion that the command hands the loader `flags.module` — the wiring no other test in the file would catch.
+
+  **One row exposed an engine gap and was worked around, not papered over.** TC-118 used vitest's curried `it.skipIf(cond)("title", …)`, whose title sits on a line the line-based extractor never reads, so the registration produced no symbol. Rewritten to `it("title", (ctx) => …)` with `ctx.skip()`. Filed upstream rather than absorbed: a repo using the modifier forms gets silent zero coverage with no diagnostic.
+
 * **2026-08-19** — the quire contract refreshes to **v0.36.0**. The vendored `coverage-v1.schema.json` is `additionalProperties: false` on `Obligation`, so once the engine began emitting `target_ids` (quire-rs CR-078) a stale copy would have made quoin **reject every coverage payload** — checked before the CLI shipped rather than after. Refreshed through `scripts/refresh-quire-schemas.mjs`, which re-records the provenance hashes TC-110 pins.
 
   `minimumCli` stays at `0.21.0`. It is a CONTRACT floor, not a capability floor, and `target_ids` is optional on the payload — an older CLI emits none and still validates.

--- a/tests/advise-command.test.ts
+++ b/tests/advise-command.test.ts
@@ -46,6 +46,7 @@ const CATALOG: MethodCatalog = {
 };
 
 describe("TC-150 the advisor is reachable from a command (FR-031-AC-10, AC-11)", () => {
+  // TC-150
   it("exposes a command class with the flags the workflow needs", async () => {
     // The command file existing is not enough: `vite.config.ts` enumerates
     // build entries by hand, and a command with no entry builds no module.

--- a/tests/advisor.test.ts
+++ b/tests/advisor.test.ts
@@ -131,6 +131,7 @@ function fixtureCatalog(): MethodCatalog {
 }
 
 describe("TC-129 the merged catalog is read from module data", () => {
+  // TC-129
   it("loads every declared method with its rules intact", () => {
     const catalog = fixtureCatalog();
     expect(catalog.methods.length).toBe(11);
@@ -164,6 +165,7 @@ describe("TC-129 the merged catalog is read from module data", () => {
 });
 
 describe("TC-130 an attack surface reaches DAST and SAST", () => {
+  // TC-130
   it("recommends the security methods rather than defaulting to Test", () => {
     const advice = advise(fixtureCatalog(), {
       id: "FR-001-AC-1",
@@ -179,6 +181,7 @@ describe("TC-130 an attack surface reaches DAST and SAST", () => {
 });
 
 describe("TC-131 temporal phrasing reaches monitors and model checking", () => {
+  // TC-131
   it("recommends the methods a single execution cannot discharge", () => {
     const advice = advise(fixtureCatalog(), {
       id: "NFR-006-AC-1",
@@ -192,6 +195,7 @@ describe("TC-131 temporal phrasing reaches monitors and model checking", () => {
 });
 
 describe("TC-132 a reliability NFR reaches fault injection", () => {
+  // TC-132
   it("recommends inducing the failure the requirement claims to tolerate", () => {
     const advice = advise(fixtureCatalog(), {
       id: "NFR-009-AC-1",
@@ -205,6 +209,7 @@ describe("TC-132 a reliability NFR reaches fault injection", () => {
 });
 
 describe("TC-133 a property shape reaches the property methods", () => {
+  // TC-133
   it("routes a round-trip criterion to property-based and metamorphic testing", () => {
     const advice = advise(fixtureCatalog(), {
       id: "FR-005-AC-1",
@@ -231,6 +236,7 @@ describe("TC-133 a property shape reaches the property methods", () => {
 });
 
 describe("TC-134 a mismatch with the authored cell is flagged, advisory only", () => {
+  // TC-134
   it("flags an authored method none of the recommendations cover", () => {
     const advice = advise(fixtureCatalog(), {
       id: "NFR-009-AC-1",
@@ -256,6 +262,7 @@ describe("TC-134 a mismatch with the authored cell is flagged, advisory only", (
 });
 
 describe("TC-135 silence is reported as silence, not as a recommendation", () => {
+  // TC-135
   it("is inconclusive when no rule matched, and flags no mismatch", () => {
     const advice = advise(fixtureCatalog(), {
       id: "FR-001-AC-9",
@@ -271,6 +278,7 @@ describe("TC-135 silence is reported as silence, not as a recommendation", () =>
 });
 
 describe("TC-136 an unobservable axis is skipped, not failed", () => {
+  // TC-136
   it("does not reject a method whose rule names an axis the advisor cannot see", () => {
     // The engine leaves the axis set open (quire-rs FR-054-CON-2), so a module
     // may declare rules this advisor has no facts for. That is a gap in what can
@@ -323,6 +331,7 @@ describe("TC-133 an unreadable module manifest is reported, not thrown (FR-031-A
   // A root with no `manifest.yaml` at all never reaches the read:
   // `locateModuleRoot` already returns `undefined` for it, which is why the
   // gap was only reachable through a manifest that exists and does not parse.
+  // TC-133
   it("skips a root with no manifest without reporting it as unreadable", () => {
     const root = mkdtempSync(join(tmpdir(), "quoin-nomanifest-"));
     const catalog = loadMethodCatalog([root]);

--- a/tests/auditor.test.ts
+++ b/tests/auditor.test.ts
@@ -6,6 +6,11 @@
  * fooled by evidence that merely *exists*.
  */
 
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -67,6 +72,7 @@ function input(over: Partial<AuditInput> = {}): AuditInput {
 }
 
 describe("TC-137 healthy evidence produces no finding", () => {
+  // TC-137
   it("reports the obligation as healthy", () => {
     const report = audit(input());
     expect(report.findings).toEqual([]);
@@ -75,6 +81,7 @@ describe("TC-137 healthy evidence produces no finding", () => {
 });
 
 describe("TC-138 a suspect link is the highest-severity finding", () => {
+  // TC-138
   it("fires when the statement changed after binding, and says so", () => {
     const report = audit(
       input({ obligations: [obligation({ statement_hash: HASH_B })] }),
@@ -91,6 +98,7 @@ describe("TC-138 a suspect link is the highest-severity finding", () => {
 });
 
 describe("TC-139 stale evidence", () => {
+  // TC-139
   it("is high when the binding names a suite with no recorded run", () => {
     const report = audit(input({ runs: [] }));
     expect(report.findings[0].kind).toBe("stale-evidence");
@@ -108,6 +116,7 @@ describe("TC-139 stale evidence", () => {
 });
 
 describe("TC-140 vacuous evidence", () => {
+  // TC-140
   it("fires when every bound symbol was skipped", () => {
     const report = audit(
       input({
@@ -150,6 +159,7 @@ describe("TC-140 vacuous evidence", () => {
 });
 
 describe("TC-141 an obligation with no binding is undischarged", () => {
+  // TC-141
   it("reports it at medium, not high", () => {
     const report = audit(input({ bindings: [] }));
     const [finding] = report.findings;
@@ -187,6 +197,7 @@ describe("TC-142 method conformance", () => {
     duplicates: [],
   };
 
+  // TC-142
   it("compares kind to kind, not entry count", () => {
     // The old test was `run.entries.length > 0`, read as "this was a test run"
     // — true of a transcribed inspection too, so every Analysis obligation
@@ -226,6 +237,7 @@ describe("TC-142 method conformance", () => {
     expect(report.findings).toEqual([]);
   });
 
+  // TC-146
   it("reports a method no catalog carries rather than skipping it", () => {
     // `declaredClasses.size === 0` used to return null — a silent skip — so the
     // requirements whose verification is LEAST well defined were exactly the
@@ -261,6 +273,7 @@ describe("TC-142 method conformance", () => {
 });
 
 describe("TC-143 multiplicity", () => {
+  // TC-143
   it("flags a critical obligation whose evidence is all one suite", () => {
     const report = audit(
       input({
@@ -303,6 +316,7 @@ describe("TC-143 multiplicity", () => {
 });
 
 describe("TC-144 ratchet and per-PR delta", () => {
+  // TC-144
   it("reports only violations absent from the baseline", () => {
     const report = audit(
       input({
@@ -385,6 +399,7 @@ describe("TC-145 one obligation, two suites (FR-032-AC-8)", () => {
     }),
   ];
 
+  // TC-145
   it("clears the multiplicity finding two independent suites satisfy", () => {
     const report = audit(
       input({
@@ -467,6 +482,7 @@ describe("TC-147 every finding kind can be baselined (FR-032-AC-11)", () => {
   // `insufficient-multiplicity` could never appear in one, so `--ratchet`
   // reported the whole existing backlog for five of the six kinds — the
   // outcome ratchet mode exists to prevent (agent-ix/quoin#105).
+  // TC-147
   it("accepts each kind by its own key", () => {
     const kinds: Array<[string, AuditInput]> = [
       ["undischarged", input({ bindings: [] })],
@@ -530,6 +546,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
     });
 
   // Trace: FR-039-AC-1
+  // TC-219
   it("says nothing until a floor is declared", () => {
     // The CR-008 lesson, applied before it could bite: a built-in floor is a
     // rule nobody chose, firing on everything the moment a criticality column
@@ -733,6 +750,7 @@ describe("TC-219 mutation score as the acceptance-criteria oracle", () => {
 
 describe("TC-220 --mutation-floor is parsed, and a bad one is refused", () => {
   // Trace: FR-039-AC-8
+  // TC-220
   it("reads <criticality>=<ratio> pairs", async () => {
     const { parseMutationFloor } =
       await import("../src/commands/evidence/audit.js");
@@ -774,5 +792,60 @@ describe("TC-220 --mutation-floor is parsed, and a bad one is refused", () => {
     };
     expect(() => parseMutationFloor(["P0"], fail)).toThrow(/expects/);
     expect(() => parseMutationFloor(["P0=high"], fail)).toThrow(/expects/);
+  });
+});
+
+describe("TC-148 the audit command reads the catalog from --module", () => {
+  // TC-148
+  it("loads only what the named module declares, not the installed roots", async () => {
+    // The disagreement this closes: obligations derived from one catalog and
+    // conformance checked against another, so a method the module declares
+    // reads as `unknown-method`. FR-032-AC-12.
+    const { loadMethodCatalog } = await import("../src/advisor/index.js");
+    const root = mkdtempSync(join(tmpdir(), "quoin-tc148-"));
+    writeFileSync(
+      join(root, "manifest.yaml"),
+      [
+        "manifest_version: 1",
+        "name: tc148-fixture",
+        "version: 0.0.0",
+        "verification_catalog:",
+        "  tc148-only-method:",
+        "    verification_class: Test",
+        "    evidence_kind: Unit",
+        "    summary: a method that exists in no installed module",
+        "",
+      ].join("\n"),
+    );
+
+    const scoped = loadMethodCatalog([root]);
+    expect(scoped.methods.map((m) => m.id)).toContain("tc148-only-method");
+
+    // And the default roots do not carry it, so the assertion above is a
+    // measurement of the flag rather than of what happens to be installed.
+    const installed = loadMethodCatalog();
+    expect(installed.methods.map((m) => m.id)).not.toContain(
+      "tc148-only-method",
+    );
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // TC-148
+  it("passes the flag through from the command, so the two agree", () => {
+    // The behavioural half above proves the loader honours a module root; this
+    // proves the command hands it one. Without it a wiring regression would
+    // pass every other test in this file.
+    const source = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "src/commands/evidence/audit.ts",
+      ),
+      "utf8",
+    );
+    expect(source).toContain(
+      "catalog: loadMethodCatalog(flags.module ? [flags.module] : undefined)",
+    );
   });
 });

--- a/tests/command-entries.test.ts
+++ b/tests/command-entries.test.ts
@@ -38,6 +38,7 @@ function commandFiles(dir: string): string[] {
 }
 
 describe("TC-149 every command file is a vite build entry", () => {
+  // TC-149
   it("has no command that would be missing from dist/", () => {
     const config = readFileSync(join(REPO, "vite.config.ts"), "utf8");
     const declared = new Set(

--- a/tests/evidence-store.test.ts
+++ b/tests/evidence-store.test.ts
@@ -56,6 +56,7 @@ const COMMIT = "abcdef0123456789";
 const HASH_B = "b".repeat(64);
 
 describe("TC-119 the store lives under spec/", () => {
+  // TC-119
   it("places the store inside the walked document root", () => {
     // quire-rs CR-045 bounds the document walk to <scope>/spec, so the authored
     // half is only a validated corpus document if the store lives there. A
@@ -71,6 +72,7 @@ describe("TC-119 the store lives under spec/", () => {
 });
 
 describe("TC-120 writes are canonical, so a diff of the store is the delta", () => {
+  // TC-120
   it("sorts keys at every level and ends with a newline", () => {
     const json = canonicalJson({ b: 1, a: { d: 2, c: 3 } });
     expect(json).toBe(
@@ -102,6 +104,7 @@ describe("TC-120 writes are canonical, so a diff of the store is the delta", () 
 });
 
 describe("TC-121 the suite is the atomic unit of evidence", () => {
+  // TC-121
   it("keeps one file per (suite, commit) and does not merge suites", () => {
     const base = {
       schemaVersion: STORE_SCHEMA_VERSION,
@@ -134,6 +137,7 @@ describe("TC-121 the suite is the atomic unit of evidence", () => {
 });
 
 describe("TC-122 first discharge auto-binds and stamps the hash", () => {
+  // TC-122
   it("binds a passing symbol's obligation with the hash as it stands now", () => {
     const outcome = recordRun({
       repo,
@@ -181,6 +185,7 @@ describe("TC-122 first discharge auto-binds and stamps the hash", () => {
 });
 
 describe("TC-123 a reworded statement makes a binding suspect", () => {
+  // TC-123
   it("reports suspicion and does NOT overwrite the hash", () => {
     const request = {
       repo,
@@ -212,6 +217,7 @@ describe("TC-123 a reworded statement makes a binding suspect", () => {
 });
 
 describe("TC-124 affirmation is the explicit act", () => {
+  // TC-124
   it("moves the hash forward and records who, at which commit", () => {
     const existing: Binding[] = [
       {
@@ -247,6 +253,7 @@ describe("TC-124 affirmation is the explicit act", () => {
 });
 
 describe("TC-125 a trace id no obligation states is reported", () => {
+  // TC-125
   it("names it rather than dropping it", () => {
     // quire-rs#72 from the other direction: a test claiming to verify something
     // the spec does not state.
@@ -267,6 +274,7 @@ describe("TC-125 a trace id no obligation states is reported", () => {
 });
 
 describe("TC-126 gc keeps the latest run and anything a binding references", () => {
+  // TC-126
   it("deletes only unreferenced older runs", () => {
     const base = {
       schemaVersion: STORE_SCHEMA_VERSION,
@@ -317,6 +325,7 @@ describe("TC-126 gc keeps the latest run and anything a binding references", () 
 });
 
 describe("TC-127 an absent store reads as empty, not as an error", () => {
+  // TC-127
   it("returns an empty binding graph before anything has been recorded", () => {
     expect(readBindings(repo).bindings).toEqual([]);
     expect(listRuns(repo, "SUITE-001")).toEqual([]);
@@ -325,6 +334,7 @@ describe("TC-127 an absent store reads as empty, not as an error", () => {
 });
 
 describe("TC-128 no obligation is ever stored", () => {
+  // TC-128
   it("keeps only the hash, never the statement", () => {
     // The governing principle: store only what cannot be recomputed from
     // spec + code at HEAD. An obligation is always re-derivable, so a stored
@@ -378,6 +388,7 @@ describe("TC-129 a second suite appends, it does not overwrite (FR-030-AC-11)", 
   // the obligation alone, so the second discharge replaced the first. The
   // relationship the file exists to hold was destroyed on write, silently
   // (agent-ix/quoin#102).
+  // TC-129
   it("keeps both bindings and orders them by (obligation, suite)", () => {
     const first = bind([], {
       obligation: "FR-001-AC-1",
@@ -495,6 +506,7 @@ describe("TC-130 the latest run is the newest, not the highest filename (FR-030-
     });
   }
 
+  // TC-130
   it("reads the newest by timestamp even when its filename sorts first", () => {
     twoRuns();
     // The premise: filename order and time order genuinely disagree here.
@@ -541,6 +553,7 @@ describe("TC-131 a corrupt store file is named, not a bare SyntaxError (FR-030-A
   // (agent-ix/quoin#106).
   const CONFLICTED = '<<<<<<< HEAD\n{"bindings": []}\n=======\n';
 
+  // TC-131
   it("names the file and the cause when the binding graph is unreadable", () => {
     mkdirSync(storeRoot(repo), { recursive: true });
     writeFileSync(bindingsPath(repo), CONFLICTED, "utf8");
@@ -579,6 +592,7 @@ describe("TC-132 the store's byte order does not depend on the locale (FR-030-AC
   // runtime's ICU data — so two machines could serialize one binding set two
   // ways and produce a diff nobody made, in a file whose diff is meant to BE
   // the per-PR delta (agent-ix/quoin#106).
+  // TC-132
   it("writes an exact, pinned byte sequence", () => {
     writeBindings(repo, {
       schemaVersion: 1,
@@ -624,6 +638,7 @@ describe("TC-245 a run binds through an obligation's declared test cases", () =>
   // Before this, `quoin evidence record --adapter agent-eval` reported
   // `bound: 0` and `unmatched trace ids … TC-EV-057` while `FR-038-AC-8 →
   // TC-EV-057` sat in the FR's own table (agent-ix/quoin#144).
+  // TC-245
   it("binds a test-case id to the criterion whose cell names it", () => {
     const outcome = recordRun({
       repo,

--- a/tests/quire-contract.test.ts
+++ b/tests/quire-contract.test.ts
@@ -65,6 +65,7 @@ function propertiesPayload(): Record<string, unknown> {
 }
 
 describe("TC-110 the vendored schemas match their recorded provenance", () => {
+  // TC-110
   it("hashes exactly what contract.ts records", () => {
     for (const [name, expected] of Object.entries(QUIRE_CONTRACT.hashes)) {
       expect(
@@ -85,6 +86,7 @@ describe("TC-110 the vendored schemas match their recorded provenance", () => {
 });
 
 describe("TC-111 a conformant payload validates", () => {
+  // TC-111
   it("accepts a coverage payload", () => {
     const result = validateCoverage(coveragePayload());
     expect(result.ok, JSON.stringify(result)).toBe(true);
@@ -97,6 +99,7 @@ describe("TC-111 a conformant payload validates", () => {
 });
 
 describe("TC-112 a drifted payload is rejected with the offending path", () => {
+  // TC-112
   it("names a missing required key rather than failing later", () => {
     const payload = coveragePayload();
     delete payload.totals;
@@ -129,6 +132,7 @@ describe("TC-112 a drifted payload is rejected with the offending path", () => {
 });
 
 describe("TC-113 unreadable output is a named diagnostic, not a throw", () => {
+  // TC-113
   it("reports a JSON parse failure as a contract violation", () => {
     const result = parseCoverage("not json at all");
     expect(result.ok).toBe(false);
@@ -147,6 +151,7 @@ describe("TC-113 unreadable output is a named diagnostic, not a throw", () => {
 });
 
 describe("TC-114 the version premise is enforced with a named diagnostic", () => {
+  // TC-114
   it("passes a satisfying version", () => {
     expect(
       checkVersionPremise(`quire ${QUIRE_CONTRACT.minimumCli}`),
@@ -172,6 +177,7 @@ describe("TC-114 the version premise is enforced with a named diagnostic", () =>
 });
 
 describe("TC-115 version parsing and comparison", () => {
+  // TC-115
   it("reads the version out of the CLI banner", () => {
     expect(parseCliVersion("quire 0.21.0")).toBe("0.21.0");
     expect(parseCliVersion("nothing here")).toBeNull();
@@ -186,6 +192,7 @@ describe("TC-115 version parsing and comparison", () => {
 });
 
 describe("TC-116 optional keys are optional and absence is not emptiness", () => {
+  // TC-116
   it("accepts a payload omitting every optional key", () => {
     expect(validateCoverage(coveragePayload()).ok).toBe(true);
   });
@@ -255,6 +262,7 @@ describe("TC-116 optional keys are optional and absence is not emptiness", () =>
 });
 
 describe("TC-117 the eval harness floor tracks the contract", () => {
+  // TC-117
   it("mirrors QUIRE_CONTRACT.minimumCli", async () => {
     // The harness restates the floor because it runs against sources rather
     // than `dist/`, and a build step between "run the evals" and "know which
@@ -274,33 +282,34 @@ describe("TC-118 the contract holds against the installed quire", () => {
     }
   })();
 
-  it.skipIf(installed === null)(
-    "the installed CLI satisfies the pinned premise",
-    () => {
-      expect(checkVersionPremise(installed)).toBeNull();
-    },
-  );
+  // TC-118
+  it("the installed CLI satisfies the pinned premise", (ctx) => {
+    // `ctx.skip()` rather than `it.skipIf(cond)("title", …)`: the curried form
+    // puts the title on a line the symbol extractor never reads, so the row
+    // bound to nothing and the matrix read ✅ over it (agent-ix/quoin#124).
+    if (installed === null) return ctx.skip();
+    expect(checkVersionPremise(installed)).toBeNull();
+  });
 
-  it.skipIf(installed === null)(
-    "a real `quire properties --json` payload validates against the pinned schema",
-    () => {
-      // Deliberately end-to-end: the schema is vendored, so the one thing a
-      // unit test cannot show is that the real binary still emits this shape.
-      const out = execFileSync(
-        "quire",
-        ["properties", "--json", "--archetype", "FR", "-"],
-        {
-          encoding: "utf8",
-          input:
-            "---\nid: FR-001\ntype: FR\ntitle: t\n---\n\n" +
-            "## Acceptance Criteria\n\n" +
-            "| ID | Criteria | Verification |\n|----|----------|--------------|\n" +
-            "| FR-001-AC-1 | Every finding defaults to warning. | Test |\n",
-          stdio: ["pipe", "pipe", "ignore"],
-        },
-      );
-      const result = parseProperties(out);
-      expect(result.ok, JSON.stringify(result)).toBe(true);
-    },
-  );
+  // TC-118
+  it("a real `quire properties --json` payload validates against the pinned schema", (ctx) => {
+    if (installed === null) return ctx.skip();
+    // Deliberately end-to-end: the schema is vendored, so the one thing a
+    // unit test cannot show is that the real binary still emits this shape.
+    const out = execFileSync(
+      "quire",
+      ["properties", "--json", "--archetype", "FR", "-"],
+      {
+        encoding: "utf8",
+        input:
+          "---\nid: FR-001\ntype: FR\ntitle: t\n---\n\n" +
+          "## Acceptance Criteria\n\n" +
+          "| ID | Criteria | Verification |\n|----|----------|--------------|\n" +
+          "| FR-001-AC-1 | Every finding defaults to warning. | Test |\n",
+        stdio: ["pipe", "pipe", "ignore"],
+      },
+    );
+    const result = parseProperties(out);
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+  });
 });


### PR DESCRIPTION
## What the number counts

Rows in `spec/matrix.md` marked ✅ that `quire coverage --scope .` **cannot confirm**, because no symbol carries their id. quire calls these *status lies*.

| | |
|---|---|
| status lies | **48 → 0** |
| rows backed | **216 → 266** (of 579) |

## The cause

One convention, uniformly applied and uniformly dead: `describe("TC-nnn …")`.

**`describe(…)` registers no symbol at all.** The TypeScript extractor treats it as a grouping construct; only `it(…)`/`test(…)` become bindable symbols. So an id in a describe title names nothing however carefully it was written.

The tests were always real — 448 of them pass. It was the binding that did not exist.

## Unified on the binding form, not a second spelling

quire-rs's `TraceTagGrammar` can model a trace-embedding test name, and declaring one would have bound the corpus **without touching a file**. But this repo's own standing rule is that *a rule accepting every spelling enforces nothing*, so 47 tags moved onto the registrations instead.

## Two rows were not a tagging problem

- **TC-146** — tested under TC-142's `describe`. Real coverage, wrong id.
- **TC-148** — **no test at all**, reading ✅ on the strength of its `Static` verification type. This repo deliberately does *not* exempt `Static` from status lies, precisely so an overclaim like this surfaces. It now has both halves: a behavioural test that `loadMethodCatalog([root])` returns a method the installed roots do not carry, and a source assertion that the command hands the loader `flags.module` — the wiring no other test in the file would catch.

## One row exposed an engine gap

TC-118 used vitest's curried `it.skipIf(cond)("title", …)`, whose title sits on a line the **line-based** extractor never reads, so the registration produced no symbol. Rewritten to `it("title", (ctx) => …)` with `ctx.skip()`.

Filed upstream rather than absorbed: any repo using the modifier forms gets **silent zero coverage with no diagnostic**.

Gates: 448 passed, eslint + prettier clean, `quire validate` clean.

Closes #124. Gate 0 of the battletesting readiness plan, epic agent-ix/quire-rs#81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)