### PR TITLE
fix(review): include EARS in the enforced all set

### DIFF
--- a/skills/spec-review/workflow-assets/skills/review/SKILL.md
+++ b/skills/spec-review/workflow-assets/skills/review/SKILL.md
@@ -24,9 +24,9 @@ document per analysis** under `spec/reviews/`, rather than a single freeform rep
   record it in the `request` interview as `review_set` plus `selected_analyses`:
   - `base` — the skill checklist only (ID formats, US/FR/TC quality, the six coverage
     rules). No analysis skills. `selected_analyses` is empty.
-  - `all` — `base` plus all six analyses: `failure-domain`, `integrity`, `dependency`,
-    `evidence`, `risk-complexity`, `scope-boundary`.
-  - `subset` — `base` plus the analyses the user picks from those six.
+  - `all` — `base` plus all seven analyses: `failure-domain`, `integrity`, `dependency`,
+    `evidence`, `risk-complexity`, `scope-boundary`, `ears-conformance`.
+  - `subset` — `base` plus the analyses the user picks from those seven.
 - **analyses_run — run the selected set, one SpecReview doc each.** Run each selected
   analysis (the matching `spec-*-analysis` skill). Prefer running them **in parallel** —
   each writes its own file, so there is no contention.
@@ -55,7 +55,7 @@ hand-copy). The structure below is a reference for what that skeleton contains �
 id: SR-001
 title: "<analysis> review of <scope>"
 type: SpecReview
-analysis: <failure-domain|integrity|dependency|evidence|risk-complexity|scope-boundary|base>
+analysis: <failure-domain|integrity|dependency|evidence|risk-complexity|scope-boundary|ears-conformance|base>
 scope: <spec paths / ids>
 review_set: <base|all|subset>
 ---

--- a/skills/spec-review/workflow-assets/skills/review/scripts/invariants.js
+++ b/skills/spec-review/workflow-assets/skills/review/scripts/invariants.js
@@ -1,6 +1,6 @@
 import { specInvariants } from "../../../dist/index.js";
 
-// Canonical "all" set — the six analyses named in the spec-review skill.
+// Canonical "all" set — the seven analyses named in the spec-review skill.
 const ALL_ANALYSES = [
   "failure-domain",
   "integrity",
@@ -8,6 +8,7 @@ const ALL_ANALYSES = [
   "evidence",
   "risk-complexity",
   "scope-boundary",
+  "ears-conformance",
 ];
 
 const norm = (value) =>
@@ -27,7 +28,7 @@ function findRequest(instance) {
 // Hard check (final gate): every selected analysis must have a recorded
 // `review_doc` (a rendered + quire-validated SpecReview doc on disk) before
 // the run can be accepted. 'base' selects nothing, so it passes trivially;
-// 'all' expands to the canonical six when the agent did not echo the list.
+// 'all' expands to the canonical seven when the agent did not echo the list.
 const selectedAnalysesCovered = ({ instance }) => {
   const request = findRequest(instance);
   const reviewSet = norm(request?.review_set);

--- a/skills/spec-review/workflow-assets/skills/review/workflows/review/def.yaml
+++ b/skills/spec-review/workflow-assets/skills/review/workflows/review/def.yaml
@@ -1,5 +1,5 @@
 name: review
-version: 0.2.0
+version: 0.2.1
 description: Run a composite specification review producing validated SpecReview docs.
 initialPhase: intake
 phases:
@@ -46,12 +46,12 @@ interviews:
         type: text
         required: true
       - key: review_set
-        prompt: "Review set: 'base' (skill checklist only), 'all' (the six analyses), or 'subset'."
+        prompt: "Review set: 'base' (skill checklist only), 'all' (the seven analyses), or 'subset'."
         type: enum
         options: [base, all, subset]
         required: true
       - key: selected_analyses
-        prompt: "Analyses to run as a list, drawn from: failure-domain, integrity, dependency, evidence, risk-complexity, scope-boundary. Use all six for 'all'; the chosen ones for 'subset'; leave empty for 'base'."
+        prompt: "Analyses to run as a list, drawn from: failure-domain, integrity, dependency, evidence, risk-complexity, scope-boundary, ears-conformance. Use all seven for 'all'; the chosen ones for 'subset'; leave empty for 'base'."
         type: list<text>
         required: false
 recipes:

--- a/spec/usecase/US-007-review-into-specreview-docs.md
+++ b/spec/usecase/US-007-review-into-specreview-docs.md
@@ -23,7 +23,7 @@ relationships:
 
 The bundled `spec-review` workflow (launched via `quoin review`, driven by
 `ix-flow`) lets the author choose a review set — `base`, `all`, or a `subset` of
-the six analyses — and produces one `SpecReview` document per selected analysis
+the seven analyses — and produces one `SpecReview` document per selected analysis
 under `spec/reviews/`. Each doc is a validated artifact: a `## Summary` plus a
 `## Findings` table whose `Severity` column is constrained to `low|medium|high`.
 The author keeps direct authoring, but two guardrails keep quality stable over
@@ -53,6 +53,12 @@ These examples clarify expectations; they are illustrative, not verification cri
 - **Given** a findings row whose `Severity` is `catastrophic`
 - **When** the doc is validated
 - **Then** validation fails because `Severity` must be one of `low|medium|high`
+
+### US-007-EX-4: The all review set includes EARS conformance
+
+- **Given** the author selects the `all` review set
+- **When** the workflow expands and checks the selected analyses
+- **Then** `ears-conformance` is required alongside the other six focused analyses and acceptance remains blocked until its validated review document is recorded
 
 ## Options (Exploratory)
 

--- a/tests/spec-review-vocab-drift.test.ts
+++ b/tests/spec-review-vocab-drift.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+
+import { filamentModulesDir } from "../src/catalog.js";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const directSkill = readFileSync(
+  join(repoRoot, "skills/spec-review/SKILL.md"),
+  "utf8",
+);
+const workflowRoot = join(
+  repoRoot,
+  "skills/spec-review/workflow-assets/skills/review",
+);
+const workflowSkill = readFileSync(join(workflowRoot, "SKILL.md"), "utf8");
+const workflowDefinition = parseYaml(
+  readFileSync(join(workflowRoot, "workflows/review/def.yaml"), "utf8"),
+) as {
+  interviews: {
+    request: {
+      questions: Array<{ key: string; prompt: string }>;
+    };
+  };
+};
+const invariantSource = readFileSync(
+  join(workflowRoot, "scripts/invariants.js"),
+  "utf8",
+);
+
+const sorted = (values: Iterable<string>) => [...values].sort();
+
+function directAnalysisSet(): Set<string> {
+  return new Set(
+    [
+      ...directSkill.matchAll(
+        /^\|\s*([a-z][a-z-]+)\s*\|\s*`spec-[^`]+`\s*\|$/gm,
+      ),
+    ].map((match) => match[1]),
+  );
+}
+
+function workflowSkillSet(): Set<string> {
+  const section = /- `all`[^\n]*analyses:([\s\S]*?)\n\s*- `subset`/.exec(
+    workflowSkill,
+  );
+  expect(section, "workflow SKILL has no `all` analysis list").toBeTruthy();
+  return new Set(
+    [...(section?.[1] ?? "").matchAll(/`([a-z][a-z-]+)`/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+function workflowTemplateSet(): Set<string> {
+  const analysis = /^analysis: <([^>]+)>$/m.exec(workflowSkill);
+  expect(
+    analysis,
+    "workflow SKILL has no SpecReview analysis reference",
+  ).toBeTruthy();
+  return new Set(
+    (analysis?.[1] ?? "").split("|").filter((value) => value !== "base"),
+  );
+}
+
+function workflowPromptSet(): Set<string> {
+  const question = workflowDefinition.interviews.request.questions.find(
+    ({ key }) => key === "selected_analyses",
+  );
+  expect(question, "workflow has no selected_analyses question").toBeTruthy();
+  const list = /drawn from: ([^.]+)\./.exec(question?.prompt ?? "");
+  expect(list, "selected_analyses prompt has no declared list").toBeTruthy();
+  return new Set((list?.[1] ?? "").split(", "));
+}
+
+function invariantSet(): Set<string> {
+  const array = /const ALL_ANALYSES = (\[[\s\S]*?\]);/.exec(invariantSource);
+  expect(array, "invariant has no ALL_ANALYSES declaration").toBeTruthy();
+  return new Set(
+    [...(array?.[1] ?? "").matchAll(/"([a-z][a-z-]+)"/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+describe("spec-review analysis vocabulary", () => {
+  it("keeps the direct skill, workflow docs, intake, gate, and schema aligned", () => {
+    const direct = directAnalysisSet();
+    expect(direct.size).toBe(7);
+    expect(direct).toContain("ears-conformance");
+    expect(sorted(workflowSkillSet())).toEqual(sorted(direct));
+    expect(sorted(workflowTemplateSet())).toEqual(sorted(direct));
+    expect(sorted(workflowPromptSet())).toEqual(sorted(direct));
+    expect(sorted(invariantSet())).toEqual(sorted(direct));
+
+    const schema = JSON.parse(
+      readFileSync(
+        join(
+          filamentModulesDir(),
+          "spec-artifacts-process/schemas/spec-review-frontmatter.schema.json",
+        ),
+        "utf8",
+      ),
+    ) as { properties: { analysis: { enum: string[] } } };
+    for (const analysis of direct) {
+      expect(schema.properties.analysis.enum).toContain(analysis);
+    }
+  });
+
+  it("blocks an all-set review until the EARS review document is recorded", async () => {
+    const module = (await import(
+      pathToFileURL(join(workflowRoot, "scripts/invariants.js")).href
+    )) as {
+      invariants: Record<
+        string,
+        (input: { instance: Record<string, unknown> }) =>
+          | true
+          | {
+              ok: false;
+              code: string;
+              details: { missing: string[] };
+            }
+      >;
+    };
+    const direct = directAnalysisSet();
+    const reviewDocs = [...direct]
+      .filter((analysis) => analysis !== "ears-conformance")
+      .map((analysis) => ({ analysis, path: `spec/reviews/${analysis}.md` }));
+    const instance = {
+      items: {
+        operation_request: [{ interviewId: "request", review_set: "all" }],
+        review_doc: reviewDocs,
+      },
+    };
+
+    const incomplete = module.invariants.selected_analyses_covered({
+      instance,
+    });
+    expect(incomplete).toMatchObject({
+      ok: false,
+      code: "selected_analyses_not_run",
+      details: { missing: ["ears-conformance"] },
+    });
+
+    reviewDocs.push({
+      analysis: "ears-conformance",
+      path: "spec/reviews/ears-conformance.md",
+    });
+    expect(module.invariants.selected_analyses_covered({ instance })).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- include ears-conformance in the workflow-backed all review set
- align workflow instructions, intake, reference template, and acceptance invariant with the direct skill
- add a vocabulary-drift regression test across all declarations and the installed SpecReview schema
- prove acceptance blocks until the EARS review document is recorded

## Verification
- make test: 47 files, 524 tests passed
- make lint: passed
- Quire specification validation: passed with existing advisory warnings

## Note
The build completes with existing declaration diagnostics in unrelated evidence-store and SBOM sources.