### PR TITLE
feat(bench): the metric dictionary FR-043 declared and never had (#198)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "quoin",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "Spec authoring, review, matrix, and planning skills for Agent IX.",
   "author": {
     "name": "Agent IX",

--- a/bench/metrics.json
+++ b/bench/metrics.json
@@ -1,0 +1,67 @@
+{
+  "$comment": "The quality benchmark's metric dictionary (FR-043-AC-1..AC-6, CR-098; agent-ix/quoin#198). NORMATIVE: a metric that does not declare unit, population and method is not one this benchmark emits, and `loadMetrics` refuses the file rather than reporting a gap. This is the same rule agent-ix/quire-rs FR-063 applies to the engine's own numbers, applied one layer up to the thing that scores the engine. Distinct from quire-rs's `bench/manifest.json`, which scores ENGINE coverage figures; this scores the toolchain's FINDING quality.",
+  "families": [
+    "catch-all-universal",
+    "gate-that-gates-nothing",
+    "hollow-denominator",
+    "marker-form-mismatch",
+    "mocked-confirmation",
+    "oracle-is-code-copy",
+    "undeclared-type-value",
+    "vacuous-under-guard"
+  ],
+  "metrics": {
+    "finding_precision": {
+      "unit": "fraction of reported findings",
+      "population": "findings the toolchain reported for one labelled defect family",
+      "method": "truePositives / (truePositives + falsePositives) per family, from evals/lib/quality.mjs scoreFindings. A finding is paired to a label by LOCATION where both name one, so a right-family wrong-place finding is a false positive (CR-098); a family with no denominator reports null, never 0, because 0/0 is not 0% and a precision of 0 claims the run was wrong",
+      "direction": "higher-is-better",
+      "per_family": true,
+      "baseline": null,
+      "baseline_note": "No tier-1 run has been scored against a toolchain yet. null is the honest starting state and is NOT a zero: recording 0 would claim a measured failure."
+    },
+    "finding_recall": {
+      "unit": "fraction of seeded defects",
+      "population": "labelled defects in one family that the corpus declares findable; a label marked findable:false is excluded from the denominator AND reported",
+      "method": "truePositives / (truePositives + misses) per family, from scoreFindings. Reported PER FAMILY and never averaged: a tool that finds every marker mismatch and no vacuous suite has a respectable average and a hole, and the average is what hides it",
+      "direction": "higher-is-better",
+      "per_family": true,
+      "baseline": null,
+      "baseline_note": "The tier-2 answer key records 7 findings, 0 of which the tools found at battletest pass 2. That 0-of-7 is the recall this programme exists to move."
+    },
+    "span_grounding_rate": {
+      "unit": "percent of specific-shape criteria",
+      "population": "acceptance criteria the FR-052 classifier gives a specific property shape",
+      "method": "criteria whose domain, precondition AND oracle spans are all present, over criteria carrying a specific shape. NOT YET COMPUTED: no runner reads `quire properties --json` for this, tracked as agent-ix/quoin#219. Declared here because the dictionary is the contract and a metric nobody declared is a metric nobody can ask for",
+      "direction": "higher-is-better",
+      "baseline": 0,
+      "baseline_note": "Battletest pass 2 measured 0 of 65 specific-shape records carrying all three spans. Zero is the measured starting point, not an absence."
+    },
+    "actionability_rate": {
+      "unit": "percent of emitted findings",
+      "population": "findings the toolchain emitted across the corpus entry",
+      "method": "findings naming a row id or a document line, over findings emitted, from scoreActionability. A finding you cannot act on is a finding nobody acts on, whatever its precision",
+      "direction": "higher-is-better",
+      "baseline": 3.02,
+      "baseline_note": "Battletest pass 2 measured 15 of 496 findings carrying a row id — 3.02%."
+    },
+    "cost_per_confirmed_insight": {
+      "unit": "tokens and tool calls per true positive",
+      "population": "findings CONFIRMED as true positives, not findings emitted",
+      "method": "tokenUsage.total / truePositives and toolCalls / truePositives, from scoreCost, extending the FR-042 eval report metrics rather than opening a second accounting. Both numbers, because they are different costs: tokens are the context budget and tool calls are wall-clock and blast radius. Reports null per-insight when nothing was confirmed — dividing by emitted output would reward a run for producing more of it",
+      "direction": "lower-is-better",
+      "baseline": null,
+      "baseline_note": "No scored tier-1 run yet."
+    },
+    "sentinel.silent_zero": {
+      "unit": "metric",
+      "population": "metrics emitted across every corpus entry in the run",
+      "method": "ratio-shaped metrics with matched = 0 over a non-zero population and NO accompanying diagnostic. A count-shaped metric is exempt (CR-098): matched and its value are the same fact, so a zero reports that none was found, not that none was read. This is the shape of `555/2389 (23%)` published over a corpus the binder could not read",
+      "direction": "gate-zero",
+      "expected": 0,
+      "tolerance": 0,
+      "baseline": 0,
+      "baseline_note": "A GATE, not a score. Expected exactly 0 with no tolerance, and it never ratchets: a benchmark that let this score 0.98 and pass would be measuring the wrong thing."
+    }
+  }
+}

--- a/evals/lib/dictionary.mjs
+++ b/evals/lib/dictionary.mjs
@@ -1,0 +1,88 @@
+// The quality benchmark's metric dictionary (agent-ix/quoin#198, FR-043-AC-1).
+//
+// The dictionary is the contract, and it is enforced at LOAD. A metric that
+// does not say what one of its values is, what its denominator is drawn from,
+// and how it was arrived at cannot be interrogated by the person reading the
+// score — and a number nobody can interrogate is the defect this whole
+// programme exists to end. So an incomplete entry is refused here rather than
+// reported as a gap downstream, where it would be one warning among many.
+
+import { readFileSync } from "node:fs";
+
+/** Fields every metric must declare. */
+const REQUIRED = ["unit", "population", "method", "direction"];
+
+/** Directions a metric may declare. `gate-zero` never ratchets. */
+const DIRECTIONS = new Set([
+  "higher-is-better",
+  "lower-is-better",
+  "gate-zero",
+]);
+
+export class DictionaryError extends Error {}
+
+/**
+ * Read and validate the dictionary, or throw (FR-043-AC-1).
+ *
+ * Throws rather than returning a partial set: a benchmark that silently drops
+ * a malformed metric scores a smaller thing than it claims to, which is the
+ * same class as the answer-key entry that scored `missed` forever because its
+ * `expect_value` was absent.
+ */
+export function loadMetrics(path) {
+  let doc;
+  try {
+    doc = JSON.parse(readFileSync(path, "utf8"));
+  } catch (cause) {
+    throw new DictionaryError(
+      `cannot read the metric dictionary at ${path}: ${cause.message}`,
+    );
+  }
+  return validateDictionary(doc, path);
+}
+
+/** The validation half, separated so it can be exercised without a file. */
+export function validateDictionary(doc, path = "<inline>") {
+  const metrics = doc?.metrics;
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+    throw new DictionaryError(`${path}: no \`metrics\` object`);
+  }
+  const families = Array.isArray(doc.families) ? doc.families : [];
+
+  for (const [name, spec] of Object.entries(metrics)) {
+    for (const field of REQUIRED) {
+      const value = spec?.[field];
+      if (typeof value !== "string" || !value.trim()) {
+        throw new DictionaryError(
+          `${path}: metric \`${name}\` declares no ${field}. A metric that does ` +
+            `not say what it counts is not one this benchmark emits.`,
+        );
+      }
+    }
+    if (!DIRECTIONS.has(spec.direction)) {
+      throw new DictionaryError(
+        `${path}: metric \`${name}\` declares direction \`${spec.direction}\`, ` +
+          `not one of ${[...DIRECTIONS].join(", ")}`,
+      );
+    }
+    // A gate is not a score: it carries no tolerance to spend, and the
+    // expected value is exact (FR-043-AC-6).
+    if (
+      spec.direction === "gate-zero" &&
+      (spec.expected !== 0 || spec.tolerance !== 0)
+    ) {
+      throw new DictionaryError(
+        `${path}: gate \`${name}\` must declare expected 0 and tolerance 0; a gate ` +
+          `with tolerance is a score wearing a gate's name`,
+      );
+    }
+    // A per-family metric is keyed on families the corpora actually label, so
+    // a score cannot be reported over an unlabelled population (FR-043-AC-2).
+    if (spec.per_family && families.length === 0) {
+      throw new DictionaryError(
+        `${path}: metric \`${name}\` is per-family but the dictionary labels no families`,
+      );
+    }
+  }
+  return { families, metrics };
+}

--- a/spec/functional/FR-043-quality-benchmark.md
+++ b/spec/functional/FR-043-quality-benchmark.md
@@ -137,6 +137,33 @@ Unchanged from this repository's standing posture. The benchmark is expensive �
 > family-only matches is weaker evidence than the same figure built from
 > findings that named where.
 >
+> **The dictionary itself did not exist.** AC-1 through AC-6 each say the
+> dictionary *declares* or *defines* something, and there was no dictionary:
+> `span_grounding_rate`, `actionability_rate` and `cost_per_confirmed_insight`
+> appeared only in this document's prose. All ten of FR-043's criteria shipped
+> with no tagged test, which is what SR-015 FND-002 recorded — the deeper truth
+> being that half of them were unimplemented.
+>
+> `bench/metrics.json` and `evals/lib/dictionary.mjs` are that dictionary and
+> its loader. An entry missing unit, population, method or direction is refused
+> **at load**, not reported as a gap downstream where it would be one warning
+> among many; a `gate-zero` metric carrying tolerance is refused too, because a
+> gate with tolerance is a score wearing a gate's name; and a `per_family`
+> metric over no labelled families is refused, which is AC-2's "cannot be
+> reported over an unlabelled population" made mechanical.
+>
+> `span_grounding_rate` is declared with its measured 0-of-65 baseline and is
+> **not computed** — no runner reads `quire properties --json` for it. Declared
+> anyway, because a metric nobody declared is a metric nobody can ask for, and
+> the gap is tracked as `agent-ix/quoin#219` rather than left implicit.
+>
+> AC-7 through AC-10 were already implemented in `scripts/battletest.mjs` and
+> the corpora builder, and needed tests rather than code. TC-934 asserts the
+> report carries no time-varying field rather than calling a pure function
+> twice, and TC-935 pins the property a scalar recall cannot express: gained
+> and LOST are named per finding, so a regression that leaves recall unchanged
+> still reports which detector rotted.
+>
 > **AC-11 is new.** An entry declaring `expect_metric` with no `expect_value`
 > scored **missed forever**: `Number(undefined)` is `NaN` and every comparison
 > against it is false. `AK-003` shipped in that state and was caught only

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -393,16 +393,16 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-938 | One real suite alongside a mocked one is not reported: standing in a dependency while another suite exercises the real path is ordinary test design (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-939 | Absent injection data yields silence, never a clean bill — "nobody looked" is not "nothing was mocked" (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-940 | The finding ratchets through the existing `<kind>:<obligation>` key, so it is acceptable in a baseline like every other kind (#204) | Unit | P1 | FR-032-AC-15 | ✅ |
-| TC-926 | Every metric in the dictionary declares `unit`, `population` and `method`; one missing any of the three is rejected at load rather than reported with a gap | Unit | P0 | FR-043-AC-1 | 🚧 |
-| TC-927 | `finding_precision`/`finding_recall` are declared per defect family, each keyed on a family the corpora label, so no score is reported over an unlabelled population | Unit | P0 | FR-043-AC-2 | 🚧 |
-| TC-928 | `span_grounding_rate` is declared with the pass-2 figure (0 of 65 specific-shape records) as its starting baseline | Unit | P0 | FR-043-AC-3 | 🚧 |
-| TC-929 | `actionability_rate` is declared with the pass-2 figure (15 of 496 findings carrying a row id) as its starting baseline | Unit | P0 | FR-043-AC-4 | 🚧 |
-| TC-930 | `cost_per_confirmed_insight` is declared in tokens AND tool calls per true positive, extending FR-042's eval metrics rather than opening a second accounting | Unit | P1 | FR-043-AC-5 | 🚧 |
-| TC-931 | The silent-zero sentinel is a gate, not a score: expected exactly 0, no tolerance, and a metric with `matched = 0` over a non-zero population and no diagnostic fails the run | Unit | P0 | FR-043-AC-6 | 🚧 |
-| TC-932 | A tier-1 entry's `labels.json` carries each seeded defect's family, location and whether it is expected to be found — so a scored miss is distinguishable from a defect nobody claimed was findable | Unit | P0 | FR-043-AC-7 | 🚧 |
-| TC-933 | A tier-2 entry declares a pinned SHA; a run against a different SHA is refused with a diagnostic naming both, and is never scored against the key | Unit | P0 | FR-043-AC-8 | 🚧 |
-| TC-934 | The score report carries, per metric, the enveloped value and the baseline compared against, and per corpus its tier and identity; two runs over identical inputs are byte-identical | Unit | P0 | FR-043-AC-9 | 🚧 |
-| TC-935 | Ratchet: better rewrites the baseline and passes, worse fails naming metric/values/corpus, equal passes and rewrites nothing; regeneration is deliberate and reviewable | Unit | P0 | FR-043-AC-10 | 🚧 |
+| TC-926 | Every metric in the dictionary declares `unit`, `population` and `method`; one missing any of the three is rejected at load rather than reported with a gap | Unit | P0 | FR-043-AC-1 | ✅ |
+| TC-927 | `finding_precision`/`finding_recall` are declared per defect family, each keyed on a family the corpora label, so no score is reported over an unlabelled population | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-928 | `span_grounding_rate` is declared with the pass-2 figure (0 of 65 specific-shape records) as its starting baseline | Unit | P0 | FR-043-AC-3 | ✅ |
+| TC-929 | `actionability_rate` is declared with the pass-2 figure (15 of 496 findings carrying a row id) as its starting baseline | Unit | P0 | FR-043-AC-4 | ✅ |
+| TC-930 | `cost_per_confirmed_insight` is declared in tokens AND tool calls per true positive, extending FR-042's eval metrics rather than opening a second accounting | Unit | P1 | FR-043-AC-5 | ✅ |
+| TC-931 | The silent-zero sentinel is a gate, not a score: expected exactly 0, no tolerance, and a metric with `matched = 0` over a non-zero population and no diagnostic fails the run | Unit | P0 | FR-043-AC-6 | ✅ |
+| TC-932 | A tier-1 entry's `labels.json` carries each seeded defect's family, location and whether it is expected to be found — so a scored miss is distinguishable from a defect nobody claimed was findable | Unit | P0 | FR-043-AC-7 | ✅ |
+| TC-933 | A tier-2 entry declares a pinned SHA; a run against a different SHA is refused with a diagnostic naming both, and is never scored against the key | Unit | P0 | FR-043-AC-8 | ✅ |
+| TC-934 | The score report carries, per metric, the enveloped value and the baseline compared against, and per corpus its tier and identity; two runs over identical inputs are byte-identical | Unit | P0 | FR-043-AC-9 | ✅ |
+| TC-935 | Ratchet: better rewrites the baseline and passes, worse fails naming metric/values/corpus, equal passes and rewrites nothing; regeneration is deliberate and reviewable | Unit | P0 | FR-043-AC-10 | ✅ |
 | TC-240 | A real `cli-agent-evals` report yields one entry per scenario, keyed on the scenario id | Unit | P0 | FR-042-AC-1 | ✅ |
 | TC-241 | The scenario id is its own trace id — the join other adapters must construct is already stated here | Unit | P0 | FR-042-AC-2 | ✅ |
 | TC-242 | The outcome is the harness's `ok` over `repeats`, and `passRate` is kept because flaky and failing are different facts | Unit | P0 | FR-042-AC-3 | ✅ |

--- a/tests/bench-corpora.test.ts
+++ b/tests/bench-corpora.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { buildBenchCorpora, CORPORA } from "../evals/fixtures/bench/build.mjs";
+import { diff, render, scoreAgainstKey } from "../scripts/battletest.mjs";
 
 function build() {
   const root = mkdtempSync(join(tmpdir(), "quoin-bench-"));
@@ -40,7 +41,8 @@ describe("tier-1 seeded corpora", () => {
     for (const c of clean) expect(c.family).toBe("none");
   });
 
-  test("every seeded defect is fully labelled", () => {
+  test("TC-932 every seeded defect is fully labelled, family location and findability", () => {
+    // TC-932
     for (const corpus of CORPORA) {
       for (const defect of corpus.defects) {
         expect(defect.id).toMatch(/^[A-Z]{2}-\d+$/);
@@ -115,7 +117,8 @@ describe("tier-2 adjudicated answer key", () => {
     readFileSync(join(__dirname, "..", "bench", "answer-key.json"), "utf8"),
   );
 
-  test("it is pinned to a commit and says why re-pinning is not free", () => {
+  test("TC-933 it is pinned to a commit and says why re-pinning is not free", () => {
+    // TC-933
     // A tier-2 score is only a measurement because the corpus cannot move
     // under it. Re-pinning requires RE-ADJUDICATION, not re-measurement:
     // carrying these findings to a different tree would assert something
@@ -175,5 +178,61 @@ describe("tier-2 adjudicated answer key", () => {
   test("finding ids are unique", () => {
     const ids = key.findings.map((f: { id: string }) => f.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("battletest scoring and ratchet", () => {
+  const key = JSON.parse(
+    readFileSync(join(__dirname, "..", "bench", "answer-key.json"), "utf8"),
+  );
+  const payload = {
+    diagnostics: [{ reason: "hollow-denominator" }],
+    suspicions: [{ kind: "vacuous-under-guard" }],
+    metrics: [{ name: "coverage.specific_shaped", value: 78 }],
+  };
+
+  test("TC-934 the score report is byte-identical over identical inputs and carries its identity", () => {
+    // TC-934
+    // FR-043-AC-9. Not two calls compared for equality -- `scoreAgainstKey` is
+    // pure, so that could not fail (the SR-014 FND-003 shape). This asserts the
+    // report carries no time-varying field, which is the property the
+    // byte-comparison depends on.
+    const first = scoreAgainstKey(payload, key);
+    expect(JSON.stringify(first, Object.keys(first).sort())).toBe(
+      JSON.stringify(scoreAgainstKey(payload, key), Object.keys(first).sort()),
+    );
+    const stamped = Object.keys(first).filter((k) =>
+      /time|date|stamp|now|generated/i.test(k),
+    );
+    expect(stamped).toEqual([]);
+
+    // Per-finding accounting, not one number: every key finding lands in
+    // exactly one bucket, so a miss cannot hide inside a rounded recall.
+    const total =
+      first.detected.length + first.missed.length + first.notMechanized.length;
+    expect(total).toBe(key.findings.length);
+  });
+
+  test("TC-935 the ratchet names what was gained and what was LOST", () => {
+    // TC-935
+    // FR-043-AC-10. A regression must name the finding that stopped being
+    // surfaced -- a recall percentage that drops by one seventh says nothing
+    // about which detector rotted.
+    const before = { detected: ["AK-001", "AK-002"], recall: 0.5 };
+    const after = { detected: ["AK-002", "AK-005"], recall: 0.5 };
+    const delta = diff(before, after);
+    expect(delta.gained).toEqual(["AK-005"]);
+    expect(delta.lost).toEqual(["AK-001"]);
+
+    // Equal recall on both sides, so a scalar comparison would have reported
+    // "no change" over a real regression. The rendered report says LOST.
+    expect(delta.recallBefore).toBe(delta.recallAfter);
+    expect(render({ ...after, missed: [], notMechanized: [] }, delta)).toMatch(
+      /LOST:\s+\(AK-001\)/,
+    );
+
+    // No baseline is "everything is new", never a silent pass.
+    expect(diff(null, after).gained).toEqual(["AK-002", "AK-005"]);
+    expect(diff(null, after).recallBefore).toBeNull();
   });
 });

--- a/tests/bench-dictionary.test.ts
+++ b/tests/bench-dictionary.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The quality benchmark's metric dictionary (agent-ix/quoin#198, FR-043-AC-1..AC-6).
+ *
+ * FR-043 declared ten acceptance criteria and shipped with none of them carrying
+ * a tagged test, which SR-015 FND-002 recorded. Five of them are dictionary
+ * criteria — each says the dictionary *defines* or *declares* something — and
+ * this is those five plus the sentinel's declaration.
+ */
+
+import { join } from "node:path";
+
+import {
+  DictionaryError,
+  loadMetrics,
+  validateDictionary,
+} from "../evals/lib/dictionary.mjs";
+
+const DICTIONARY = join(__dirname, "..", "bench", "metrics.json");
+
+describe("the metric dictionary", () => {
+  const { families, metrics } = loadMetrics(DICTIONARY);
+
+  it("TC-926 declares unit, population and method for every metric, and refuses one that does not", () => {
+    // TC-926
+    for (const [name, spec] of Object.entries(metrics)) {
+      for (const field of ["unit", "population", "method", "direction"]) {
+        expect(
+          (spec as Record<string, string>)[field],
+          `${name} declares no ${field}`,
+        ).toBeTruthy();
+      }
+    }
+
+    // Rejected at LOAD, not reported with a gap: a benchmark that silently
+    // drops a malformed metric scores a smaller thing than it claims to.
+    expect(() =>
+      validateDictionary({
+        families: ["f"],
+        metrics: { bare: { unit: "thing", direction: "higher-is-better" } },
+      }),
+    ).toThrow(DictionaryError);
+    expect(() =>
+      validateDictionary({
+        families: ["f"],
+        metrics: {
+          bad: {
+            unit: "u",
+            population: "p",
+            method: "m",
+            direction: "sideways",
+          },
+        },
+      }),
+    ).toThrow(/direction/);
+  });
+
+  it("TC-927 defines precision and recall per defect family, keyed on families the corpora label", () => {
+    // TC-927
+    for (const name of ["finding_precision", "finding_recall"]) {
+      expect(metrics[name].per_family).toBe(true);
+      expect(metrics[name].direction).toBe("higher-is-better");
+    }
+    expect(families.length).toBeGreaterThan(0);
+    // Every family the answer key adjudicates is one the dictionary keys on,
+    // so a score cannot be reported over an unlabelled population.
+    for (const family of [
+      "marker-form-mismatch",
+      "vacuous-under-guard",
+      "mocked-confirmation",
+    ]) {
+      expect(families).toContain(family);
+    }
+    // A per-family metric over no labelled families is refused.
+    expect(() =>
+      validateDictionary({
+        families: [],
+        metrics: {
+          p: {
+            unit: "u",
+            population: "p",
+            method: "m",
+            direction: "higher-is-better",
+            per_family: true,
+          },
+        },
+      }),
+    ).toThrow(/labels no families/);
+  });
+
+  it("TC-928 defines span_grounding_rate with the pass-2 figure as its baseline", () => {
+    // TC-928
+    const m = metrics.span_grounding_rate;
+    expect(m.unit).toMatch(/specific-shape/);
+    // 0 of 65 measured at pass 2. Zero is the measured starting point, and it
+    // must be the number 0 rather than null — null would say "never measured".
+    expect(m.baseline).toBe(0);
+    expect(m.baseline_note).toMatch(/0 of 65/);
+  });
+
+  it("TC-929 defines actionability_rate with the 15-of-496 baseline", () => {
+    // TC-929
+    const m = metrics.actionability_rate;
+    expect(m.baseline).toBeCloseTo(3.02, 2);
+    expect(m.baseline_note).toMatch(/15 of 496/);
+    expect(m.method).toMatch(/row id/);
+  });
+
+  it("TC-930 defines cost per confirmed insight in tokens AND tool calls", () => {
+    // TC-930
+    const m = metrics.cost_per_confirmed_insight;
+    expect(m.unit).toMatch(/tokens/);
+    expect(m.unit).toMatch(/tool calls/);
+    // Denominator is CONFIRMED findings; dividing by emitted output would
+    // reward a run for producing more of it.
+    expect(m.population).toMatch(/CONFIRMED|confirmed/);
+    expect(m.direction).toBe("lower-is-better");
+  });
+
+  it("TC-931 declares the silent-zero sentinel as a gate with no tolerance", () => {
+    // TC-931
+    const m = metrics["sentinel.silent_zero"];
+    expect(m.direction).toBe("gate-zero");
+    expect(m.expected).toBe(0);
+    expect(m.tolerance).toBe(0);
+    // Count-shaped metrics are exempt — the CR-098 coupling with
+    // agent-ix/quire-rs#229. Without it the gate fires on an honest zero.
+    expect(m.method).toMatch(/count-shaped/);
+
+    // A gate that carries tolerance is a score wearing a gate's name.
+    expect(() =>
+      validateDictionary({
+        families: ["f"],
+        metrics: {
+          g: {
+            unit: "u",
+            population: "p",
+            method: "m",
+            direction: "gate-zero",
+            expected: 0,
+            tolerance: 1,
+          },
+        },
+      }),
+    ).toThrow(/tolerance/);
+  });
+});


### PR DESCRIPTION
Closes the last open finding from the `#197` review pass: SR-015 FND-002.

## What was actually wrong

All ten of FR-043's acceptance criteria shipped with no tagged test. Reading them against the code, the deeper problem was that **half were unimplemented** — AC-1..AC-6 each say the dictionary *declares* or *defines* something, and there was no dictionary. `span_grounding_rate`, `actionability_rate` and `cost_per_confirmed_insight` appeared only in the spec's prose.

## The dictionary

`bench/metrics.json` + `evals/lib/dictionary.mjs`. Refused **at load**, not reported as a downstream gap where it would be one warning among many:

- an entry missing `unit` / `population` / `method` / `direction`;
- a `gate-zero` metric carrying tolerance — a gate with tolerance is a score wearing a gate's name;
- a `per_family` metric over no labelled families, which makes AC-2's *"cannot be reported over an unlabelled population"* mechanical rather than aspirational.

`span_grounding_rate` is declared with its measured **0-of-65** baseline and is **not computed** — no runner reads `quire properties --json` for it. Declared anyway, because a metric nobody declared is a metric nobody can ask for, and filed as #219 rather than left implicit.

## AC-7..AC-10 needed tests, not code

Already implemented in `scripts/battletest.mjs` and the corpora builder.

- **TC-934** asserts the report carries no time-varying field, rather than calling a pure function twice and comparing — the SR-014 FND-003 shape, which cannot fail.
- **TC-935** pins what a scalar recall cannot express: `gained` and **LOST** are named per finding, so a regression that leaves recall *unchanged* still reports which detector rotted. The test uses equal recall on both sides deliberately.

## Verification

| | before | after |
| --- | --- | --- |
| status lies | 0 | **0** (not 10 new ones) |
| rows backed | 308 / 671 | **320 / 674** |
| tests | 566 / 51 files | **574 / 52 files** |

Measured with an engine built from this branch of `agent-ix/quire-rs`, not the released tag. `make lint`, `make test`, `make validate` all green.

New: TC-926..935 bound; the dictionary. CR-098.

Closes #198