### PR TITLE
feat(quire): consume the v0.41.0 output contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "zod": ">=4.4.3"
   },
   "devDependencies": {
-    "@agent-ix/quire-cli": "^0.26.0",
+    "@agent-ix/quire-cli": "^0.28.0",
     "@types/node": "26.1.2",
     "@typescript-eslint/eslint-plugin": "8.66.0",
     "@typescript-eslint/parser": "8.66.0",

--- a/src/quire/contract.ts
+++ b/src/quire/contract.ts
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url";
 /** Where the vendored schemas came from, and exactly which bytes. */
 export const QUIRE_CONTRACT = {
   /** The quire-rs release the vendored schemas were copied from. */
-  sourceTag: "v0.39.1",
+  sourceTag: "v0.41.0",
   /** The contract version, as carried in each schema's `$id` and filename. */
   contractVersion: "v1",
   /**
@@ -64,7 +64,7 @@ export const QUIRE_CONTRACT = {
    */
   hashes: {
     "coverage-v1.schema.json":
-      "20dbff7bca2cdde91d67c1586f5e9932a94e21c625c5a8f3fbbb6e1b06e001fc",
+      "4248b9c873957fb0b1a6fedf6fff0a233df85908a778f5acb0125394df4dc411",
     "properties-v1.schema.json":
       "d81f1ec85abdecd1f1664ded15e081f9aecb6c0f054d6b332b71e904cf826292",
   },

--- a/src/quire/schemas/coverage-v1.schema.json
+++ b/src/quire/schemas/coverage-v1.schema.json
@@ -28,6 +28,11 @@
       "description": "FR-050-AC-16 (CR-041): unbacked rows exempted from status_lies by a declared method that mints no source symbol. ABSENT — not empty — for a module declaring no `no_source_symbol` vocabulary, which is what keeps FR-050-AC-7 byte-identity.",
       "items": { "$ref": "#/$defs/NoSymbolRow" }
     },
+    "undeclared_statuses": {
+      "type": "array",
+      "description": "FR-050-AC-21 (CR-083): rows whose authored status value the module's `traceability.status` vocabulary classes as nothing. ABSENT — not empty — for a corpus whose every status value is declared, which is what keeps FR-050-AC-7 byte-identity. Additive under FR-055-CON-3: no existing key changes meaning, no required key is added, and a consumer written against this schema before the key existed reads an unchanged payload from a conformant corpus.",
+      "items": { "$ref": "#/$defs/UndeclaredStatus" }
+    },
     "untracked_symbols": {
       "type": "array",
       "description": "FR-050-AC-5: source symbols whose trace tag resolves to no declared target or reference row.",
@@ -89,6 +94,17 @@
         "row_id": { "type": ["string", "null"] },
         "status": { "type": "string", "description": "The authored status value, verbatim." },
         "target_ids": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "UndeclaredStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reference", "document", "status"],
+      "properties": {
+        "reference": { "type": "string", "description": "The declaration that produced the row." },
+        "document": { "type": "string", "description": "Scope-relative path, `/`-separated on every platform." },
+        "row_id": { "type": ["string", "null"] },
+        "status": { "type": "string", "description": "The authored status value, verbatim. No class is carried: having none is the finding." }
       }
     },
     "NoSymbolRow": {

--- a/src/quire/types.ts
+++ b/src/quire/types.ts
@@ -41,6 +41,36 @@ export interface NoSymbolRow {
   target_ids: string[];
 }
 
+/**
+ * A row whose authored status the module's vocabulary classes as nothing
+ * (FR-050-AC-21, quire-rs CR-083).
+ *
+ * Carries no class, deliberately: having none is the entire finding, and two
+ * undeclared glyphs in one corpus are told apart only by the authored value.
+ */
+export interface UndeclaredStatus {
+  reference: string;
+  document: string;
+  row_id?: string | null;
+  /** The authored status value, verbatim. */
+  status: string;
+}
+
+/**
+ * One `implements` edge — requirement to production code (FR-062).
+ *
+ * **Carries no weight in `totals`.** Scope is not evidence: folding it into the
+ * backed set would let code that merely cites a requirement move a coverage
+ * number, which is the backdoor quire-rs CR-061 closed.
+ */
+export interface ImplementsRecord {
+  path: string;
+  symbol: string;
+  trace_id: string;
+  /** Name of the declared marker form that bound it. */
+  form: string;
+}
+
 /** A source symbol whose trace tag resolves to nothing declared. */
 export interface UntrackedSymbol {
   path: string;
@@ -116,11 +146,20 @@ export interface CoverageReport {
   status_lies: StatusLie[];
   /** Absent — not empty — when the module declares no exemption vocabulary. */
   no_symbol_rows?: NoSymbolRow[];
+  /** Absent — not empty — when every status value in the corpus is declared. */
+  undeclared_statuses?: UndeclaredStatus[];
   untracked_symbols: UntrackedSymbol[];
   groups: GroupCounts[];
   criteria?: CriteriaCounts[];
   diagnostics?: CoverageDiagnostic[];
   obligations?: Obligation[];
+  /**
+   * Absent when the module declares no `implements` marker forms. Present in
+   * the published schema since CR-080 and missing from this interface until
+   * CR-083 — the vendored contract and its types had drifted in the one
+   * direction the contract test does not check.
+   */
+  implements?: ImplementsRecord[];
   totals: CoverageTotals;
 }
 

--- a/tests/quire-contract.test.ts
+++ b/tests/quire-contract.test.ts
@@ -90,6 +90,39 @@ describe("TC-110 the vendored schemas match their recorded provenance", () => {
 
 describe("TC-111 a conformant payload validates", () => {
   // TC-111
+  it("TC-116 accepts the v0.41.0 optional keys, and rejects a malformed one", () => {
+    // A vendored schema can drift from the engine in the one direction nothing
+    // notices: a NEW optional key. The payload still validates because the key
+    // is simply unknown — until `additionalProperties: false` rejects it, which
+    // is what would happen here if the refresh had not been run.
+    const withDrift = coveragePayload();
+    withDrift.undeclared_statuses = [
+      {
+        reference: "traces-to",
+        document: "spec/tests.md",
+        row_id: "TC-006",
+        status: "\u26a0\ufe0f scale evidence deferred",
+      },
+    ];
+    withDrift.implements = [
+      {
+        path: "src/lib.rs",
+        symbol: "parse",
+        trace_id: "FR-001",
+        form: "rust-implements-line",
+      },
+    ];
+    expect(validateCoverage(withDrift).ok).toBe(true);
+
+    // `status` is required, and the class is deliberately NOT carried — having
+    // none is the finding.
+    const malformed = coveragePayload();
+    malformed.undeclared_statuses = [
+      { reference: "traces-to", document: "spec/tests.md" },
+    ];
+    expect(validateCoverage(malformed).ok).toBe(false);
+  });
+
   it("accepts a coverage payload", () => {
     const result = validateCoverage(coveragePayload());
     expect(result.ok, JSON.stringify(result)).toBe(true);


### PR DESCRIPTION
Re-vendors the published schemas from **quire-rs v0.41.0** and teaches the types the two keys that release added.

| key | source |
|---|---|
| `undeclared_statuses` | quire-rs CR-083 — rows whose authored status the module's vocabulary classes as nothing. Carries **no class**, deliberately: having none is the entire finding. |
| `implements` | quire-rs CR-080 — in the **published schema since v0.39** and missing from `types.ts` the whole time. |

That second one is worth pausing on: the vendored contract and its TypeScript types had drifted in the one direction nothing checks, because the contract test validates payloads against the *schema* and never against the *interface*.

`sourceTag` moves `v0.39.1` → `v0.41.0`; the SHA-256 hashes are regenerated by `scripts/refresh-quire-schemas.mjs`, which refuses to run against any other checkout.

### The CLI range could never have resolved the fix

`package.json` widens `@agent-ix/quire-cli` from `^0.26.0` to `^0.28.0`. On a 0.x range a caret is `>=0.26.0 <0.27.0` — so the old pin could not resolve 0.27 or 0.28, and the CLI carrying the engine capabilities was unreachable from this package **by construction**.

### TC-116

Exercises both new keys against the vendored schema, and asserts a **malformed** `undeclared_statuses` entry is rejected. A payload that only ever validates is a tautology — the trap TC-118's own comment already records.

### Not included, and why

The `default-modules.yaml` pin bump to `spec-artifacts-iso 0.18.0` / `spec-artifacts-process 0.23.0`.

Bisected to that file alone, it makes **TC-118 fail**: `reconcile` installs the new refs and the resulting module set loads with **no `trace_targets`**, so the end-to-end `quire coverage` mints nothing and the `implements` guard goes vacuous. The same command run by hand against the same installed modules works fine, so it is something about how `reconcile` materializes those refs rather than about the modules themselves.

Filed rather than forced — nothing else in this PR depends on it.

463 passed across 40 files · eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)