### PR TITLE
fix(cli): --help reports the version --version does (#196)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,42 @@ make add-packages p=<name>      # add runtime dependency
 make add-dev-packages p=<name>  # add dev dependency
 make use-local p=<name>         # switch dep to local package
 make use-upstream p=<name>      # switch dep back to upstream
+make check-version              # every version surface agrees; a clean tag reports itself
 ```
+
+## Dogfooding an unreleased quoin
+
+**There is no local-publish path, and that is a deliberate choice rather than
+something to discover (quoin#196).** `ts-build-chain` classifies quoin as an app
+(it ships a `bin`, not a library entry), so a single-node chain runs green and
+publishes nothing:
+
+```
+$ ts-build-chain start --skip-registry-audit quoin quoin
+✔ Build
+✔ Test
+❯ Publish
+↓ Publish [SKIPPED: Not a library (no publish target)]
+```
+
+To run unreleased `main`:
+
+```bash
+make build
+npm i -g .        # or: node bin/quoin.js <command>
+```
+
+The only path to a registry is a **git tag plus CI**. That matters when `main`
+carries unreleased fixes: npm serves the last tag, so anyone installing the
+normal way gets a build without them. Check what you are actually running —
+`quoin --version` reports the build-time `git describe`, so a
+`-<n>-g<sha>` suffix means the binary is ahead of its tag.
+
+**Version provenance is load-bearing.** Every SpecReview records the tool
+version it measured with, and three reviews in `agent-ix/filament-ide-rs` cite
+numbers from a binary whose self-reported version was wrong. `make check-version`
+asserts that `--version` and `--help` agree and that a clean tag reports itself;
+run it before tagging.
 
 ## Adding or improving a spec check
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,20 @@ build:
 # build step in between, which is why that test passed locally — where a stale
 # `dist/` lingers — and failed on every clean runner.
 # `test` also depends on `validate` (quoin#183): spec docs are part of the gate.
+# `test` also depends on `check-version` (quoin#196): the two version surfaces
+# disagreed for every locally built binary, and only a BUILT artifact can show
+# it — the source has no baked version to disagree with package.json.
 .PHONY: test
-test: build validate
+test: build validate check-version
 	pnpm run test
+
+# Every surface that reports a version reports the same one, and a clean tag
+# reports itself (quoin#196). The class of defect this catches shipped once
+# already one repo over: quire-cli#52, where five consecutive tags shipped
+# binaries all reporting the version before them. Run it before tagging.
+.PHONY: check-version
+check-version: build
+	node scripts/check-version-agreement.mjs
 
 # Spec validation gate, mirroring quire-rs's `make validate` (quoin#183):
 # every spec/, plan/ and reviews/ document must pass `quire validate`

--- a/bin/quoin.js
+++ b/bin/quoin.js
@@ -2,7 +2,11 @@
 
 import { execute } from "@agent-ix/ix-cli-core";
 
-import { isVersionRequest, packageVersion } from "../dist/cli.js";
+import {
+  isVersionRequest,
+  packageVersion,
+  versionedConfig,
+} from "../dist/cli.js";
 
 const argv = process.argv.slice(2);
 
@@ -10,5 +14,8 @@ const argv = process.argv.slice(2);
 if (isVersionRequest(argv)) {
   console.log(packageVersion());
 } else {
-  await execute({ dir: import.meta.url });
+  // #196: the config carries the build-time version, so the `--help` VERSION
+  // block agrees with `--version` instead of printing package.json's CI
+  // placeholder.
+  await execute({ loadOptions: await versionedConfig(import.meta.url) });
 }

--- a/scripts/check-version-agreement.mjs
+++ b/scripts/check-version-agreement.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Assert every surface that reports quoin's version reports the SAME version,
+// and — on a clean tag — that it is the tag (agent-ix/quoin#196).
+//
+// The defect this exists to catch shipped once already, one repo over:
+// agent-ix/quire-cli#52, where the 0.24.0–0.28.0 tags all shipped binaries
+// reporting 0.23.0. Version provenance is load-bearing here — every SpecReview
+// records the tool version it measured with, and three reviews in
+// agent-ix/filament-ide-rs cite numbers from a binary whose self-reported
+// version was wrong.
+//
+// Runs against the BUILT binary, not the source: the disagreement was between
+// a build-time baked value and package.json, so only a built artifact can show
+// it. `make build` first.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const bin = join(root, "bin", "quoin.js");
+
+if (!existsSync(join(root, "dist", "cli.js"))) {
+  console.error("check-version: dist/ is absent — run `make build` first");
+  process.exit(2);
+}
+
+const runBin = (args) =>
+  execFileSync(process.execPath, [bin, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+const flag = runBin(["--version"]).trim();
+
+// oclif renders `VERSION\n  <name>/<version> <platform> <node>`.
+const help = runBin(["--help"]);
+const block = help.match(/^VERSION\n\s+\S+\/(\S+)/m);
+if (!block) {
+  console.error("check-version: no VERSION block in `--help` output");
+  process.exit(1);
+}
+const helpVersion = block[1];
+
+let failed = false;
+const check = (ok, message) => {
+  console.log(`${ok ? "ok  " : "FAIL"} ${message}`);
+  if (!ok) failed = true;
+};
+
+check(
+  flag === helpVersion,
+  `--version (${flag}) and --help (${helpVersion}) agree`,
+);
+
+// A clean tag must report itself. A build ahead of its tag reports the drift
+// suffix, which is the point of baking `git describe` and is not a failure.
+let describe = null;
+try {
+  describe = execFileSync("git", ["describe", "--tags", "--dirty"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+} catch {
+  console.log("skip  no git tag reachable — drift check not applicable");
+}
+
+if (describe) {
+  const clean = /^v?\d+\.\d+\.\d+$/.test(describe);
+  if (clean) {
+    check(
+      flag === describe.replace(/^v/, ""),
+      `a clean tag reports itself (${flag} vs ${describe})`,
+    );
+  } else {
+    console.log(
+      `skip  build is ahead of its tag (${describe}) — drift expected`,
+    );
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/skills/spec-review/workflow-assets/skills/review/SKILL.md
+++ b/skills/spec-review/workflow-assets/skills/review/SKILL.md
@@ -24,9 +24,9 @@ document per analysis** under `spec/reviews/`, rather than a single freeform rep
   record it in the `request` interview as `review_set` plus `selected_analyses`:
   - `base` — the skill checklist only (ID formats, US/FR/TC quality, the six coverage
     rules). No analysis skills. `selected_analyses` is empty.
-  - `all` — `base` plus all six analyses: `failure-domain`, `integrity`, `dependency`,
-    `evidence`, `risk-complexity`, `scope-boundary`.
-  - `subset` — `base` plus the analyses the user picks from those six.
+  - `all` — `base` plus all seven analyses: `failure-domain`, `integrity`, `dependency`,
+    `evidence`, `risk-complexity`, `scope-boundary`, `ears-conformance`.
+  - `subset` — `base` plus the analyses the user picks from those seven.
 - **analyses_run — run the selected set, one SpecReview doc each.** Run each selected
   analysis (the matching `spec-*-analysis` skill). Prefer running them **in parallel** —
   each writes its own file, so there is no contention.
@@ -55,7 +55,7 @@ hand-copy). The structure below is a reference for what that skeleton contains �
 id: SR-001
 title: "<analysis> review of <scope>"
 type: SpecReview
-analysis: <failure-domain|integrity|dependency|evidence|risk-complexity|scope-boundary|base>
+analysis: <failure-domain|integrity|dependency|evidence|risk-complexity|scope-boundary|ears-conformance|base>
 scope: <spec paths / ids>
 review_set: <base|all|subset>
 ---

--- a/skills/spec-review/workflow-assets/skills/review/scripts/invariants.js
+++ b/skills/spec-review/workflow-assets/skills/review/scripts/invariants.js
@@ -1,6 +1,6 @@
 import { specInvariants } from "../../../dist/index.js";
 
-// Canonical "all" set — the six analyses named in the spec-review skill.
+// Canonical "all" set — the seven analyses named in the spec-review skill.
 const ALL_ANALYSES = [
   "failure-domain",
   "integrity",
@@ -8,6 +8,7 @@ const ALL_ANALYSES = [
   "evidence",
   "risk-complexity",
   "scope-boundary",
+  "ears-conformance",
 ];
 
 const norm = (value) =>
@@ -27,7 +28,7 @@ function findRequest(instance) {
 // Hard check (final gate): every selected analysis must have a recorded
 // `review_doc` (a rendered + quire-validated SpecReview doc on disk) before
 // the run can be accepted. 'base' selects nothing, so it passes trivially;
-// 'all' expands to the canonical six when the agent did not echo the list.
+// 'all' expands to the canonical seven when the agent did not echo the list.
 const selectedAnalysesCovered = ({ instance }) => {
   const request = findRequest(instance);
   const reviewSet = norm(request?.review_set);

--- a/skills/spec-review/workflow-assets/skills/review/workflows/review/def.yaml
+++ b/skills/spec-review/workflow-assets/skills/review/workflows/review/def.yaml
@@ -1,5 +1,5 @@
 name: review
-version: 0.2.0
+version: 0.2.1
 description: Run a composite specification review producing validated SpecReview docs.
 initialPhase: intake
 phases:
@@ -46,12 +46,12 @@ interviews:
         type: text
         required: true
       - key: review_set
-        prompt: "Review set: 'base' (skill checklist only), 'all' (the six analyses), or 'subset'."
+        prompt: "Review set: 'base' (skill checklist only), 'all' (the seven analyses), or 'subset'."
         type: enum
         options: [base, all, subset]
         required: true
       - key: selected_analyses
-        prompt: "Analyses to run as a list, drawn from: failure-domain, integrity, dependency, evidence, risk-complexity, scope-boundary. Use all six for 'all'; the chosen ones for 'subset'; leave empty for 'base'."
+        prompt: "Analyses to run as a list, drawn from: failure-domain, integrity, dependency, evidence, risk-complexity, scope-boundary, ears-conformance. Use all seven for 'all'; the chosen ones for 'subset'; leave empty for 'base'."
         type: list<text>
         required: false
 recipes:

--- a/spec/usecase/US-007-review-into-specreview-docs.md
+++ b/spec/usecase/US-007-review-into-specreview-docs.md
@@ -23,7 +23,7 @@ relationships:
 
 The bundled `spec-review` workflow (launched via `quoin review`, driven by
 `ix-flow`) lets the author choose a review set — `base`, `all`, or a `subset` of
-the six analyses — and produces one `SpecReview` document per selected analysis
+the seven analyses — and produces one `SpecReview` document per selected analysis
 under `spec/reviews/`. Each doc is a validated artifact: a `## Summary` plus a
 `## Findings` table whose `Severity` column is constrained to `low|medium|high`.
 The author keeps direct authoring, but two guardrails keep quality stable over
@@ -53,6 +53,12 @@ These examples clarify expectations; they are illustrative, not verification cri
 - **Given** a findings row whose `Severity` is `catastrophic`
 - **When** the doc is validated
 - **Then** validation fails because `Severity` must be one of `low|medium|high`
+
+### US-007-EX-4: The all review set includes EARS conformance
+
+- **Given** the author selects the `all` review set
+- **When** the workflow expands and checks the selected analyses
+- **Then** `ears-conformance` is required alongside the other six focused analyses and acceptance remains blocked until its validated review document is recorded
 
 ## Options (Exploratory)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,8 @@
-import { run, type RunnerLoadOptions } from "@agent-ix/ix-cli-core";
+import { fileURLToPath } from "node:url";
+
+import type { Config } from "@oclif/core";
+
+import { loadConfig, run, type RunnerLoadOptions } from "@agent-ix/ix-cli-core";
 
 import { packageVersion } from "./version.js";
 
@@ -58,5 +62,59 @@ export async function main(
     console.log(packageVersion());
     return;
   }
-  await run(argv, options);
+  await run(argv, await versionedConfig(options));
+}
+
+/**
+ * The oclif {@link Config} with its `version` corrected to the build-time one
+ * (#196).
+ *
+ * oclif reads `version` from `package.json`, which carries `0.9.0` — the
+ * placeholder the CI tag rewrite replaces on release. `--version` prints the
+ * baked `git describe` string. So a locally built binary reported two
+ * different versions depending on which flag you asked:
+ *
+ * ```
+ * $ quoin --version
+ * 0.21.2-27-g07aa699
+ * $ quoin --help
+ * VERSION
+ *   @agent-ix/quoin/0.9.0 wsl-x64 node-v22.15.0
+ * ```
+ *
+ * Version provenance is load-bearing here: every SpecReview records the tool
+ * version it measured with, and three reviews in `agent-ix/filament-ide-rs`
+ * cite numbers from a binary whose self-reported version was wrong. Same class
+ * as `agent-ix/quire-cli#52`, where five tags shipped binaries all reporting
+ * the version before them.
+ *
+ * The flag stays the source of truth — it is the one that knows about drift —
+ * and the help block is made to agree with it.
+ */
+export async function versionedConfig(
+  options?: RunnerLoadOptions,
+): Promise<Config> {
+  return loadConfig(withBakedVersion(options));
+}
+
+/**
+ * The load options with the build-time version injected.
+ *
+ * `Config` resolves `this.version = this.options.version || this.pjson.version`,
+ * so the **option** wins over `package.json` — and `Config.load` rebuilds from
+ * `opts.options`, so it survives the reload that `run`/`execute` perform.
+ *
+ * Mutating an already-loaded `Config` does not work and was the first thing
+ * tried: `Config.load` calls `new Config({...opts.options, plugins})` and
+ * re-runs `load()`, so the corrected `version` and `userAgent` are both
+ * discarded. Recorded here because the failure is silent — the mutation
+ * appears to take, and only the rendered help shows it did not.
+ *
+ * A non-string `options` (a pre-loaded `Config`, as the tests supply) passes
+ * through untouched: those callers own their own version.
+ */
+function withBakedVersion(options?: RunnerLoadOptions): RunnerLoadOptions {
+  if (typeof options !== "string") return options as RunnerLoadOptions;
+  const root = options.startsWith("file://") ? fileURLToPath(options) : options;
+  return { root, version: packageVersion() } as RunnerLoadOptions;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -26,7 +26,12 @@ vi.mock("../src/modules", () => ({
   defaultModulesManifest: () => ({ schemaVersion: 1, entries: [] }),
 }));
 
-import { main, packageVersion, resolveVersion } from "../src/cli";
+import {
+  main,
+  packageVersion,
+  resolveVersion,
+  versionedConfig,
+} from "../src/cli";
 import CatalogIndex from "../src/commands/catalog/index";
 import CatalogList from "../src/commands/catalog/list";
 import CatalogShow from "../src/commands/catalog/show";
@@ -282,7 +287,39 @@ describe("version", () => {
     expect(resolveVersion("")).toBe(packageVersion());
     expect(typeof resolveVersion("")).toBe("string");
   });
+
+  // #196: `--version` printed the baked `git describe` string while `--help`
+  // printed package.json's `0.9.0` — the placeholder the CI tag rewrite
+  // replaces. A locally installed build therefore reported two different
+  // versions depending on which flag you asked, and neither matched what npm
+  // served. Version provenance is load-bearing: every SpecReview records the
+  // tool version it measured with.
+  test("the oclif config carries the same version --version prints", async () => {
+    const config = await versionedConfig(binEntryUrl());
+    expect(config.version).toBe(packageVersion());
+    // `userAgent` is what the help header renders, and it is composed at load
+    // time from `version` — which is why injecting through the load options is
+    // the fix and mutating a loaded Config is not.
+    expect(config.userAgent).toContain(packageVersion());
+    expect(config.userAgent).toContain(config.name);
+  });
+
+  // The specific failure that made the first attempt look like it worked:
+  // `Config.load` rebuilds from `opts.options` and re-runs `load()`, so a
+  // version written onto an already-loaded Config is silently discarded. The
+  // injected option survives that round trip; this asserts the round trip.
+  test("the injected version survives the reload run/execute perform", async () => {
+    const { Config } = await import("@oclif/core");
+    const reloaded = await Config.load(await versionedConfig(binEntryUrl()));
+    expect(reloaded.version).toBe(packageVersion());
+    expect(reloaded.userAgent).toContain(packageVersion());
+  });
 });
+
+/** The bin script's own location — the load root the shipped entry point uses. */
+function binEntryUrl(): string {
+  return new URL("../bin/quoin.js", import.meta.url).href;
+}
 
 // ---- main() dispatch ---------------------------------------------------------
 

--- a/tests/spec-review-vocab-drift.test.ts
+++ b/tests/spec-review-vocab-drift.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+
+import { filamentModulesDir } from "../src/catalog.js";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const directSkill = readFileSync(
+  join(repoRoot, "skills/spec-review/SKILL.md"),
+  "utf8",
+);
+const workflowRoot = join(
+  repoRoot,
+  "skills/spec-review/workflow-assets/skills/review",
+);
+const workflowSkill = readFileSync(join(workflowRoot, "SKILL.md"), "utf8");
+const workflowDefinition = parseYaml(
+  readFileSync(join(workflowRoot, "workflows/review/def.yaml"), "utf8"),
+) as {
+  interviews: {
+    request: {
+      questions: Array<{ key: string; prompt: string }>;
+    };
+  };
+};
+const invariantSource = readFileSync(
+  join(workflowRoot, "scripts/invariants.js"),
+  "utf8",
+);
+
+const sorted = (values: Iterable<string>) => [...values].sort();
+
+function directAnalysisSet(): Set<string> {
+  return new Set(
+    [
+      ...directSkill.matchAll(
+        /^\|\s*([a-z][a-z-]+)\s*\|\s*`spec-[^`]+`\s*\|$/gm,
+      ),
+    ].map((match) => match[1]),
+  );
+}
+
+function workflowSkillSet(): Set<string> {
+  const section = /- `all`[^\n]*analyses:([\s\S]*?)\n\s*- `subset`/.exec(
+    workflowSkill,
+  );
+  expect(section, "workflow SKILL has no `all` analysis list").toBeTruthy();
+  return new Set(
+    [...(section?.[1] ?? "").matchAll(/`([a-z][a-z-]+)`/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+function workflowTemplateSet(): Set<string> {
+  const analysis = /^analysis: <([^>]+)>$/m.exec(workflowSkill);
+  expect(
+    analysis,
+    "workflow SKILL has no SpecReview analysis reference",
+  ).toBeTruthy();
+  return new Set(
+    (analysis?.[1] ?? "").split("|").filter((value) => value !== "base"),
+  );
+}
+
+function workflowPromptSet(): Set<string> {
+  const question = workflowDefinition.interviews.request.questions.find(
+    ({ key }) => key === "selected_analyses",
+  );
+  expect(question, "workflow has no selected_analyses question").toBeTruthy();
+  const list = /drawn from: ([^.]+)\./.exec(question?.prompt ?? "");
+  expect(list, "selected_analyses prompt has no declared list").toBeTruthy();
+  return new Set((list?.[1] ?? "").split(", "));
+}
+
+function invariantSet(): Set<string> {
+  const array = /const ALL_ANALYSES = (\[[\s\S]*?\]);/.exec(invariantSource);
+  expect(array, "invariant has no ALL_ANALYSES declaration").toBeTruthy();
+  return new Set(
+    [...(array?.[1] ?? "").matchAll(/"([a-z][a-z-]+)"/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+describe("spec-review analysis vocabulary", () => {
+  it("keeps the direct skill, workflow docs, intake, gate, and schema aligned", () => {
+    const direct = directAnalysisSet();
+    expect(direct.size).toBe(7);
+    expect(direct).toContain("ears-conformance");
+    expect(sorted(workflowSkillSet())).toEqual(sorted(direct));
+    expect(sorted(workflowTemplateSet())).toEqual(sorted(direct));
+    expect(sorted(workflowPromptSet())).toEqual(sorted(direct));
+    expect(sorted(invariantSet())).toEqual(sorted(direct));
+
+    const schema = JSON.parse(
+      readFileSync(
+        join(
+          filamentModulesDir(),
+          "spec-artifacts-process/schemas/spec-review-frontmatter.schema.json",
+        ),
+        "utf8",
+      ),
+    ) as { properties: { analysis: { enum: string[] } } };
+    for (const analysis of direct) {
+      expect(schema.properties.analysis.enum).toContain(analysis);
+    }
+  });
+
+  it("blocks an all-set review until the EARS review document is recorded", async () => {
+    const module = (await import(
+      pathToFileURL(join(workflowRoot, "scripts/invariants.js")).href
+    )) as {
+      invariants: Record<
+        string,
+        (input: { instance: Record<string, unknown> }) =>
+          | true
+          | {
+              ok: false;
+              code: string;
+              details: { missing: string[] };
+            }
+      >;
+    };
+    const direct = directAnalysisSet();
+    const reviewDocs = [...direct]
+      .filter((analysis) => analysis !== "ears-conformance")
+      .map((analysis) => ({ analysis, path: `spec/reviews/${analysis}.md` }));
+    const instance = {
+      items: {
+        operation_request: [{ interviewId: "request", review_set: "all" }],
+        review_doc: reviewDocs,
+      },
+    };
+
+    const incomplete = module.invariants.selected_analyses_covered({
+      instance,
+    });
+    expect(incomplete).toMatchObject({
+      ok: false,
+      code: "selected_analyses_not_run",
+      details: { missing: ["ears-conformance"] },
+    });
+
+    reviewDocs.push({
+      analysis: "ears-conformance",
+      path: "spec/reviews/ears-conformance.md",
+    });
+    expect(module.invariants.selected_analyses_covered({ instance })).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Closes agent-ix/quoin#196. Part of agent-ix/quoin#197.

## The defect

```
$ quoin --version
0.21.2-27-g07aa699

$ quoin --help
VERSION
  @agent-ix/quoin/0.9.0 wsl-x64 node-v22.15.0
```

`--version` prints the build-time `git describe`; oclif's VERSION block reads `package.json`'s `0.9.0` — the placeholder the CI tag rewrite replaces. A locally installed build reported two different versions depending on which flag you asked, and neither matched what npm served.

**Version provenance is load-bearing here.** Every SpecReview records the tool version it measured with, and three reviews in `agent-ix/filament-ide-rs` cite numbers from a binary whose self-reported version was wrong. Same class as agent-ix/quire-cli#52, where five consecutive tags shipped binaries all reporting the version before them.

## The fix is the load option, not the loaded object

`Config` resolves:

```js
this.version = this.options.version || this.pjson.version || '0.0.0'
```

— the **option** wins over `package.json`, and `Config.load` rebuilds from `opts.options`, so an injected option survives the reload.

### What did not work, and why it looked like it did

Mutating an already-loaded `Config` was the first attempt:

```ts
const config = await loadConfig(options);
config.version = packageVersion();
config.userAgent = /* recomposed */;
```

`Config.load` calls `new Config({...opts.options, plugins})` and re-runs `load()`, discarding **both**. Verified directly:

```
after Config.load -> 0.9.0 | @agent-ix/quoin/0.9.0 wsl-x64 node-v22.15.0
same object: false
```

The failure is silent — the mutation appears to take, and only the rendered help shows it did not. It is recorded in the code comment and pinned by a test that asserts the round trip specifically, so the next person does not spend the same hour.

`userAgent` matters too: it is what the help header renders and it is composed **at load time** from `version`, which is why injecting through the options is the fix.

## `make check-version`

Wired into `make test`. Asserts:

1. `--version` and the `--help` VERSION block agree.
2. A clean tag reports itself; a build ahead of its tag reports the drift suffix, which is the point of baking `git describe` and is not a failure.

It runs against the **built binary** — the disagreement was between a baked value and `package.json`, and only a built artifact can show it.

```
$ make check-version
ok   --version (0.21.2-27-g07aa699) and --help (0.21.2-27-g07aa699) agree
skip  build is ahead of its tag (v0.21.2-27-g07aa699-dirty) — drift expected
```

## Part 1 — the missing local-publish path

#196 offered *"either quoin should be publishable to npm.ix like a library, or the local-dogfood path should be documented so it is a deliberate choice rather than a discovery."* This takes the second option: `CLAUDE.md` now documents `npm i -g .`, why it exists (`ts-build-chain` classifies quoin as an app because it ships a `bin`), and the consequence — the only path to a registry is a git tag plus CI, so `main` carrying unreleased fixes means npm serves a build without them.

The classifier itself lives in `ts-build-chain`, not here. Making quoin publishable as a library is a packaging decision with its own blast radius and is not folded in.

## Verification

`make test` — **526 passed**, 47 files. `make lint` — clean. `make check-version` — ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDesP1LiJfUcsqGkrs8Zb6