### PR TITLE
docs(skills): retire the warning status marker from the matrix vocabulary

### DIFF
--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -13,7 +13,7 @@ stay here — the command reports and does not judge (quire-rs FR-050-CON-1).
 Built by `spec-matrix` (`quoin/skills/spec-matrix/SKILL.md`). Key tables:
 
 - **Test Case Summary** — `Test ID | Title | Type | Priority | Traces To | Status`, where
-  `Test ID` = `TC-xxx`, `Traces To` = `FR-XXX-AC-X` etc., `Status` ∈ `✅ ⚠️ ❌ 🚧 ⛔`.
+  `Test ID` = `TC-xxx`, `Traces To` = `FR-XXX-AC-X` etc., `Status` ∈ `✅ ❌ 🚧 ⛔` (`⚠️` retired — partial work is `🚧`).
 - **Per-requirement coverage** — StR/US/FR/NFR → AC → TC → Status tables.
 
 What each column *means* is not this skill's knowledge either: the active module declares it

--- a/skills/spec-matrix/SKILL.md
+++ b/skills/spec-matrix/SKILL.md
@@ -129,8 +129,14 @@ missing generator show up as a gap.
 
 ### `Status`
 
-`✅` complete · `⚠️` partial · `❌` failed · `🚧` in progress · `⛔` retired.
-A marker may be followed by text (`✅ Complete`); the marker must come first.
+`✅` complete · `❌` failed · `🚧` in progress/pending · `⛔` retired.
+A marker may be followed by text (`🚧 scale evidence deferred`); the marker
+must come first — the note carries information the bare marker cannot.
+
+`⚠️` is **retired** and no longer validates. It was admitted by the contract
+and classed by the traceability model as nothing, so every row carrying it was
+exempt from the status-lie check by construction. Partial work is `🚧`; a
+second form for one meaning enforces nothing.
 
 ### `Traces To`
 
@@ -175,7 +181,6 @@ Use template section `## Integration Test Matrix` with:
 ## Markers
 
 -   ✅ Complete
--   ⚠️ Partial
 -   ❌ Missing
--   🚧 In Progress
+-   🚧 In Progress / Partial / Pending
 -   ⛔ Retired

--- a/skills/spec-matrix/assets/test-matrix-example.md
+++ b/skills/spec-matrix/assets/test-matrix-example.md
@@ -50,8 +50,8 @@ This is an example test matrix demonstrating comprehensive test coverage for the
 | TC-012 | Full Clone Option | Integration | P2 | FR-001-OPT-B | 🚧 In Progress |
 | TC-013 | Repository at Size Limit | Integration | P2 | FR-001-CON-1 | 🚧 In Progress |
 | TC-014 | Clone at Timeout Boundary | Integration | P2 | FR-001-CON-2 | 🚧 In Progress |
-| TC-015 | Monorepo with Multiple K8s Projects | Integration | P2 | EC-001 | ⚠️ Partial |
-| TC-016 | Mixed K8s and Non-K8s YAML Files | Integration | P2 | EC-002 | ⚠️ Partial |
+| TC-015 | Monorepo with Multiple K8s Projects | Integration | P2 | EC-001 | 🚧 Partial |
+| TC-016 | Mixed K8s and Non-K8s YAML Files | Integration | P2 | EC-002 | 🚧 Partial |
 | TC-017 | Malformed YAML Handling | Integration | P1 | EC-003 | ❌ Missing |
 | TC-018 | Symlinks to K8s Configs | Integration | P2 | EC-004 | ❌ Missing |
 | TC-019 | Repository Changes During Clone | Integration | P2 | EC-005 | ❌ Missing |

--- a/skills/spec-matrix/assets/test-matrix-template.md
+++ b/skills/spec-matrix/assets/test-matrix-template.md
@@ -38,8 +38,8 @@ This matrix ensures comprehensive test coverage by transforming requirements int
 
 | Test ID | Title | Type | Priority | Traces To | Status |
 |---------|-------|------|----------|-----------|--------|
-| TC-001 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [US-XXX-AC-X] | [✅/⚠️/❌/🚧/⛔] |
-| TC-002 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [FR-XXX-AC-X] | [✅/⚠️/❌/🚧/⛔] |
+| TC-001 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [US-XXX-AC-X] | [✅/❌/🚧/⛔] |
+| TC-002 | [Test Title] | [Unit/Integration/E2E/Property] | [P0/P1/P2/P3/P4] | [FR-XXX-AC-X] | [✅/❌/🚧/⛔] |
 
 **Note**: Detailed test case definitions should be in separate files in `test-cases/` directory.
 
@@ -82,7 +82,7 @@ is validated, so `Unit / pg_test` and other compounds are rejected.
 | Integration ID | Purpose | Service | Type | Test Cases | Status |
 |----------------|---------|---------|------|------------|--------|
 | INT-010 | Data persistence | postgres.ix | database | TC-INT-010a, TC-INT-010b, TC-INT-010c | ✅ |
-| INT-011 | Cache operations | redis.ix | service | TC-INT-011, TC-INT-012 | ⚠️ |
+| INT-011 | Cache operations | redis.ix | service | TC-INT-011, TC-INT-012 | 🚧 |
 | INT-012 | Message publishing | event-bus | event | TC-INT-013, TC-INT-014, TC-INT-015 | ❌ |
 
 ### Browser/UI Integrations


### PR DESCRIPTION
`⚠️` is retired from the TestMatrix contract (FR-003 CR-031, agent-ix/spec-artifacts-process#52). It was admitted by `column_patterns.Status` and classed by `traceability.status` as **nothing** — so `class_of` returned `Unknown`, the coverage rollup asked only `== Complete`, and every row carrying it was exempt from the status-lie check **by construction**.

### These skills are the generator

Retiring the marker in the module while `spec-matrix` keeps teaching it **re-contaminates the corpus on the next matrix an agent writes**. This is a blocking companion to the module change, not follow-up tidying — it must merge before the enforcing module version tags.

### Six sites

| File | What |
|---|---|
| `skills/spec-matrix/SKILL.md` | the `Status` vocabulary + the Markers list |
| `skills/spec-matrix/assets/test-matrix-template.md` | two placeholder cells, one integration row |
| `skills/spec-matrix/assets/test-matrix-example.md` | two example rows |
| `skills/gap-analysis/references/step-3-matrix-verification.md` | the matrix-verification vocabulary |

Partial work is `🚧`, which already meant pending — a second form for one meaning enforces nothing. The two remaining occurrences of the glyph are the sentences explaining that it is retired.

`npm test`: 462 passed (40 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)