### PR TITLE
test(bench): tier-1 seeded corpora and the tier-2 answer key (#199, #200)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,19 @@ test: build validate check-version
 # reports itself (quoin#196). The class of defect this catches shipped once
 # already one repo over: quire-cli#52, where five consecutive tags shipped
 # binaries all reporting the version before them. Run it before tagging.
+# Re-pin the tier-2 answer key (quoin#200). NOT a re-measurement: the findings
+# are claims about a specific tree, and carrying them to a different commit
+# without reading it again asserts something nobody checked. This target only
+# moves the pin — the adjudication is human work, and the diff belongs in the
+# pull request. Same discipline as quire-rs's coverage_baseline.
+.PHONY: answer-key-repin
+answer-key-repin:
+	@test -n "$(SHA)" || { echo "usage: make answer-key-repin SHA=<commit>"; exit 2; }
+	@echo "Re-pinning the answer key to $(SHA)."
+	@echo "STOP: re-read the corpus at that commit and re-adjudicate every finding."
+	@echo "Moving the pin without re-adjudicating turns the recall denominator into fiction."
+	python3 -c "import json,sys; p='bench/answer-key.json'; d=json.load(open(p)); d['pinned_sha']='$(SHA)'; json.dump(d, open(p,'w'), indent=2); open(p,'a').write('\n')"
+
 .PHONY: check-version
 check-version: build
 	node scripts/check-version-agreement.mjs

--- a/bench/answer-key.json
+++ b/bench/answer-key.json
@@ -1,0 +1,105 @@
+{
+  "$comment": "Tier-2 adjudicated answer key (agent-ix/quoin#200, FR-043-AC-8). The manual findings of battletest pass 2, made machine-readable and keyed to a pinned commit. This set is the RECALL DENOMINATOR for 'would the tools have found what humans found'. Every entry was adjudicated by reading the corpus, not inferred from tool output — which is the point, since the tools found none of them.",
+  "corpus": "agent-ix/filament-ide-rs",
+  "pinned_sha": "fc5d644",
+  "adjudicated": "2026-08-22",
+  "sources": [
+    "agent-ix/filament-ide-rs#451 (pass-2 umbrella)",
+    "SR-153, SR-154, SR-155",
+    "agent-ix/filament-ide-rs#460 (owed corpus findings)"
+  ],
+  "re_pin_policy": "Re-pinning requires RE-ADJUDICATION, not re-measurement. The findings below are claims about a specific tree; carrying them to a different commit without reading it again would assert something nobody checked. Use `make answer-key-repin`, whose diff belongs in the pull request — the same discipline as quire-rs/tests/fixtures/coverage_baseline/expected.json.",
+  "findings": [
+    {
+      "id": "AK-001",
+      "family": "marker-form-mismatch",
+      "summary": "The declared `rust-test-name-id` pattern has no separator, so `fn tc_NNN_` binds nothing.",
+      "measured": "1,292 `fn tc_NNN_` sites against 0 of the declared `fn tcNNN_` spelling. Widening the pattern took coverage from 555/2389 (23%) to 1158/2389 (48%) with no test written.",
+      "location": "declared in spec-artifacts-process; observed across 24 crates",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "controlled experiment — copy the module, widen one regex, diff the census",
+      "expect_reason": "no-symbol-bound",
+      "now_detectable": true,
+      "detectable_since": "quire-rs v0.43.0 (FR-050-AC-27)",
+      "fixed_by": "agent-ix/spec-artifacts-process#65"
+    },
+    {
+      "id": "AK-002",
+      "family": "hollow-denominator",
+      "summary": "`quire coverage` published a confident 23% over a corpus whose tag patterns matched nothing, with no signal that the premise was hollow.",
+      "measured": "0 of 1,292 evidence symbols bound; 0 of 643 trace lines matched. Three published SpecReviews (SR-150/151/152) cite figures computed under it.",
+      "location": "spec/**/matrix/tests.md, all 12 module matrices",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual — noticing that a 23% figure and a 1,292-symbol repository were inconsistent",
+      "expect_reason": "hollow-denominator",
+      "now_detectable": true,
+      "detectable_since": "quire-rs v0.43.0 (FR-063-AC-5)",
+      "fixed_by": "agent-ix/quire-rs#239"
+    },
+    {
+      "id": "AK-003",
+      "family": "catch-all-universal",
+      "summary": "The properties headline read 54% extractable; 440 of those 515 were the `universal` catch-all, so the figure for 'the tool told me what property to write' was 8%.",
+      "measured": "515/951 extractable; 78/951 specifically shaped. 65 of 67 specific-shape non-`example` records carried zero spans.",
+      "location": "274 spec files",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual — reading the per-shape breakdown the summary line omitted",
+      "expect_metric": "coverage.specific_shaped",
+      "now_detectable": true,
+      "detectable_since": "quire-rs v0.43.0 (FR-050-AC-28)",
+      "fixed_by": "agent-ix/quire-rs#240"
+    },
+    {
+      "id": "AK-004",
+      "family": "vacuous-under-guard",
+      "summary": "A property suite asserted nothing in a measured 97.7% of samples and was green throughout.",
+      "measured": "4,000 samples: `Ok(Some)` 2.3%, `Ok(None)` 79.0%, `Err` 18.8%. The assertion was inside the `Ok(Some)` arm.",
+      "location": "TC-1596",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual semantic review",
+      "expect_suspicion": "vacuous-under-guard",
+      "now_detectable": true,
+      "detectable_since": "quire-rs main, post v0.43.0 (FR-064-AC-1)",
+      "fixed_by": "agent-ix/quire-rs#247"
+    },
+    {
+      "id": "AK-005",
+      "family": "oracle-is-code-copy",
+      "summary": "A test oracle was a character-for-character copy of the code under test, redundant branch included.",
+      "measured": "Replacing it with a real oracle immediately exposed a genuine Windows containment gap.",
+      "location": "TC-1598",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual semantic review — pass 2's highest-value finding",
+      "expect_suspicion": "oracle-resembles-implementation",
+      "now_detectable": "partially",
+      "detectable_since": "quire-rs main, post v0.43.0 (FR-064-AC-2) — the COMPARISON is implemented; the join from an oracle span to the implementation it judges is not wired, so this is not yet detected end to end",
+      "fixed_by": "agent-ix/quire-rs#247"
+    },
+    {
+      "id": "AK-006",
+      "family": "mocked-confirmation",
+      "summary": "An acceptance criterion with no implementation passed via a mocked confirmation.",
+      "measured": "One AC; the mock stood in for the behaviour the AC asserts.",
+      "location": "pass-2 semantic review, SR-155",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual semantic review",
+      "now_detectable": false,
+      "detectable_since": null,
+      "fixed_by": null,
+      "tracked_by": "agent-ix/quoin#204"
+    },
+    {
+      "id": "AK-007",
+      "family": "gate-that-gates-nothing",
+      "summary": "Repository gates that gated nothing — wired, green, and asserting no condition that could fail.",
+      "measured": "Observed across the repo's own CI configuration during pass 2.",
+      "location": "pass-2 semantic review",
+      "found_by_tools_at_pass_2": false,
+      "found_by": "manual semantic review",
+      "now_detectable": false,
+      "detectable_since": null,
+      "fixed_by": null,
+      "tracked_by": "agent-ix/quoin#204"
+    }
+  ]
+}

--- a/evals/fixtures/bench/build.mjs
+++ b/evals/fixtures/bench/build.mjs
@@ -1,0 +1,254 @@
+// Tier-1 seeded-defect corpora (agent-ix/quoin#199, FR-043-AC-7).
+//
+// Every defect here is placed deliberately and enumerated in `labels.json`, so
+// precision and recall are computable rather than estimated. That is the whole
+// point: tier 2 (`filament-ide-rs` at a pinned SHA) tells you whether the tools
+// find what humans found in the wild; tier 1 tells you whether they find a
+// defect you KNOW is there, cheaply enough to run every time.
+//
+// Tier 1 alone overfits — a seeded defect is one somebody already knew how to
+// describe — which is why FR-043 requires both.
+//
+// Built with the existing `evals/lib/fixtures.mjs` helpers rather than a new
+// generator, per #199.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** The module every mini-repo is validated against. */
+const MODULE = `name: bench
+manifest_version: 1.0.0
+version: 0.0.1
+artifact_types:
+- name: FR
+  grammar_ref: iso-spec-core
+- name: TestMatrix
+  body_extraction:
+    yield_pattern:
+      match:
+        test_cases:
+          from: table_row
+          under_section: Test Cases
+          required: true
+          multiple: true
+          assert:
+            id_column: ID
+            column_choices:
+              Type: [Unit, Integration, Inspection]
+traceability:
+  trace_targets:
+  - name: test-case
+    archetype: TestMatrix
+    section: Test Cases
+    id_column: ID
+  - name: acceptance-criterion
+    archetype: FR
+    section: Acceptance Criteria
+    id_column: ID
+  document_references:
+  - name: traces-to
+    archetype: TestMatrix
+    section: Test Cases
+    row_id_column: ID
+    column: Traces To
+    targets: [acceptance-criterion, test-case]
+    pattern: '([A-Z]{2,4}-\\d+(?:-[A-Z]{2,4}-\\d+)?)'
+  status:
+    column: Status
+    complete: ["✅"]
+    pending: ["\u{1F6A7}"]
+  vocabularies:
+    test_type_column: Type
+    test_type: [Unit, Integration, Inspection]
+  trace_tags:
+    markers:
+    - name: rust-trace-attribute
+      language: rust
+      pattern: '#\\[trace\\(([^)]*)\\)\\]'
+      template: '#[trace({ids})]'
+`;
+
+const fr = (criteria) =>
+  `---\nid: FR-001\ntype: FR\n---\n\n## Acceptance Criteria\n\n` +
+  `| ID | Criteria | Verification |\n|----|----------|--------------|\n` +
+  criteria
+    .map((c, i) => `| FR-001-AC-${i + 1} | ${c} | Test (TC-00${i + 1}) |\n`)
+    .join("");
+
+const matrix = (rows) =>
+  `---\nid: TM-001\ntype: TestMatrix\n---\n\n## Test Cases\n\n` +
+  `| ID | Traces To | Type | Status |\n|----|-----------|------|--------|\n` +
+  rows.map((r) => `| ${r} |\n`).join("");
+
+/**
+ * The corpora. Each is one defect FAMILY in isolation — a mini-repo mixing
+ * three defects cannot tell you which one a finding was about, and precision
+ * per family is what FR-043-AC-2 asks for.
+ */
+export const CORPORA = [
+  {
+    name: "marker-mismatch",
+    family: "marker-form-mismatch",
+    summary:
+      "Real tests, real tags, a marker spelling the module never declared. " +
+      "1,292 such symbols in filament-ide-rs bound nothing and the report said 23%.",
+    files: {
+      "module/manifest.yaml": MODULE,
+      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | \u{1F6A7}"]),
+      "src/lib.rs":
+        '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[tracks("TC-001")]\n' +
+        "    #[test]\n    fn covers() {\n        assert_eq!(1, 1);\n    }\n}\n",
+    },
+    defects: [
+      {
+        id: "MM-1",
+        family: "marker-form-mismatch",
+        location: "src/lib.rs:5",
+        row_id: "TC-001",
+        findable: true,
+        expect_reason: "no-symbol-bound",
+        note: "the module declares `#[trace(...)]`; the source writes `#[tracks(...)]`",
+        confirmed_at: "quire-rs v0.43.0",
+      },
+    ],
+  },
+  {
+    name: "wrong-type-cell",
+    family: "undeclared-type-value",
+    summary:
+      "A `Type` cell naming a verification method the vocabulary has no word " +
+      "for. 128 such rows in filament-ide-rs, and the `Inspection` ones were " +
+      "reported as status lies because no declared type said what they are.",
+    files: {
+      "module/manifest.yaml": MODULE,
+      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Demonstration | ✅"]),
+      "src/lib.rs":
+        '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +
+        "    #[test]\n    fn covers() {\n        assert_eq!(1, 1);\n    }\n}\n",
+    },
+    defects: [
+      {
+        id: "WT-1",
+        family: "undeclared-type-value",
+        location: "spec/tests.md:8",
+        row_id: "TC-001",
+        findable: true,
+        expect_reason: "assert",
+        note:
+          "`Demonstration` is not in this module's declared test_type vocabulary. " +
+          "The first draft of this label was WRONG: the module declared the " +
+          "vocabulary but no `column_choices` assert, so nothing could fire. " +
+          "Verifying the labels is what caught it.",
+        confirmed_at: "quire-rs v0.43.0",
+      },
+    ],
+  },
+  {
+    name: "catch-all-properties",
+    family: "catch-all-universal",
+    summary:
+      "Every extractable criterion is the `universal` catch-all, so the " +
+      "extractable headline reads far higher than the figure for 'the tool " +
+      "told me what property to write' — 54% against 8% in pass 2.",
+    files: {
+      "module/manifest.yaml": MODULE,
+      "spec/FR-001.md": fr([
+        "Every request shall carry a trace id.",
+        "Every response shall carry a status.",
+      ]),
+      "spec/tests.md": matrix([
+        "TC-001 | FR-001-AC-1 | Unit | \u{1F6A7}",
+        "TC-002 | FR-001-AC-2 | Unit | \u{1F6A7}",
+      ]),
+      "src/lib.rs": "//! seeded, no tests\n",
+    },
+    defects: [
+      {
+        id: "CA-1",
+        family: "catch-all-universal",
+        location: "spec/FR-001.md",
+        row_id: null,
+        findable: true,
+        expect_metric: "coverage.specific_shaped",
+        expect_value: 0,
+        note: "specific_shaped must be 0 while property_shaped is not",
+        confirmed_at: "quire-rs v0.43.0",
+      },
+    ],
+  },
+  {
+    name: "vacuous-property-suite",
+    family: "vacuous-under-guard",
+    summary:
+      "Every assertion sits behind a narrowing guard, so an input that does " +
+      "not enter it passes unchecked. TC-1596 was green while checking 2.3% " +
+      "of its samples.",
+    files: {
+      "module/manifest.yaml": MODULE,
+      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
+      "src/lib.rs":
+        '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +
+        "    #[test]\n    fn covers() {\n" +
+        "        if let Some(v) = parse() {\n            assert_eq!(v, 1);\n        }\n" +
+        "    }\n}\n",
+    },
+    defects: [
+      {
+        id: "VP-1",
+        family: "vacuous-under-guard",
+        location: "src/lib.rs:7",
+        row_id: "TC-001",
+        findable: true,
+        expect_suspicion: "vacuous-under-guard",
+        note: "the only assertion is inside an `if let`",
+        // Confirmed against the detector directly; the CLI surface needs an
+        // engine newer than v0.43.0, which is when `suspicions` landed.
+        confirmed_at: "quire-rs main (post v0.43.0)",
+        needs_engine: "> v0.43.0",
+      },
+    ],
+  },
+  {
+    name: "clean-control",
+    family: "none",
+    summary:
+      "No seeded defect. The control every corpus needs and most lack: a " +
+      "check that cannot stay silent on healthy input is not a check, it is " +
+      "a constant.",
+    files: {
+      "module/manifest.yaml": MODULE,
+      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
+      "src/lib.rs":
+        '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +
+        "    #[test]\n    fn covers() {\n        assert_eq!(parse(), 1);\n    }\n}\n",
+    },
+    defects: [],
+  },
+];
+
+/** Materialize every corpus under `root`, and write the label file. */
+export function buildBenchCorpora(root) {
+  const labels = { corpora: [] };
+  for (const corpus of CORPORA) {
+    for (const [rel, body] of Object.entries(corpus.files)) {
+      const target = join(root, corpus.name, rel);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, body);
+    }
+    labels.corpora.push({
+      name: corpus.name,
+      family: corpus.family,
+      summary: corpus.summary,
+      defects: corpus.defects,
+    });
+  }
+  writeFileSync(
+    join(root, "labels.json"),
+    JSON.stringify(labels, null, 2) + "\n",
+  );
+  return labels;
+}

--- a/tests/bench-corpora.test.ts
+++ b/tests/bench-corpora.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The tier-1 seeded corpora and their labels (quoin#199, FR-043-AC-7).
+ *
+ * A label nobody checks is a claim, not ground truth. These tests assert the
+ * SHAPE of the label set — the part that makes precision and recall computable
+ * — and the build's determinism. Whether each seeded defect is actually found
+ * is verified against a real engine and recorded per defect in `confirmed_at`;
+ * doing it here would make the unit suite depend on a `quire` binary.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildBenchCorpora, CORPORA } from "../evals/fixtures/bench/build.mjs";
+
+function build() {
+  const root = mkdtempSync(join(tmpdir(), "quoin-bench-"));
+  const labels = buildBenchCorpora(root);
+  return { root, labels };
+}
+
+describe("tier-1 seeded corpora", () => {
+  test("every corpus isolates ONE defect family", () => {
+    // A mini-repo mixing three defects cannot tell you which one a finding was
+    // about, and precision PER FAMILY is what FR-043-AC-2 asks for.
+    for (const corpus of CORPORA) {
+      const families = new Set(corpus.defects.map((d) => d.family));
+      expect(families.size).toBeLessThanOrEqual(1);
+      for (const family of families) expect(family).toBe(corpus.family);
+    }
+  });
+
+  test("there is a clean control with no seeded defect", () => {
+    // The control most corpora lack: a check that cannot stay silent on
+    // healthy input is not a check, it is a constant. Two of the checks in
+    // this programme were deleted for exactly that (quire-rs CR-094).
+    const clean = CORPORA.filter((c) => c.defects.length === 0);
+    expect(clean.length).toBeGreaterThanOrEqual(1);
+    for (const c of clean) expect(c.family).toBe("none");
+  });
+
+  test("every seeded defect is fully labelled", () => {
+    for (const corpus of CORPORA) {
+      for (const defect of corpus.defects) {
+        expect(defect.id).toMatch(/^[A-Z]{2}-\d+$/);
+        expect(defect.family).toBe(corpus.family);
+        expect(defect.location).toBeTruthy();
+        // `findable` distinguishes a scored MISS from a defect nobody claimed
+        // was findable — FR-043-AC-7's whole point.
+        expect(typeof defect.findable).toBe("boolean");
+        expect(defect.note).toBeTruthy();
+        // The engine the label was CONFIRMED against. A label verified by
+        // nobody is a claim; this records who checked and with what.
+        expect(defect.confirmed_at).toBeTruthy();
+        // Exactly one expectation kind, so scoring never has to guess.
+        const kinds = [
+          "expect_reason",
+          "expect_metric",
+          "expect_suspicion",
+        ].filter((k) => k in defect);
+        expect(kinds).toHaveLength(1);
+      }
+    }
+  });
+
+  test("defect ids are unique across the whole corpus set", () => {
+    const ids = CORPORA.flatMap((c) => c.defects.map((d) => d.id));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("the build is deterministic and writes labels.json", () => {
+    const a = build();
+    const b = build();
+    try {
+      expect(a.labels).toEqual(b.labels);
+      const onDisk = JSON.parse(
+        readFileSync(join(a.root, "labels.json"), "utf8"),
+      );
+      expect(onDisk).toEqual(a.labels);
+      // Every corpus materializes its module, spec and source.
+      for (const corpus of CORPORA) {
+        for (const rel of Object.keys(corpus.files)) {
+          expect(
+            readFileSync(join(a.root, corpus.name, rel), "utf8").length,
+          ).toBeGreaterThan(0);
+        }
+      }
+    } finally {
+      rmSync(a.root, { recursive: true, force: true });
+      rmSync(b.root, { recursive: true, force: true });
+    }
+  });
+
+  test("every named battletest failure family has a corpus", () => {
+    // The families #197 enumerates. `stale-name-correct-trace` and
+    // `oracle=code-copy` are deliberately absent here and covered as
+    // declarative cases in quire-rs (tests/fixtures/corpus_cases), where the
+    // engine can be driven directly — duplicating them would give two places
+    // to update and one to forget.
+    const covered = new Set(CORPORA.map((c) => c.family));
+    for (const family of [
+      "marker-form-mismatch",
+      "undeclared-type-value",
+      "catch-all-universal",
+      "vacuous-under-guard",
+    ]) {
+      expect(covered).toContain(family);
+    }
+  });
+});
+
+describe("tier-2 adjudicated answer key", () => {
+  const key = JSON.parse(
+    readFileSync(join(__dirname, "..", "bench", "answer-key.json"), "utf8"),
+  );
+
+  test("it is pinned to a commit and says why re-pinning is not free", () => {
+    // A tier-2 score is only a measurement because the corpus cannot move
+    // under it. Re-pinning requires RE-ADJUDICATION, not re-measurement:
+    // carrying these findings to a different tree would assert something
+    // nobody checked.
+    expect(key.pinned_sha).toMatch(/^[0-9a-f]{7,40}$/);
+    expect(key.corpus).toBe("agent-ix/filament-ide-rs");
+    expect(key.re_pin_policy).toMatch(/re-adjudication/i);
+    expect(key.sources.length).toBeGreaterThan(0);
+  });
+
+  test("every finding records how it was found, and it was not the tools", () => {
+    // The EPIC's premise, as data: every conclusion-changing finding of pass 2
+    // came from manual work. This is the recall denominator — if the tools had
+    // found them, there would be nothing to measure improvement against.
+    expect(key.findings.length).toBeGreaterThanOrEqual(5);
+    for (const f of key.findings) {
+      expect(f.id).toMatch(/^AK-\d{3}$/);
+      expect(f.family).toBeTruthy();
+      expect(f.summary).toBeTruthy();
+      expect(f.measured).toBeTruthy();
+      expect(f.found_by).toBeTruthy();
+      expect(f.found_by_tools_at_pass_2).toBe(false);
+    }
+  });
+
+  test("a finding that is not yet detectable says so and names its ticket", () => {
+    // The honest half. Claiming detection the toolchain does not have would
+    // make the recall number a fiction, which is the exact failure this
+    // programme exists to end.
+    for (const f of key.findings) {
+      if (f.now_detectable === true || f.now_detectable === "partially") {
+        expect(f.detectable_since).toBeTruthy();
+      } else {
+        expect(f.now_detectable).toBe(false);
+        expect(f.detectable_since).toBeNull();
+        expect(f.tracked_by).toMatch(/#\d+$/);
+      }
+    }
+  });
+
+  test("finding ids are unique", () => {
+    const ids = key.findings.map((f: { id: string }) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
Closes agent-ix/quoin#199, agent-ix/quoin#200. WS2 of agent-ix/quoin#197, implementing FR-043-AC-7 and AC-8.

## #199 — tier 1: five mini-repos, one defect family each

| corpus | family |
|---|---|
| `marker-mismatch` | an undeclared marker spelling |
| `wrong-type-cell` | a `Type` value the vocabulary has no word for |
| `catch-all-properties` | every extractable criterion is the catch-all |
| `vacuous-property-suite` | every assertion behind a narrowing guard |
| `clean-control` | **no seeded defect** |

One family each, deliberately: a repo mixing three defects cannot tell you which one a finding was about, and precision **per family** is what FR-043-AC-2 asks for.

**The control is not filler.** A check that cannot stay silent on healthy input is not a check, it is a constant — two checks in this programme were deleted for exactly that (quire-rs CR-094).

Built with the existing `evals/lib/fixtures.mjs` conventions rather than a new generator, per the ticket.

### The labels are verified, not asserted — and one was wrong

Running all five against a `quire-cli` built at the **v0.43.0** pin found that `wrong-type-cell` declared the `test_type` vocabulary but **no `column_choices` assert**, so nothing could fire. The label claimed a defect the module could not detect. Verifying is what caught it.

Every defect now records `confirmed_at` — the engine its label was confirmed against — and the vacuity label records `needs_engine: "> v0.43.0"`, since `suspicions` landed after that tag.

That run also showed agent-ix/quire-cli#58 working end to end:

```
spec/tests.md: line 9: [TestMatrix] 'test_cases': TC-001: column 'Type'
  cell 'Demonstration' is not one of ["Unit", "Integration", "Inspection"]
```

Row id, own line — where before there were 496 findings sharing one line per document.

## #200 — tier 2: the adjudicated answer key

The manual findings of pass 2, machine-readable and keyed to `filament-ide-rs @ fc5d644`. This is the **recall denominator**, and its headline is the EPIC's premise as data:

| | |
|---|---|
| findings | **7** |
| found by the tools at pass 2 | **0** |
| now detectable | **4** |
| partially detectable | **1** |
| not yet detectable | **2** |

The two that are not yet detectable say so, carry a **null** `detectable_since`, and name their ticket (agent-ix/quoin#204). Claiming detection the toolchain does not have would make the recall number a fiction — which is the failure this programme exists to end.

`AK-005` (oracle-is-code-copy) is recorded as **`"partially"`**: the comparison is implemented (quire-rs FR-064-AC-2) but the join from an oracle span to the implementation it judges is not wired, so it is not detected end to end. Said plainly rather than counted as a win.

### Re-pinning is not re-measurement

`make answer-key-repin SHA=<commit>` moves the pin and prints that re-adjudication is human work:

```
STOP: re-read the corpus at that commit and re-adjudicate every finding.
Moving the pin without re-adjudicating turns the recall denominator into fiction.
```

The findings are claims about a specific tree. Same discipline as `quire-rs/tests/fixtures/coverage_baseline/expected.json`.

## Verification

`make test` — **536 passed**, 48 files. `make lint` — clean.

10 new tests: one-family-per-corpus, the clean control exists, every defect fully labelled with exactly one expectation kind, unique ids, deterministic build, every named failure family covered — plus, for the answer key, that it is pinned, that every finding records how it was found and that it was not the tools, and that an undetectable finding names its ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDesP1LiJfUcsqGkrs8Zb6