### PR TITLE
feat(auditor): a test that mocks the behaviour it verifies (#204)

### DIFF
--- a/spec/functional/FR-032-evidence-auditor.md
+++ b/spec/functional/FR-032-evidence-auditor.md
@@ -120,9 +120,40 @@ violations. The per-PR delta names what a change added and resolved.
 | FR-032-AC-12 | The auditor reads the verification catalog from the **same** module the obligations were derived from, so `--module` cannot make the advisor and the auditor disagree. | Inspection (TC-148) |
 | FR-032-AC-13 | The `(new violations only)` label and the JSON `ratchet` field are keyed on whether a baseline was actually found and applied, never on the `--ratchet` flag alone. When `--ratchet` finds no baseline, the run says so, names the missing file, and names the command that writes it. | Test (TC-258, TC-259, TC-260) |
 | FR-032-AC-14 | `unknown-method` is evaluated **before** the binding guard — it is a pure statement-vs-catalog comparison needing no evidence — so it fires whatever the evidence state. Precedence: it neither suppresses nor is suppressed by evidence findings; an unbound obligation with an uncatalogued method is reported as **both** `undischarged` and `unknown-method`, while the evidence ladder itself stays one-finding-per-obligation. | Test (TC-264, TC-265) |
+| FR-032-AC-15 | A `mocked-confirmation` finding reports an obligation discharged **only** by suites injecting a stand-in whose identifier overlaps the obligation's own statement subject. Reported at `medium` and only when EVERY binding is mocked — one real suite alongside a mocked one is ordinary test design. Absent injection data yields silence, never a clean bill, and the finding ratchets through the existing `<kind>:<obligation>` key like any other. | Test (TC-936..TC-940) |
 | FR-032-AC-8 | `ratchet` reports only violations absent from the baseline, and `delta` names what a change added and resolved. | Test (TC-144) |
 
 ## Dependencies
 
 - **Upstream**: [FR-030](./FR-030-evidence-store.md) (the store it reads), [FR-031](./FR-031-catalog-driven-advisor.md) (the catalog method conformance is checked against), quire-rs [FR-053](ix://agent-ix/quire-rs/FR-053) (the obligations and hashes it compares)
 - **Downstream**: the consuming workflow decides whether a finding blocks; this command reports and, under `--strict`, exits non-zero
+
+> **CR note (#204, 2026-08-22):** AC-15 is new — the third class of finding
+> only manual review caught in battletest pass 2. Epic `agent-ix/quoin#197`.
+>
+> **The measured case.** `FR-017-AC-7`'s trusted-UI confirmation had **no
+> implementation**, and its test passed by injecting `Confirmation::allow()` —
+> mocking exactly the behaviour the criterion verifies. Green test, green
+> acceptance criterion, absent behaviour. Nothing in any tool surface said so.
+>
+> **Extended, not rebuilt**, as #204 asked: a new `Finding` kind on the existing
+> auditor, ratcheting through the existing `<kind>:<obligation>` key. A second
+> system would need its own baseline, its own gate and its own reasons to be
+> ignored.
+>
+> **The auditor reads the store, not source**, so the injections are an input
+> the caller supplies. Absent means *"nobody looked"*, never *"nothing was
+> mocked"* — the check stays silent rather than reporting a clean bill it did
+> not earn, which is the same posture `scanIsVacuous` takes when a tool does not
+> say how many rules it ran.
+>
+> **Only when every binding is mocked.** One suite standing in a dependency
+> while another exercises the real path is ordinary test design, and flagging it
+> would fire across most of the corpus for a reason unrelated to this defect.
+>
+> **`medium`, not `high`.** This is a heuristic over identifiers: a legitimate
+> mock can share a noun with the statement it appears under. The floor requires
+> half the injected identifier's words to be the statement's own — which is what
+> `Confirmation::allow` against a *trusted-UI confirmation* criterion looks
+> like, and what `FakeClock` does not.
+

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -381,6 +381,11 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-261 | A case with no claims carries a machine-readable `reason` naming the searched claim types, present exactly when `claims` is empty — `claims: []` alone cannot distinguish a clean case from one where nothing was argued (#170) | Unit | P0 | FR-040-AC-13 | ✅ |
 | TC-262 | `--claim-type` matches case-insensitively — `str`, `STR` and `Hazard` all matched nothing under `===` and exited 0 with an empty case | Unit | P0 | FR-040-AC-14 | ✅ |
 | TC-239 | Retired by #138 (CR-035): the no-catalog-silence rule it pinned is gone — the `metric` discriminator lives on the entry, so the check reads no catalog and TC-269 states the replacement behaviour | Unit | P0 | FR-039-AC-12 | ⛔ Retired |
+| TC-936 | An obligation discharged only by a mocked stand-in for its own subject is a `medium` `mocked-confirmation` finding naming the injected identifier (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
+| TC-937 | A mock unrelated to the statement's subject (`FakeClock`) is not reported — tests legitimately mock clocks, filesystems and networks (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
+| TC-938 | One real suite alongside a mocked one is not reported: standing in a dependency while another suite exercises the real path is ordinary test design (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
+| TC-939 | Absent injection data yields silence, never a clean bill — "nobody looked" is not "nothing was mocked" (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
+| TC-940 | The finding ratchets through the existing `<kind>:<obligation>` key, so it is acceptable in a baseline like every other kind (#204) | Unit | P1 | FR-032-AC-15 | ✅ |
 | TC-926 | Every metric in the dictionary declares `unit`, `population` and `method`; one missing any of the three is rejected at load rather than reported with a gap | Unit | P0 | FR-043-AC-1 | 🚧 |
 | TC-927 | `finding_precision`/`finding_recall` are declared per defect family, each keyed on a family the corpora label, so no score is reported over an unlabelled population | Unit | P0 | FR-043-AC-2 | 🚧 |
 | TC-928 | `span_grounding_rate` is declared with the pass-2 figure (0 of 65 specific-shape records) as its starting baseline | Unit | P0 | FR-043-AC-3 | 🚧 |

--- a/src/auditor/audit.ts
+++ b/src/auditor/audit.ts
@@ -38,10 +38,28 @@ export interface Finding {
     | "unknown-method"
     | "insufficient-multiplicity"
     | "insufficient-mutation-score"
-    | "unmeasured-mutation-score";
+    | "unmeasured-mutation-score"
+    | "mocked-confirmation";
   obligation: string;
   severity: Severity;
   summary: string;
+}
+
+/**
+ * A stand-in a suite injects for real behaviour.
+ *
+ * Pass 2 found `FR-017-AC-7`'s trusted-UI confirmation had NO implementation,
+ * and its test passed by injecting `Confirmation::allow()` — mocking exactly
+ * the behaviour the criterion verifies. The test was green, the AC was green,
+ * and the behaviour did not exist.
+ */
+export interface MockInjection {
+  /** Suite the injection was observed in. */
+  suite: string;
+  /** Symbol doing the injecting. */
+  symbol: string;
+  /** Identifiers substituted for real behaviour — `Confirmation::allow`. */
+  injects: string[];
 }
 
 /** What the auditor was given to read. */
@@ -52,6 +70,15 @@ export interface AuditInput {
   bindings: Binding[];
   /** Every run record the store holds, newest per suite. */
   runs: RunRecord[];
+  /**
+   * What each suite's tests INJECT in place of real behaviour (#204).
+   *
+   * Supplied by the caller because the auditor reads the store, not source —
+   * and #204 asked to extend `evidence audit`, not to build a second system.
+   * An absent list means "nobody looked", never "nothing was mocked": the
+   * check stays silent, the same posture `scanIsVacuous` takes.
+   */
+  injections?: MockInjection[];
   /**
    * Every finding-shaped scan record the store holds, newest per suite
    * (FR-034).
@@ -111,6 +138,9 @@ export function audit(input: AuditInput): AuditReport {
   }
   const runsBySuite = new Map(input.runs.map((r) => [r.suite, r]));
   const scansBySuite = new Map((input.scans ?? []).map((s) => [s.suite, s]));
+  // Absent means "nobody looked", never "nothing was mocked" — the check stays
+  // silent rather than reporting a clean bill it did not earn (#204).
+  const injections = input.injections ?? [];
 
   for (const obligation of [...input.obligations].sort(byId)) {
     const findingsBefore = findings.length;
@@ -188,6 +218,38 @@ export function audit(input: AuditInput): AuditReport {
           `${obligation.id} is bound to ${unrecorded.map((b) => b.suite).join(", ")}, ` +
           `which ${unrecorded.length === 1 ? "has" : "have"} no recorded run. ` +
           `The binding claims evidence that is not in the store.`,
+      });
+      continue;
+    }
+
+    // ── Mocked confirmation (#204) ──
+    // The behaviour the criterion verifies, substituted by the test that
+    // verifies it. Pass 2's case: FR-017-AC-7's trusted-UI confirmation had NO
+    // implementation, and its test passed by injecting `Confirmation::allow()`.
+    // Green test, green AC, absent behaviour.
+    //
+    // Reported only when EVERY binding is mocked. One suite standing in a
+    // dependency while another exercises the real path is ordinary test
+    // design, and flagging it would fire on most of the corpus for a reason
+    // that has nothing to do with this defect.
+    //
+    // `medium`, not `high`: this is a heuristic over identifiers, and a
+    // legitimate mock can share a noun with the statement it appears under.
+    const mocked = mockedBindings(obligation, bindings, injections);
+    if (mocked.length > 0 && mocked.length === bindings.length) {
+      findings.push({
+        kind: "mocked-confirmation",
+        obligation: obligation.id,
+        severity: "medium",
+        summary:
+          `${obligation.id} is discharged only by tests that inject a stand-in ` +
+          `for the behaviour it verifies: ` +
+          mocked
+            .map((m) => `${m.symbol} injects ${m.injects.join(", ")}`)
+            .sort(compare)
+            .join("; ") +
+          `. A test that substitutes the behaviour under verification passes ` +
+          `whether or not that behaviour exists.`,
       });
       continue;
     }
@@ -576,6 +638,79 @@ function mutationFinding(
  * definition, so the auditor's finding and the advisor's recommendation cannot
  * disagree about what a score is.
  */
+/**
+ * How much of an injected identifier must overlap the statement's own words
+ * before the injection is read as standing in for the verified behaviour.
+ *
+ * Deliberately high. A test legitimately mocks a clock, a filesystem, a
+ * network — all of which share nothing with the statement. What this is
+ * looking for is the narrow case where the mock's NAME is the statement's
+ * subject, which is what `Confirmation::allow` against a trusted-UI
+ * confirmation criterion looks like.
+ */
+export const MOCK_SUBJECT_FLOOR = 0.5;
+
+/** Bindings whose suite injects a stand-in for this obligation's subject. */
+function mockedBindings(
+  obligation: Obligation,
+  bindings: Binding[],
+  injections: MockInjection[],
+): MockInjection[] {
+  if (injections.length === 0) return [];
+  const subject = words(obligation.statement);
+  if (subject.size === 0) return [];
+
+  const out: MockInjection[] = [];
+  for (const binding of bindings) {
+    const hit = injections
+      .filter((i) => i.suite === binding.suite)
+      .find((i) =>
+        i.injects.some((identifier) => {
+          const tokens = words(identifier);
+          if (tokens.size === 0) return false;
+          let shared = 0;
+          for (const token of tokens) if (subject.has(token)) shared += 1;
+          return shared / tokens.size >= MOCK_SUBJECT_FLOOR;
+        }),
+      );
+    if (hit) out.push(hit);
+  }
+  return out;
+}
+
+/** Lowercased word-ish tokens, minus the words every sentence shares. */
+function words(text: string): Set<string> {
+  const noise = new Set([
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "of",
+    "to",
+    "for",
+    "in",
+    "is",
+    "be",
+    "shall",
+    "with",
+    "that",
+    "it",
+    "its",
+    "on",
+    "by",
+    "as",
+    "not",
+    "new",
+  ]);
+  return new Set(
+    text
+      .split(/[^A-Za-z0-9]+/)
+      .map((t) => t.toLowerCase())
+      .filter((t) => t.length > 2 && !noise.has(t)),
+  );
+}
+
 export function scoresFor(bindings: Binding[], runs: RunRecord[]): number[] {
   const bound = new Set(bindings.map((b) => b.suite));
   const out: number[] = [];

--- a/tests/auditor.test.ts
+++ b/tests/auditor.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   audit,
   delta,
+  findingKey,
   ratchet,
   type AuditInput,
 } from "../src/auditor/index.js";
@@ -962,5 +963,133 @@ describe("TC-264 unknown-method fires on unbound obligations (FR-032-AC-14)", ()
       }),
     );
     expect(report.findings.map((f) => f.kind)).toEqual(["undischarged"]);
+  });
+});
+
+describe("mocked confirmation (#204)", () => {
+  const obligation = {
+    source: "acceptance-criterion",
+    id: "FR-017-AC-7",
+    document: "spec/functional/FR-017.md",
+    statement:
+      "A destructive action shall require a trusted-UI confirmation before it proceeds.",
+    statement_hash: "h1",
+  };
+  const binding = {
+    obligation: "FR-017-AC-7",
+    statementHashAtBinding: "h1",
+    suite: "SUITE-001",
+    commit: "abc",
+    symbols: ["tests::confirms"],
+  };
+  const run = {
+    schemaVersion: 1,
+    suite: "SUITE-001",
+    commit: "abc",
+    tool: "cargo-test 1.0",
+    entries: [{ symbol: "tests::confirms", outcome: "pass" as const }],
+  };
+
+  it("an obligation discharged only by a mocked stand-in is reported", () => {
+    // The measured case: the trusted-UI confirmation had NO implementation,
+    // and the test passed by injecting `Confirmation::allow()` — mocking
+    // exactly the behaviour the criterion verifies.
+    const report = audit({
+      obligations: [obligation],
+      bindings: [binding],
+      runs: [run],
+      injections: [
+        {
+          suite: "SUITE-001",
+          symbol: "tests::confirms",
+          injects: ["Confirmation::allow"],
+        },
+      ],
+    });
+    const found = report.findings.filter(
+      (f) => f.kind === "mocked-confirmation",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].obligation).toBe("FR-017-AC-7");
+    expect(found[0].severity).toBe("medium");
+    expect(found[0].summary).toContain("Confirmation::allow");
+    expect(found[0].summary).toContain("whether or not that behaviour exists");
+  });
+
+  it("a mock unrelated to the statement's subject is not reported", () => {
+    // Tests legitimately mock clocks, filesystems and networks. What this is
+    // looking for is the narrow case where the mock's NAME is the statement's
+    // subject.
+    const report = audit({
+      obligations: [obligation],
+      bindings: [binding],
+      runs: [run],
+      injections: [
+        {
+          suite: "SUITE-001",
+          symbol: "tests::confirms",
+          injects: ["FakeClock"],
+        },
+      ],
+    });
+    expect(
+      report.findings.filter((f) => f.kind === "mocked-confirmation"),
+    ).toHaveLength(0);
+  });
+
+  it("one real suite alongside a mocked one is not reported", () => {
+    // Ordinary test design: a suite stands in a dependency while another
+    // exercises the real path. Flagging it would fire across most of the
+    // corpus for a reason unrelated to this defect.
+    const second = { ...binding, suite: "SUITE-002" };
+    const report = audit({
+      obligations: [obligation],
+      bindings: [binding, second],
+      runs: [run, { ...run, suite: "SUITE-002" }],
+      injections: [
+        {
+          suite: "SUITE-001",
+          symbol: "tests::confirms",
+          injects: ["Confirmation::allow"],
+        },
+      ],
+    });
+    expect(
+      report.findings.filter((f) => f.kind === "mocked-confirmation"),
+    ).toHaveLength(0);
+  });
+
+  it("no injection data means silence, not a clean bill", () => {
+    // Absent means "nobody looked". Reporting healthy here would be the
+    // silent-zero defect this whole programme is about.
+    const report = audit({
+      obligations: [obligation],
+      bindings: [binding],
+      runs: [run],
+    });
+    expect(
+      report.findings.filter((f) => f.kind === "mocked-confirmation"),
+    ).toHaveLength(0);
+  });
+
+  it("the finding ratchets through the existing key form", () => {
+    // #204 asked to extend `evidence audit`, not to build a second system, so
+    // the finding must be acceptable in a baseline like every other kind.
+    const report = audit({
+      obligations: [obligation],
+      bindings: [binding],
+      runs: [run],
+      injections: [
+        {
+          suite: "SUITE-001",
+          symbol: "tests::confirms",
+          injects: ["Confirmation::allow"],
+        },
+      ],
+    });
+    const found = report.findings.find(
+      (f) => f.kind === "mocked-confirmation",
+    )!;
+    expect(findingKey(found)).toBe("mocked-confirmation:FR-017-AC-7");
   });
 });


### PR DESCRIPTION
Closes agent-ix/quoin#204. WS4 of agent-ix/quoin#197 — the third finding class only manual review caught.

## The measured case

`FR-017-AC-7`'s trusted-UI confirmation had **no implementation**. Its test passed by injecting `Confirmation::allow()` — mocking exactly the behaviour the criterion verifies.

Green test. Green acceptance criterion. Absent behaviour. Nothing in any tool surface said so.

## Extended, not rebuilt

A new `Finding` kind on the existing auditor, ratcheting through the existing `<kind>:<obligation>` key — as #204 asked. A second system would need its own baseline, its own gate, and its own reasons to be ignored.

## Three deliberate narrowings

**The auditor reads the store, not source**, so injections are an input the caller supplies. **Absent means "nobody looked", never "nothing was mocked"** — the check stays silent rather than reporting a clean bill it did not earn. Same posture `scanIsVacuous` takes when a tool does not say how many rules it ran.

**Only when every binding is mocked.** One suite standing in a dependency while another exercises the real path is ordinary test design; flagging it would fire across most of the corpus for a reason unrelated to this defect.

**`medium`, not `high`.** A heuristic over identifiers, and a legitimate mock can share a noun with the statement it appears under. The floor requires half the injected identifier's words to be the statement's own:

| injection | statement subject | flagged |
|---|---|---|
| `Confirmation::allow` | *"a trusted-UI **confirmation**"* | yes |
| `FakeClock` | — | no |

## Verification

`make test` — **541 passed**, 48 files. `make lint` — clean.

TC-936..TC-940: the measured case, the unrelated mock, the mixed-suite case, silence on absent data, and that the finding ratchets like every other kind.

This closes `AK-006` in the tier-2 answer key (agent-ix/quoin#210) from *not detectable* to detectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDesP1LiJfUcsqGkrs8Zb6