### PR TITLE
feat(evals): quality dimensions beside the cost columns (#201)

### DIFF
--- a/evals/lib/quality.mjs
+++ b/evals/lib/quality.mjs
@@ -1,0 +1,148 @@
+// Quality scoring for eval runs (agent-ix/quoin#201, FR-043-AC-2/4/5).
+//
+// The harness already records tokens, latency and tool calls per scenario —
+// so an eval run answered "was it cheap" and could not answer "was it right".
+// These three dimensions close that, fed by the seeded-defect labels in
+// `evals/fixtures/bench/labels.json`.
+//
+// The point is not to add numbers. It is that a cheap run producing wrong
+// findings currently scores better than an expensive run producing right ones,
+// and nothing in the report says so.
+
+/**
+ * Finding precision and recall against a labelled corpus (FR-043-AC-2).
+ *
+ * Reported **per defect family**, never as one figure. A tool that finds every
+ * marker mismatch and no vacuous suite has a respectable average and a hole,
+ * and the average is what hides it.
+ *
+ * A finding matching no label is a false positive; a label the run did not
+ * match is a miss — unless the label says it was never `findable`, in which
+ * case it is excluded from the denominator. That distinction is FR-043-AC-7's
+ * whole reason for existing: a scored miss must be distinguishable from a
+ * defect nobody claimed was findable.
+ */
+export function scoreFindings(found, labels) {
+  const families = new Map();
+  const bucket = (family) => {
+    if (!families.has(family)) {
+      families.set(family, {
+        family,
+        truePositives: 0,
+        falsePositives: 0,
+        misses: 0,
+      });
+    }
+    return families.get(family);
+  };
+
+  const expected = labels.filter((l) => l.findable !== false);
+  const matched = new Set();
+
+  for (const finding of found) {
+    const hit = expected.find(
+      (l) => !matched.has(l.id) && l.family === finding.family,
+    );
+    if (hit) {
+      matched.add(hit.id);
+      bucket(hit.family).truePositives += 1;
+    } else {
+      bucket(finding.family).falsePositives += 1;
+    }
+  }
+  for (const label of expected) {
+    if (!matched.has(label.id)) bucket(label.family).misses += 1;
+  }
+
+  const rows = [...families.values()]
+    .map((f) => ({
+      ...f,
+      precision: ratio(f.truePositives, f.truePositives + f.falsePositives),
+      recall: ratio(f.truePositives, f.truePositives + f.misses),
+    }))
+    .sort((a, b) => a.family.localeCompare(b.family));
+
+  // Labels declared unfindable are reported, not silently dropped: an
+  // excluded denominator nobody sees is a denominator nobody can question.
+  const excluded = labels.filter((l) => l.findable === false).map((l) => l.id);
+  return { families: rows, excluded };
+}
+
+/**
+ * Actionability: the fraction of findings a reader can act on without opening
+ * another tool (FR-043-AC-4).
+ *
+ * Measured at pass 2 as **15 of 496** — 481 findings that named neither the row
+ * they came from nor a line that distinguished them. A finding you cannot act
+ * on is a finding nobody acts on, whatever its precision.
+ */
+export function scoreActionability(found) {
+  const actionable = found.filter((f) => hasLocus(f)).length;
+  return {
+    actionable,
+    total: found.length,
+    rate: ratio(actionable, found.length),
+  };
+}
+
+/** A finding is actionable when it names WHERE — a row id or a document line. */
+function hasLocus(finding) {
+  return Boolean(
+    (finding.rowId && String(finding.rowId).trim()) ||
+    (typeof finding.line === "number" && finding.line > 0),
+  );
+}
+
+/**
+ * Cost per confirmed insight (FR-043-AC-5), in tokens **and** tool calls.
+ *
+ * Both, because they are different costs: tokens are the context budget and
+ * tool calls are wall-clock and blast radius. A run that reads the whole corpus
+ * once and a run that greps it forty times can spend the same tokens.
+ *
+ * Denominator is CONFIRMED findings — true positives — not findings emitted.
+ * Dividing by emitted output rewards a run for producing more of it, which is
+ * precisely backwards.
+ */
+export function scoreCost(metrics, truePositives) {
+  const tokens = metrics?.tokenUsage?.total ?? 0;
+  const toolCalls = metrics?.toolCalls ?? 0;
+  if (truePositives === 0) {
+    // Not Infinity and not 0. A run that confirmed nothing has no cost PER
+    // insight, and reporting either number would be a claim about efficiency
+    // that the run does not support.
+    return {
+      tokens,
+      toolCalls,
+      truePositives: 0,
+      tokensPer: null,
+      toolCallsPer: null,
+    };
+  }
+  return {
+    tokens,
+    toolCalls,
+    truePositives,
+    tokensPer: Math.round(tokens / truePositives),
+    toolCallsPer: Number((toolCalls / truePositives).toFixed(2)),
+  };
+}
+
+/** Every quality dimension for one scenario, ready to sit beside the cost columns. */
+export function scoreScenario({ found = [], labels = [], metrics = {} }) {
+  const findings = scoreFindings(found, labels);
+  const truePositives = findings.families.reduce(
+    (n, f) => n + f.truePositives,
+    0,
+  );
+  return {
+    findings,
+    actionability: scoreActionability(found),
+    cost: scoreCost(metrics, truePositives),
+  };
+}
+
+/** `null` rather than 0 when there is no denominator — 0/0 is not 0%. */
+function ratio(num, den) {
+  return den === 0 ? null : Number((num / den).toFixed(3));
+}

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -381,6 +381,11 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-261 | A case with no claims carries a machine-readable `reason` naming the searched claim types, present exactly when `claims` is empty — `claims: []` alone cannot distinguish a clean case from one where nothing was argued (#170) | Unit | P0 | FR-040-AC-13 | ✅ |
 | TC-262 | `--claim-type` matches case-insensitively — `str`, `STR` and `Hazard` all matched nothing under `===` and exited 0 with an empty case | Unit | P0 | FR-040-AC-14 | ✅ |
 | TC-239 | Retired by #138 (CR-035): the no-catalog-silence rule it pinned is gone — the `metric` discriminator lives on the entry, so the check reads no catalog and TC-269 states the replacement behaviour | Unit | P0 | FR-039-AC-12 | ⛔ Retired |
+| TC-941 | Finding precision/recall is reported PER FAMILY: a tool finding every marker mismatch and no vacuous suite shows recall 1 and 0, not a respectable average (#201) | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-942 | A finding matching no label is a false positive; an unfindable label is excluded from the denominator AND reported, so a scored miss stays distinguishable from a defect nobody claimed was findable (#201) | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-943 | A family with no denominator reports `null`, not 0 — 0/0 is not 0%, and a precision of 0 claims the run was wrong (#201) | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-944 | Actionability counts findings naming a row id or a line — the property measured at 15 of 496 in pass 2 (#201) | Unit | P0 | FR-043-AC-4 | ✅ |
+| TC-945 | Cost per confirmed insight reports tokens AND tool calls, divides by CONFIRMED findings rather than emitted ones, and reports `null` per-insight when nothing was confirmed (#201) | Unit | P0 | FR-043-AC-5 | ✅ |
 | TC-936 | An obligation discharged only by a mocked stand-in for its own subject is a `medium` `mocked-confirmation` finding naming the injected identifier (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-937 | A mock unrelated to the statement's subject (`FakeClock`) is not reported — tests legitimately mock clocks, filesystems and networks (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-938 | One real suite alongside a mocked one is not reported: standing in a dependency while another suite exercises the real path is ordinary test design (#204) | Unit | P0 | FR-032-AC-15 | ✅ |

--- a/tests/eval-quality.test.ts
+++ b/tests/eval-quality.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Eval quality dimensions (quoin#201, FR-043-AC-2/AC-4/AC-5).
+ *
+ * The harness already recorded tokens, latency and tool calls — so an eval run
+ * answered "was it cheap" and could not answer "was it right". A cheap run
+ * producing wrong findings scored better than an expensive run producing right
+ * ones, and nothing in the report said so.
+ */
+
+import {
+  scoreActionability,
+  scoreCost,
+  scoreFindings,
+  scoreScenario,
+} from "../evals/lib/quality.mjs";
+
+const labels = [
+  { id: "MM-1", family: "marker-form-mismatch", findable: true },
+  { id: "VP-1", family: "vacuous-under-guard", findable: true },
+  { id: "GG-1", family: "gate-that-gates-nothing", findable: false },
+];
+
+describe("finding precision and recall", () => {
+  it("is reported per family, because an average hides a hole", () => {
+    // A tool that finds every marker mismatch and no vacuous suite has a
+    // respectable average — and the average is exactly what hides it.
+    const { families } = scoreFindings(
+      [{ family: "marker-form-mismatch", rowId: "TC-001" }],
+      labels,
+    );
+    const byFamily = Object.fromEntries(families.map((f) => [f.family, f]));
+    expect(byFamily["marker-form-mismatch"].recall).toBe(1);
+    expect(byFamily["vacuous-under-guard"].recall).toBe(0);
+    expect(byFamily["vacuous-under-guard"].misses).toBe(1);
+  });
+
+  it("counts a finding matching no label as a false positive", () => {
+    const { families } = scoreFindings(
+      [
+        { family: "marker-form-mismatch", rowId: "TC-001" },
+        { family: "marker-form-mismatch", rowId: "TC-002" },
+      ],
+      labels,
+    );
+    const mm = families.find((f) => f.family === "marker-form-mismatch")!;
+    expect(mm.truePositives).toBe(1);
+    expect(mm.falsePositives).toBe(1);
+    expect(mm.precision).toBe(0.5);
+  });
+
+  it("excludes an unfindable label from the denominator AND reports it", () => {
+    // FR-043-AC-7's whole reason for existing: a scored miss must be
+    // distinguishable from a defect nobody claimed was findable. An excluded
+    // denominator nobody sees is a denominator nobody can question.
+    const { families, excluded } = scoreFindings([], labels);
+    expect(excluded).toEqual(["GG-1"]);
+    expect(families.some((f) => f.family === "gate-that-gates-nothing")).toBe(
+      false,
+    );
+  });
+
+  it("reports null, not zero, when a family has no denominator", () => {
+    // 0/0 is not 0%. A precision of 0 claims the run was wrong; null says it
+    // emitted nothing to be right or wrong about.
+    const { families } = scoreFindings([], labels);
+    const vp = families.find((f) => f.family === "vacuous-under-guard")!;
+    expect(vp.precision).toBeNull();
+    expect(vp.recall).toBe(0);
+  });
+});
+
+describe("actionability", () => {
+  it("counts findings that name where, which is what 15 of 496 measured", () => {
+    // Pass 2: 481 findings named neither the row they came from nor a line
+    // that distinguished them. A finding you cannot act on is a finding nobody
+    // acts on, whatever its precision.
+    const scored = scoreActionability([
+      { family: "x", rowId: "TC-001" },
+      { family: "x", line: 42 },
+      { family: "x" },
+      { family: "x", rowId: "  " },
+      { family: "x", line: 0 },
+    ]);
+    expect(scored.actionable).toBe(2);
+    expect(scored.total).toBe(5);
+    expect(scored.rate).toBe(0.4);
+  });
+
+  it("has no rate when there were no findings", () => {
+    expect(scoreActionability([]).rate).toBeNull();
+  });
+});
+
+describe("cost per confirmed insight", () => {
+  it("reports tokens AND tool calls, which are different costs", () => {
+    // Tokens are the context budget; tool calls are wall-clock and blast
+    // radius. A run that reads the corpus once and one that greps it forty
+    // times can spend the same tokens.
+    const cost = scoreCost({ tokenUsage: { total: 90000 }, toolCalls: 12 }, 3);
+    expect(cost.tokensPer).toBe(30000);
+    expect(cost.toolCallsPer).toBe(4);
+  });
+
+  it("divides by CONFIRMED findings, not by findings emitted", () => {
+    // Dividing by emitted output rewards a run for producing more of it,
+    // which is precisely backwards.
+    const cheapAndWrong = scoreCost(
+      { tokenUsage: { total: 10000 }, toolCalls: 2 },
+      1,
+    );
+    const dearAndRight = scoreCost(
+      { tokenUsage: { total: 30000 }, toolCalls: 6 },
+      5,
+    );
+    expect(dearAndRight.tokensPer).toBeLessThan(cheapAndWrong.tokensPer!);
+  });
+
+  it("reports null per-insight cost when nothing was confirmed", () => {
+    // Not Infinity and not 0 — a run that confirmed nothing has no cost per
+    // insight, and either number would be a claim the run does not support.
+    const cost = scoreCost({ tokenUsage: { total: 50000 }, toolCalls: 9 }, 0);
+    expect(cost.tokens).toBe(50000);
+    expect(cost.tokensPer).toBeNull();
+    expect(cost.toolCallsPer).toBeNull();
+  });
+});
+
+describe("scoreScenario", () => {
+  it("carries all three dimensions beside the cost columns", () => {
+    const scored = scoreScenario({
+      found: [{ family: "marker-form-mismatch", rowId: "TC-001" }],
+      labels,
+      metrics: { tokenUsage: { total: 20000 }, toolCalls: 8 },
+    });
+    expect(scored.findings.families.length).toBeGreaterThan(0);
+    expect(scored.actionability.rate).toBe(1);
+    expect(scored.cost.tokensPer).toBe(20000);
+  });
+
+  it("survives an empty run without inventing numbers", () => {
+    const scored = scoreScenario({});
+    expect(scored.findings.families).toEqual([]);
+    expect(scored.actionability.rate).toBeNull();
+    expect(scored.cost.tokensPer).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes agent-ix/quoin#201. WS2 of agent-ix/quoin#197, implementing FR-043-AC-2, AC-4 and AC-5.

The 44-scenario harness already recorded tokens, latency and tool calls. So an eval run answered *"was it cheap"* and could not answer *"was it right"* — **a cheap run producing wrong findings scored better than an expensive run producing right ones**, and nothing in the report said so.

Three dimensions, fed by the seeded-defect labels from agent-ix/quoin#210.

## Precision and recall, per family

Never as one figure. A tool that finds every marker mismatch and no vacuous suite has a respectable average **and a hole**, and the average is what hides it:

```
marker-form-mismatch   recall 1
vacuous-under-guard    recall 0   misses 1
```

An **unfindable** label is excluded from the denominator *and reported*. An excluded denominator nobody sees is a denominator nobody can question — and FR-043-AC-7 exists precisely so a scored miss stays distinguishable from a defect nobody claimed was findable.

## Actionability

The fraction of findings naming a row id or a line. Measured at pass 2 as **15 of 496** — 481 findings that named neither the row they came from nor a line that distinguished them.

A finding you cannot act on is a finding nobody acts on, whatever its precision.

## Cost per confirmed insight

Tokens **and** tool calls, because they are different costs: tokens are the context budget, tool calls are wall-clock and blast radius. A run that reads the corpus once and one that greps it forty times can spend the same tokens.

The denominator is **confirmed** findings, not findings emitted. Dividing by emitted output rewards a run for producing more of it, which is precisely backwards.

## Three places it reports `null` rather than a number

| case | why not a number |
|---|---|
| a family with no denominator | 0/0 is not 0%; a precision of 0 *claims the run was wrong* |
| actionability over an empty run | there is no rate |
| cost-per-insight with nothing confirmed | not `Infinity`, not `0` — either is a claim about efficiency the run does not support |

## Verification

`make test` — **552 passed**, 49 files. `make lint` — clean.

11 new tests, including that dividing by confirmed findings makes a dearer-and-righter run score *better* than a cheap-and-wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDesP1LiJfUcsqGkrs8Zb6