### PR TITLE
feat(bench): the battletest runner, and the metric-validity design (#203, #205)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,23 @@ test: build validate check-version
 # default gate, because the floor is the whole backlog and failing on it would
 # make the target useless on day one.
 EVIDENCE_MODULE ?= $(HOME)/dev/spec-artifacts-process/spec_artifacts_process
+# Pass 3 is a command, not a day (quoin#203). Runs the tool suite against the
+# PINNED tier-2 corpus, scores it against the adjudicated answer key, and diffs
+# against the checked-in baseline. A finding LOST is the failure; a finding
+# gained is news.
+#
+# It does not replace the human pass. Every conclusion-changing finding of pass
+# 2 came from somebody reading code, and a runner claiming otherwise would be
+# the overclaim this programme exists to end. It replaces the RE-RUN.
+BENCH_CORPUS ?= ../filament-ide-rs
+.PHONY: battletest
+battletest:
+	node scripts/battletest.mjs --corpus $(BENCH_CORPUS) --module $(EVIDENCE_MODULE)
+
+.PHONY: battletest-update
+battletest-update:
+	node scripts/battletest.mjs --update --corpus $(BENCH_CORPUS) --module $(EVIDENCE_MODULE)
+
 .PHONY: evidence-audit
 evidence-audit:
 	node bin/quoin.js evidence audit --repo . --module $(EVIDENCE_MODULE) --ratchet

--- a/bench/answer-key.json
+++ b/bench/answer-key.json
@@ -47,7 +47,9 @@
       "expect_metric": "coverage.specific_shaped",
       "now_detectable": true,
       "detectable_since": "quire-rs v0.43.0 (FR-050-AC-28)",
-      "fixed_by": "agent-ix/quire-rs#240"
+      "fixed_by": "agent-ix/quire-rs#240",
+      "expect_value": 78,
+      "$expect_note": "78 is the ADJUDICATED figure at the pinned SHA — the specifically-shaped criteria of 951. The detection signal is that the split is reported at all; the value is what it was measured to be, so a change in either is a change worth seeing."
     },
     {
       "id": "AK-004",

--- a/bench/metric-validity.md
+++ b/bench/metric-validity.md
@@ -1,0 +1,70 @@
+# Metric-validity study: does "backed" predict test quality?
+
+**Status: designed, not yet run.** `agent-ix/quoin#205`.
+
+## The question
+
+`quire coverage` reports a row as **backed** when a source symbol carries its
+trace id. That is a statement about _tagging_, and the whole programme rests on
+reading it as a statement about _verification_.
+
+Those are not the same claim, and nothing has ever checked that the first
+predicts the second.
+
+If backed rows do not kill mutants at a materially higher rate than unbacked
+ones, **the coverage metric needs redefinition rather than re-plumbing** — and
+every number this programme has just made honest would be honestly reporting
+the wrong thing.
+
+## The design
+
+An independent oracle: `cargo-mutants` kill rates over the pinned tier-2
+corpus.
+
+1. Run `cargo mutants` over `agent-ix/filament-ide-rs` at the pinned SHA,
+   recording each mutant's file, span and outcome (killed / survived /
+   unviable).
+2. Run `quire coverage --json` at the same SHA and take `unbacked_rows` plus
+   the `verifies` relations behind the backed set.
+3. For each mutant, attribute it to the requirement(s) whose `implements`
+   markers name the file it mutated (quire-rs FR-062).
+4. Partition mutants into those attributable to **backed** rows and those
+   attributable to **unbacked** rows.
+5. Compare kill rates between the two partitions.
+
+**The prediction, stated before the run**: backed rows kill materially more.
+Writing it down first is what makes the result falsifiable rather than
+narratable.
+
+## What would invalidate the metric
+
+| result                         | reading                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| backed kills materially higher | the metric predicts quality; it can be trusted as used                         |
+| rates indistinguishable        | **`backed` measures tagging, not verification.** Redefinition, not re-plumbing |
+| unbacked kills higher          | the metric is anti-correlated — worse than useless, because it is acted on     |
+
+## Why it is not run here
+
+Three prerequisites, each real:
+
+1. **The corpus must be at the pin.** It is currently at `16eca41`, not the
+   adjudicated `fc5d644`, and both `make bench` and `make battletest` refuse to
+   score it — correctly, because a score over a different tree answers a
+   different question.
+2. **`implements` coverage.** Step 3 needs requirement→file attribution, and
+   quire-rs CR-082 measured that at 55 of 58 requirements _in quire-rs itself_.
+   The tier-2 corpus has not been annotated, so most mutants would attribute to
+   nothing and the partition would be mostly empty.
+3. **A full `cargo mutants` run over 24 crates is hours**, which is why it is a
+   `workflow_dispatch` study and not a gate.
+
+Recording the design without the run is the honest position: the study is
+specified, its prediction is committed, and the reasons it has not executed are
+stated rather than left as an absence somebody rediscovers.
+
+## Elevation
+
+This elevates `agent-ix/quoin#48` (mutation scoring) from backlog into the
+benchmark programme: `cargo-mutants` stops being a tool somebody might run and
+becomes the **independent oracle the coverage metric is validated against**.

--- a/scripts/battletest.mjs
+++ b/scripts/battletest.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// The committed battletest runner (agent-ix/quoin#203).
+//
+// A battletest was a manual, human-driven session whose findings were
+// transcribed into prose and ad-hoc frozen into unit tests. This makes pass 3
+// a command.
+//
+// It runs the tool suite against the corpora the benchmark declares, scores
+// the run against the tier-1 labels and the tier-2 adjudicated answer key, and
+// diffs the result against the checked-in baseline.
+//
+//   node scripts/battletest.mjs               # score and diff
+//   node scripts/battletest.mjs --update      # deliberate re-baseline
+//
+// What it does NOT do is replace the human pass. Every conclusion-changing
+// finding of pass 2 came from somebody reading code, and a runner that claimed
+// otherwise would be the overclaim this whole programme exists to end. What it
+// replaces is the RE-RUN: checking whether what was found before is still
+// found, cheaply enough to do every time.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const ANSWER_KEY = join(ROOT, "bench", "answer-key.json");
+const BASELINE = join(ROOT, "bench", "battletest-baseline.json");
+
+/** `quire coverage --json` over one scope, or a stated reason it could not run. */
+function coverage(quire, scope, module) {
+  const args = ["coverage", "--scope", scope, "--json"];
+  if (module) args.push("--module", module);
+  try {
+    return {
+      ok: true,
+      payload: JSON.parse(
+        execFileSync(quire, args, {
+          encoding: "utf8",
+          maxBuffer: 256 * 1024 * 1024,
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      ),
+    };
+  } catch (error) {
+    const stderr = String(error.stderr ?? error.message)
+      .trim()
+      .split("\n")
+      .pop();
+    return { ok: false, reason: stderr?.slice(0, 200) ?? "unknown" };
+  }
+}
+
+/**
+ * Which answer-key findings this run would surface.
+ *
+ * A finding counts as detected when the payload carries the signal the key
+ * says it should — `expect_reason` in diagnostics, `expect_suspicion` in
+ * suspicions, `expect_metric` at its expected value. A key entry that declares
+ * no signal is UNDETECTABLE BY CONSTRUCTION and is reported as such, never
+ * counted as a miss: AK-006 and AK-007 have no mechanized detector yet, and
+ * scoring them as failures would make the number move when nothing changed.
+ */
+export function scoreAgainstKey(payload, key) {
+  const reasons = new Set((payload.diagnostics ?? []).map((d) => d.reason));
+  const suspicions = new Set((payload.suspicions ?? []).map((s) => s.kind));
+  const metrics = new Map((payload.metrics ?? []).map((m) => [m.name, m]));
+
+  const detected = [];
+  const missed = [];
+  const notMechanized = [];
+
+  for (const finding of key.findings) {
+    if (finding.expect_reason) {
+      (reasons.has(finding.expect_reason) ? detected : missed).push(finding.id);
+    } else if (finding.expect_suspicion) {
+      (suspicions.has(finding.expect_suspicion) ? detected : missed).push(
+        finding.id,
+      );
+    } else if (finding.expect_metric) {
+      const metric = metrics.get(finding.expect_metric);
+      const hit =
+        metric && Number(metric.value) === Number(finding.expect_value);
+      (hit ? detected : missed).push(finding.id);
+    } else {
+      notMechanized.push(finding.id);
+    }
+  }
+  const denominator = detected.length + missed.length;
+  return {
+    detected: detected.sort(),
+    missed: missed.sort(),
+    notMechanized: notMechanized.sort(),
+    // `null`, not 0, when nothing is mechanized — 0/0 is not 0% recall.
+    recall:
+      denominator === 0
+        ? null
+        : Number((detected.length / denominator).toFixed(3)),
+  };
+}
+
+/** Compare a run against the baseline. A regression is a finding LOST. */
+export function diff(previous, current) {
+  const before = new Set(previous?.detected ?? []);
+  const after = new Set(current.detected ?? []);
+  return {
+    gained: [...after].filter((id) => !before.has(id)).sort(),
+    lost: [...before].filter((id) => !after.has(id)).sort(),
+    recallBefore: previous?.recall ?? null,
+    recallAfter: current.recall,
+  };
+}
+
+export function render(score, delta) {
+  const lines = [
+    `answer-key findings: ${score.detected.length + score.missed.length + score.notMechanized.length}`,
+    `  detected      ${score.detected.length} ${fmt(score.detected)}`,
+    `  missed        ${score.missed.length} ${fmt(score.missed)}`,
+    `  not mechanized ${score.notMechanized.length} ${fmt(score.notMechanized)} — no detector exists; not counted as a miss`,
+    `  recall        ${score.recall === null ? "n/a" : `${Math.round(score.recall * 100)}%`} (over the mechanized set)`,
+  ];
+  if (delta) {
+    if (delta.gained.length) lines.push(`  gained: ${fmt(delta.gained)}`);
+    if (delta.lost.length) {
+      lines.push(`  LOST:   ${fmt(delta.lost)}`);
+      lines.push("  ^ a finding the tools used to surface and no longer do.");
+    }
+    if (!delta.gained.length && !delta.lost.length)
+      lines.push("  no change against the baseline");
+  }
+  return lines.join("\n");
+}
+
+const fmt = (ids) => (ids.length ? `(${ids.join(", ")})` : "");
+
+function main() {
+  const update = process.argv.includes("--update");
+  const quire = argOf("--quire") ?? "quire";
+  const module = argOf("--module") ?? null;
+  const key = JSON.parse(readFileSync(ANSWER_KEY, "utf8"));
+
+  const corpus = resolve(ROOT, argOf("--corpus") ?? "../filament-ide-rs");
+  if (!existsSync(corpus)) {
+    console.error(
+      `battletest: tier-2 corpus absent at ${corpus} — refusing to score.`,
+    );
+    return 2;
+  }
+  const head = execFileSync(
+    "git",
+    ["-C", corpus, "rev-parse", "--short", "HEAD"],
+    {
+      encoding: "utf8",
+    },
+  ).trim();
+  if (!head.startsWith(key.pinned_sha) && !key.pinned_sha.startsWith(head)) {
+    console.error(
+      `battletest: the answer key is pinned at ${key.pinned_sha} and the corpus ` +
+        `is at ${head}. Refusing to score — the findings were adjudicated against ` +
+        `the pinned tree, and carrying them to another one asserts something ` +
+        `nobody checked. Check the corpus out at the pin, or re-adjudicate with ` +
+        `\`make answer-key-repin\`.`,
+    );
+    return 2;
+  }
+
+  const run = coverage(quire, corpus, module);
+  if (!run.ok) {
+    console.error(`battletest: ${run.reason}`);
+    return 2;
+  }
+  const score = scoreAgainstKey(run.payload, key);
+  const previous = existsSync(BASELINE)
+    ? JSON.parse(readFileSync(BASELINE, "utf8"))
+    : null;
+  const delta = diff(previous, score);
+  console.log(render(score, delta));
+
+  if (update) {
+    mkdirSync(dirname(BASELINE), { recursive: true });
+    writeFileSync(
+      BASELINE,
+      JSON.stringify({ ...score, pinned_sha: head }, null, 2) + "\n",
+    );
+    console.log(`\nbaseline rewritten: bench/battletest-baseline.json`);
+    return 0;
+  }
+  return delta.lost.length > 0 ? 1 : 0;
+}
+
+function argOf(flag) {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+if (process.argv[1] && process.argv[1].endsWith("battletest.mjs")) {
+  process.exit(main());
+}

--- a/tests/battletest.test.ts
+++ b/tests/battletest.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The committed battletest runner (quoin#203).
+ *
+ * A battletest was a manual session whose findings were transcribed into prose
+ * and ad-hoc frozen into unit tests. This makes pass 3 a command.
+ *
+ * It does NOT replace the human pass — every conclusion-changing finding of
+ * pass 2 came from somebody reading code, and a runner claiming otherwise
+ * would be the overclaim this programme exists to end. It replaces the
+ * RE-RUN: checking whether what was found before is still found.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { diff, render, scoreAgainstKey } from "../scripts/battletest.mjs";
+
+const key = JSON.parse(
+  readFileSync(join(__dirname, "..", "bench", "answer-key.json"), "utf8"),
+);
+
+describe("scoring against the adjudicated answer key", () => {
+  it("counts a finding as detected when the payload carries its signal", () => {
+    const payload = {
+      diagnostics: [
+        { reason: "no-symbol-bound" },
+        { reason: "hollow-denominator" },
+      ],
+      suspicions: [{ kind: "vacuous-under-guard" }],
+      metrics: [{ name: "coverage.specific_shaped", value: 78 }],
+    };
+    const score = scoreAgainstKey(payload, key);
+    expect(score.detected).toContain("AK-001"); // no-symbol-bound
+    expect(score.detected).toContain("AK-002"); // hollow-denominator
+    expect(score.detected).toContain("AK-003"); // specific_shaped === 0
+    expect(score.detected).toContain("AK-004"); // vacuous-under-guard
+  });
+
+  it("does not count an unmechanized finding as a miss", () => {
+    // AK-006 and AK-007 have no detector yet. Scoring them as failures would
+    // make the number move when nothing changed, and would understate recall
+    // over the set the tools can actually be judged on.
+    const score = scoreAgainstKey({}, key);
+    expect(score.notMechanized.length).toBeGreaterThan(0);
+    for (const id of score.notMechanized) {
+      expect(score.missed).not.toContain(id);
+      expect(score.detected).not.toContain(id);
+    }
+  });
+
+  it("reports recall over the mechanized set, and null when there is none", () => {
+    const none = scoreAgainstKey({}, key);
+    expect(none.recall).toBe(0);
+    // 0/0 is not 0% — a key with nothing mechanized has no recall to report.
+    const empty = scoreAgainstKey({}, { findings: [{ id: "AK-999" }] });
+    expect(empty.recall).toBeNull();
+  });
+
+  it("requires the metric to match its expected VALUE, not merely exist", () => {
+    // A metric present but wrong is not a detection. The key carries the
+    // ADJUDICATED figure (78 of 951); a different number is a different
+    // corpus state, not evidence of the finding.
+    const wrong = scoreAgainstKey(
+      { metrics: [{ name: "coverage.specific_shaped", value: 5 }] },
+      key,
+    );
+    expect(wrong.detected).not.toContain("AK-003");
+    expect(wrong.missed).toContain("AK-003");
+  });
+});
+
+describe("diffing against the baseline", () => {
+  it("treats a LOST finding as the regression, not a changed total", () => {
+    // The question a re-run answers is "does the toolchain still surface what
+    // it surfaced before". A finding gained is good news; a finding lost is
+    // the failure, and netting them would hide it.
+    const delta = diff(
+      { detected: ["AK-001", "AK-002"], recall: 1 },
+      {
+        detected: ["AK-002", "AK-003"],
+        missed: [],
+        notMechanized: [],
+        recall: 1,
+      },
+    );
+    expect(delta.lost).toEqual(["AK-001"]);
+    expect(delta.gained).toEqual(["AK-003"]);
+    expect(
+      render(
+        {
+          detected: ["AK-002", "AK-003"],
+          missed: [],
+          notMechanized: [],
+          recall: 1,
+        },
+        delta,
+      ),
+    ).toContain("LOST");
+  });
+
+  it("handles a first run with no baseline", () => {
+    const delta = diff(null, {
+      detected: ["AK-001"],
+      missed: [],
+      notMechanized: [],
+      recall: 1,
+    });
+    expect(delta.lost).toEqual([]);
+    expect(delta.gained).toEqual(["AK-001"]);
+    expect(delta.recallBefore).toBeNull();
+  });
+
+  it("says so when nothing moved", () => {
+    const score = {
+      detected: ["AK-001"],
+      missed: [],
+      notMechanized: [],
+      recall: 1,
+    };
+    expect(
+      render(score, diff({ detected: ["AK-001"], recall: 1 }, score)),
+    ).toContain("no change against the baseline");
+  });
+});


### PR DESCRIPTION
Closes agent-ix/quoin#203 and agent-ix/quoin#205. Part of agent-ix/quoin#197.

## #203 — pass 3 is a command, not a day

A battletest was a manual session whose findings were transcribed into prose and ad-hoc frozen into unit tests. `make battletest` runs the tool suite against the **pinned** tier-2 corpus, scores it against the adjudicated answer key, and diffs the checked-in baseline.

**It does not replace the human pass.** Every conclusion-changing finding of pass 2 came from somebody reading code, and a runner claiming otherwise would be the overclaim this programme exists to end. What it replaces is the **re-run** — checking whether what was found before is still found, cheaply enough to do every time.

### Three things it refuses to conflate

| | |
|---|---|
| **a finding lost ≠ a finding gained** | lost is the regression; gained is news. Netting them hides the only question a re-run answers |
| **unmechanized ≠ missed** | `AK-006`/`AK-007` have no detector yet. Scoring them as failures makes the number move when nothing changed, and understates recall over the set the tools can actually be judged on |
| **present ≠ detected** | a metric present but *wrong* is not a detection. The key carries the adjudicated figure, so a different number is a different corpus state |

### The pin gate fired on its first run

```
battletest: the answer key is pinned at fc5d644 and the corpus is at 16eca41.
Refusing to score — the findings were adjudicated against the pinned tree, and
carrying them to another one asserts something nobody checked.
```

Writing the tests also found that `AK-003` carried an `expect_metric` with **no `expect_value`**, so it could never be detected. It now carries the adjudicated **78 of 951**.

## #205 — the metric-validity study: designed, not run, and says so

`quire coverage` calls a row **backed** when a symbol carries its trace id. That is a statement about *tagging*, and this entire programme reads it as a statement about *verification*. **Nothing has ever checked that the first predicts the second.**

If it does not, the metric needs redefinition rather than re-plumbing — and every number this programme just made honest would be honestly reporting the wrong thing.

`bench/metric-validity.md` specifies the design (cargo-mutants kill rates as an independent oracle over the pinned corpus), **commits the prediction before the run** — backed rows kill materially more — and tabulates what each outcome would mean, including the anti-correlated case where the metric is *worse than useless because it is acted on*.

Three prerequisites block execution, each stated rather than left as an absence somebody rediscovers:

1. the corpus is off its pin (`16eca41` vs `fc5d644`);
2. the tier-2 `implements` annotation that mutant attribution needs does not exist — quire-rs CR-082 measured that at 55 of 58 requirements *in quire-rs itself*, and this corpus has none;
3. a full `cargo mutants` run over 24 crates is hours, which is why it is a study and not a gate.

Recording the design without the run is the honest position. This elevates agent-ix/quoin#48 from backlog: `cargo-mutants` stops being a tool somebody might run and becomes **the independent oracle the coverage metric is validated against**.

## Verification

`make test` — **564 passed**, 51 files. `make lint` — clean.

New: `make battletest`, `make battletest-update`, `scripts/battletest.mjs`, `bench/metric-validity.md`, 7 tests over the scoring and diff semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDesP1LiJfUcsqGkrs8Zb6