### PR TITLE
spec(trace): normalize slash-separated id chains

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -664,7 +664,7 @@ describe("write", () => {
     expect(parsed.types[0].name).toBe("FR");
   });
 
-  // FR-025-AC-6 / FR-023-AC-4: the --org flag has to survive oclif's own flag
+  // FR-025-AC-6, FR-023-AC-4: the --org flag has to survive oclif's own flag
   // parsing into the pack, in both renderings. Driven through the command class
   // rather than main(), matching the rest of this suite: dispatching through
   // the runner would execute from dist/, where the src/modules mock does not


### PR DESCRIPTION
Part of agent-ix/spec-artifacts-process#37.

Every legacy trace form joins an id list on a **comma** and nothing else. This repo writes a slash, and capture group 1 stops at the first id — the second is dropped **inside the regex**, before any engine code runs, so there is no diagnostic. A dropped id never becomes a relation, so it can never appear in `untracked_symbols`; it shows only as the row it would have backed reading unbacked.

Swept by `quire-rs/scripts/slash_tag_sweep.py` (agent-ix/quire-rs#208). The classifier **refuses far more than it edits** — a chain is auto-edited only when *every* id in it is a shape a trace target mints. Comment lines only, byte-identical elsewhere.

### The gate

Verified before and after with the same binary and module (quire-cli @ quire-rs v0.41.0). The closed-loop rule is that **no untracked symbol may appear that was not there before**: a normalization that binds an id nothing mints adds a dead tag rather than coverage — the trap agent-ix/quire-rs#193 hit and backed out of.

**Two repositories in this sweep failed that gate and were reverted rather than landed** (`identity` would have minted 4 dead tags, `auth-service` 1). This one passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)