### PR TITLE
The tier-1 runner, and the first scored run there has ever been (#199)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,23 @@ battletest:
 battletest-update:
 	node scripts/battletest.mjs --update --corpus $(BENCH_CORPUS) --module $(EVIDENCE_MODULE)
 
+# TIER 1: the seeded corpora, built, scanned and scored on every run. Cheap
+# enough to gate on, unlike `battletest`, which needs a pinned external tree.
+#
+# The ratchet is one-way and quire-rs `scripts/bench.py`'s: a regression keeps
+# the OLD baseline, so a bad run can never lower the bar, and `--update` is the
+# only way a number moves. `QUIRE` overrides the binary — point it at a local
+# build to score an engine that is not the installed one, which is the whole
+# reason three SpecReviews once cited figures from a binary nobody checked.
+QUIRE ?= quire
+.PHONY: bench-tier1
+bench-tier1:
+	node scripts/bench-tier1.mjs --quire $(QUIRE)
+
+.PHONY: bench-tier1-update
+bench-tier1-update:
+	node scripts/bench-tier1.mjs --update --quire $(QUIRE)
+
 .PHONY: evidence-audit
 evidence-audit:
 	node bin/quoin.js evidence audit --repo . --module $(EVIDENCE_MODULE) --ratchet

--- a/bench/metrics.json
+++ b/bench/metrics.json
@@ -18,7 +18,7 @@
       "direction": "higher-is-better",
       "per_family": true,
       "baseline": null,
-      "baseline_note": "No tier-1 run has been scored against a toolchain yet. null is the honest starting state and is NOT a zero: recording 0 would claim a measured failure."
+      "baseline_note": "Per-family, so the numbers live in `bench/tier1-baseline.json` rather than here \u2014 one scalar cannot hold eight families, and averaging them is the exact hiding this metric exists to prevent. First scored run (2026-08-23, quire built from quire-rs@8c4928a): five families at 1.00, three with no denominator because nothing fired on them. `null` here still means no single figure is declared, NOT zero."
     },
     "finding_recall": {
       "unit": "fraction of seeded defects",
@@ -27,7 +27,7 @@
       "direction": "higher-is-better",
       "per_family": true,
       "baseline": null,
-      "baseline_note": "The tier-2 answer key records 7 findings, 0 of which the tools found at battletest pass 2. That 0-of-7 is the recall this programme exists to move."
+      "baseline_note": "Per-family, in `bench/tier1-baseline.json`. First scored run (2026-08-23): catch-all-universal, hollow-denominator, marker-form-mismatch, undeclared-type-value and vacuous-under-guard at 1.00; gate-that-gates-nothing, mocked-confirmation and oracle-is-code-copy at 0.00 for three DIFFERENT reasons \u2014 no detector, a detector with no producer (quoin#204), and a detector with no caller (quire-rs#236). The tier-2 key records 7 findings, 0 of which the tools found at battletest pass 2; that 0-of-7 is the recall this programme exists to move."
     },
     "span_grounding_rate": {
       "unit": "percent of specific-shape criteria",
@@ -43,12 +43,12 @@
       "method": "findings naming a row id or a document line, over findings emitted, from scoreActionability. A finding you cannot act on is a finding nobody acts on, whatever its precision",
       "direction": "higher-is-better",
       "baseline": 3.02,
-      "baseline_note": "Battletest pass 2 measured 15 of 496 findings carrying a row id — 3.02%."
+      "baseline_note": "Battletest pass 2 measured 15 of 496 findings carrying a row id \u2014 3.02%. Tier 1's first scored run reads 2 of 7 (29%): a small, clean corpus flatters the figure, which is why the tier-2 number is the one to move and both are kept."
     },
     "cost_per_confirmed_insight": {
       "unit": "tokens and tool calls per true positive",
       "population": "findings CONFIRMED as true positives, not findings emitted",
-      "method": "tokenUsage.total / truePositives and toolCalls / truePositives, from scoreCost, extending the FR-042 eval report metrics rather than opening a second accounting. Both numbers, because they are different costs: tokens are the context budget and tool calls are wall-clock and blast radius. Reports null per-insight when nothing was confirmed — dividing by emitted output would reward a run for producing more of it",
+      "method": "tokenUsage.total / truePositives and toolCalls / truePositives, from scoreCost, extending the FR-042 eval report metrics rather than opening a second accounting. Both numbers, because they are different costs: tokens are the context budget and tool calls are wall-clock and blast radius. Reports null per-insight when nothing was confirmed \u2014 dividing by emitted output would reward a run for producing more of it",
       "direction": "lower-is-better",
       "baseline": null,
       "baseline_note": "No scored tier-1 run yet."
@@ -62,6 +62,14 @@
       "tolerance": 0,
       "baseline": 0,
       "baseline_note": "A GATE, not a score. Expected exactly 0 with no tolerance, and it never ratchets: a benchmark that let this score 0.98 and pass would be measuring the wrong thing."
+    },
+    "finding_localisation_rate": {
+      "unit": "fraction of confirmed findings",
+      "population": "true positives from a scored tier-1 run",
+      "method": "positional pairings over true positives, from evals/lib/quality.mjs scoreFindings. A finding pairs positionally only when it and its label BOTH name a place and the places agree, so this is the share of confirmed findings that said where. It is the metric that encodes the actual requirement \u2014 an alert nobody can locate is an alert nobody acts on \u2014 and it is deliberately not per-family: the question is about the toolchain's output, not about one detector",
+      "direction": "higher-is-better",
+      "baseline": 0.4,
+      "baseline_note": "First scored tier-1 run (2026-08-23): 2 of 5 true positives named where. The three that did not are `hollow-denominator` (the diagnostic carries no path \u2014 it names a metric), `catch-all-universal` (an aggregate metric, not a located finding) and `marker-form-mismatch` (`no-symbol-bound` names the LANGUAGE, `rust`, not the marker's line). All three are quoin#197 workstream 4."
     }
   }
 }

--- a/bench/tier1-baseline.json
+++ b/bench/tier1-baseline.json
@@ -1,0 +1,88 @@
+{
+  "families": [
+    {
+      "family": "catch-all-universal",
+      "truePositives": 1,
+      "falsePositives": 0,
+      "misses": 0,
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "family": "gate-that-gates-nothing",
+      "truePositives": 0,
+      "falsePositives": 0,
+      "misses": 1,
+      "precision": null,
+      "recall": 0
+    },
+    {
+      "family": "hollow-denominator",
+      "truePositives": 1,
+      "falsePositives": 0,
+      "misses": 0,
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "family": "marker-form-mismatch",
+      "truePositives": 1,
+      "falsePositives": 0,
+      "misses": 0,
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "family": "mocked-confirmation",
+      "truePositives": 0,
+      "falsePositives": 0,
+      "misses": 1,
+      "precision": null,
+      "recall": 0
+    },
+    {
+      "family": "oracle-is-code-copy",
+      "truePositives": 0,
+      "falsePositives": 0,
+      "misses": 1,
+      "precision": null,
+      "recall": 0
+    },
+    {
+      "family": "undeclared-type-value",
+      "truePositives": 1,
+      "falsePositives": 0,
+      "misses": 0,
+      "precision": 1,
+      "recall": 1
+    },
+    {
+      "family": "vacuous-under-guard",
+      "truePositives": 1,
+      "falsePositives": 0,
+      "misses": 0,
+      "precision": 1,
+      "recall": 1
+    }
+  ],
+  "excluded": [],
+  "collateral": [
+    {
+      "family": "marker-form-mismatch",
+      "reason": "no-symbol-bound"
+    },
+    {
+      "family": "hollow-denominator",
+      "reason": "hollow-denominator"
+    }
+  ],
+  "positional": 2,
+  "finding_localisation_rate": 0.4,
+  "actionability": {
+    "actionable": 2,
+    "total": 7,
+    "rate": 0.286
+  },
+  "corpora": 9,
+  "findings": 7
+}

--- a/bench/tier1-mapping.json
+++ b/bench/tier1-mapping.json
@@ -1,0 +1,60 @@
+{
+  "$comment": "The tier-1 payload→family mapping (agent-ix/quoin#199, FR-043-AC-2). NORMATIVE and REVIEWABLE: this table is the contract between what a tool emits and what the benchmark calls a finding, and it belongs in the repository rather than in a script's head. A family the scorer reads out of a payload section this file does not name is a family nobody agreed on, and `scripts/bench-tier1.mjs` refuses a payload signal it cannot map rather than dropping it — an unmapped signal is a scoring hole, and a silent one reads exactly like a tool that found nothing.",
+  "sources": {
+    "coverage.diagnostics": "quire coverage --json, `diagnostics[]`. Keyed on `reason`. Carries `path` sometimes and never a line.",
+    "coverage.suspicions": "quire coverage --json, `suspicions[]`. Keyed on `kind`. Carries `path` and `line`.",
+    "coverage.metrics": "quire coverage --json, `metrics[]`. Keyed on `name`, matched against the label's `expect_value`. Carries no locus at all — a metric is a number about a corpus, not a place.",
+    "validate.findings": "quire validate --diagnostics-format json, one NDJSON object per finding. Keyed on the bracketed reason at the end of `message`. See `parse_fragility` below.",
+    "audit.findings": "quoin evidence audit --json, `findings[]`. Keyed on `kind`. Carries an obligation id and NO locus."
+  },
+  "parse_fragility": {
+    "what": "`validate` has no `--json` payload. `--diagnostics-format json` emits `{kind, message, severity}` and embeds the path, the line and the reason INSIDE the message string, so the runner parses them with a regex.",
+    "why_it_matters": "A message-format change silently stops every `validate`-sourced family scoring, and a family that stops scoring looks like a family with nothing to report. The runner therefore refuses a `ValidationError` whose message it cannot parse, rather than skipping it.",
+    "tracked_by": "agent-ix/quire-cli#65"
+  },
+  "families": {
+    "marker-form-mismatch": {
+      "source": "coverage.diagnostics",
+      "key": "no-symbol-bound",
+      "locus": "path"
+    },
+    "hollow-denominator": {
+      "source": "coverage.diagnostics",
+      "key": "hollow-denominator",
+      "locus": "none"
+    },
+    "undeclared-type-value": {
+      "source": "validate.findings",
+      "key": "assert",
+      "locus": "path-line"
+    },
+    "catch-all-universal": {
+      "source": "coverage.metrics",
+      "key": "coverage.specific_shaped",
+      "locus": "none"
+    },
+    "vacuous-under-guard": {
+      "source": "coverage.suspicions",
+      "key": "vacuous-under-guard",
+      "locus": "path-line"
+    },
+    "oracle-is-code-copy": {
+      "source": "coverage.suspicions",
+      "key": "oracle-resembles-implementation",
+      "locus": "path-line",
+      "$note": "The comparison ships in quire-rs `src/skeptic.rs` and has NO production caller — `oracle_copies` is reached only by its own unit tests. Mapped anyway: the contract is what a detector must emit, and declaring it before the detector exists is what lets the detector be built against something. Recall reads 0 until agent-ix/quire-rs#236."
+    },
+    "mocked-confirmation": {
+      "source": "audit.findings",
+      "key": "mocked-confirmation",
+      "locus": "none",
+      "$note": "quoin's own auditor, not quire — `quire coverage` and `quire properties` cannot see this family, which is why the runner calls a third command. The detector additionally cannot fire: `AuditInput.injections` is never supplied by any caller (agent-ix/quoin#204, reopened)."
+    },
+    "gate-that-gates-nothing": {
+      "source": "none",
+      "key": "gate-that-gates-nothing",
+      "locus": "none",
+      "$note": "No detector exists anywhere in the ecosystem. `source: none` is a DECLARED hole, not an omission: it makes the recall of 0 a fact this file states rather than an absence a reader has to infer. agent-ix/quoin#197 workstream 4."
+    }
+  }
+}

--- a/evals/fixtures/bench/build.mjs
+++ b/evals/fixtures/bench/build.mjs
@@ -75,6 +75,23 @@ const fr = (criteria) =>
     .map((c, i) => `| FR-001-AC-${i + 1} | ${c} | Test (TC-00${i + 1}) |\n`)
     .join("");
 
+/**
+ * A criterion the FR-052 classifier gives a SPECIFIC shape (`idempotence`).
+ *
+ * Every corpus but `catch-all-properties` carries it, and the reason is a
+ * measurement: the first tier-1 run scored `catch-all-universal` at precision
+ * **11%** — 1 true positive and 8 false ones. Those 8 were not the tool being
+ * wrong. Every corpus's only criterion was `universal`-shaped, so
+ * `coverage.specific_shaped` read 0 across all nine and the family's signal was
+ * a CONSTANT, present in the clean control too.
+ *
+ * A control that carries the defect is not a control, and a check that cannot
+ * stay silent on healthy input is not a check. This is the same rule
+ * `clean-control` exists to enforce, applied one level down to a single family.
+ */
+const SPECIFIC_CRITERION =
+  "Applying the normalizer twice shall give the same result as applying it once.";
+
 const matrix = (rows) =>
   `---\nid: TM-001\ntype: TestMatrix\n---\n\n## Test Cases\n\n` +
   `| ID | Traces To | Type | Status |\n|----|-----------|------|--------|\n` +
@@ -94,7 +111,10 @@ export const CORPORA = [
       "1,292 such symbols in filament-ide-rs bound nothing and the report said 23%.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/FR-001.md": fr([
+        "Every finding shall default to warning.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | \u{1F6A7}"]),
       "src/lib.rs":
         '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[tracks("TC-001")]\n' +
@@ -110,6 +130,26 @@ export const CORPORA = [
         expect_reason: "no-symbol-bound",
         note: "the module declares `#[trace(...)]`; the source writes `#[tracks(...)]`",
         confirmed_at: "quire-rs v0.43.0",
+        // The mirror of `hollow-metric`'s declaration, and the first tier-1
+        // run is what proved it necessary: this corpus scored
+        // `hollow-denominator` precision at 50% — one true positive from the
+        // corpus that seeds it, one "false" positive from here.
+        //
+        // Both are correct. A marker the binder cannot read makes
+        // `coverage.backed` a ratio over an unread population, so the
+        // relationship holds in BOTH directions and both corpora have to say
+        // so. One-sided collateral is how a symmetric consequence gets scored
+        // as an error against whichever corpus forgot to declare it.
+        collateral: [
+          {
+            family: "hollow-denominator",
+            reason: "hollow-denominator",
+            note:
+              "an unread marker IS a hollow denominator; `coverage.backed` is " +
+              "the only ratio metric that can go hollow and this is its only " +
+              "cause, so the two findings are one fact seen twice",
+          },
+        ],
       },
     ],
   },
@@ -122,7 +162,10 @@ export const CORPORA = [
       "reported as status lies because no declared type said what they are.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/FR-001.md": fr([
+        "Every finding shall default to warning.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Demonstration | ✅"]),
       "src/lib.rs":
         '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +
@@ -201,7 +244,10 @@ export const CORPORA = [
       "of its samples.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/FR-001.md": fr([
+        "Every finding shall default to warning.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
       "src/lib.rs":
         '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +
@@ -234,7 +280,10 @@ export const CORPORA = [
       "evidence symbols, and three SpecReviews cite figures computed under it.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/FR-001.md": fr([
+        "Every finding shall default to warning.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | \u{1F6A7}"]),
       // A real test, no marker at all — the binder walks one candidate and
       // binds none, so `coverage.backed` is a ratio over a corpus it could
@@ -296,6 +345,7 @@ export const CORPORA = [
       "module/manifest.yaml": MODULE,
       "spec/FR-001.md": fr([
         "Every path shall be relative and free of dot segments.",
+        SPECIFIC_CRITERION,
       ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
       // The oracle restates the implementation's own rules, token for token.
@@ -349,6 +399,7 @@ export const CORPORA = [
       "module/manifest.yaml": MODULE,
       "spec/FR-001.md": fr([
         "The shell shall obtain the user's confirmation before granting a root.",
+        SPECIFIC_CRITERION,
       ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
       // The only binding for the criterion injects a stand-in for the exact
@@ -408,7 +459,10 @@ export const CORPORA = [
       "a human, and detected by nothing anywhere in the ecosystem.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["No production symbol shall call `unwrap`."]),
+      "spec/FR-001.md": fr([
+        "No production symbol shall call `unwrap`.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Inspection | ✅"]),
       // The gate the matrix row claims verifies FR-001-AC-1. It greps, it
       // exits 0, and it exits 0 whatever the grep finds: the pipeline's status
@@ -459,7 +513,10 @@ export const CORPORA = [
       "a constant.",
     files: {
       "module/manifest.yaml": MODULE,
-      "spec/FR-001.md": fr(["Every finding shall default to warning."]),
+      "spec/FR-001.md": fr([
+        "Every finding shall default to warning.",
+        SPECIFIC_CRITERION,
+      ]),
       "spec/tests.md": matrix(["TC-001 | FR-001-AC-1 | Unit | ✅"]),
       "src/lib.rs":
         '//! seeded\n\n#[cfg(test)]\nmod tests {\n    #[trace("TC-001")]\n' +

--- a/reviews/26-08-23-tier1-runner-code-review.md
+++ b/reviews/26-08-23-tier1-runner-code-review.md
@@ -1,0 +1,131 @@
+---
+id: SR-018
+title: "Code review — the tier-1 runner and its ratchet (quoin#199)"
+type: SpecReview
+analysis: code-review
+scope: "scripts/bench-tier1.mjs, bench/tier1-mapping.json, bench/metrics.json, evals/fixtures/bench/build.mjs, tests/bench-tier1.test.ts, Makefile"
+review_set: subset
+---
+
+# SR-018: Code review — the tier-1 runner and its ratchet (quoin#199)
+
+## Summary
+
+Reviewed the working diff on `feat/199-tier1-runner`: `scripts/bench-tier1.mjs`,
+the committed payload→family mapping, the `make bench-tier1` gate, two corpus
+repairs the first run exposed, and eight tracked tests. `make lint`, `make test`
+(53 files) and `make bench-tier1` are green, and the gate was mutation-verified:
+retiring one mapping key takes `vacuous-under-guard` recall 1.00 → 0.00, prints
+`!!`, holds the baseline at 1 and exits non-zero.
+
+The tier-1 corpora have a production caller for the first time. Every metric in
+`bench/metrics.json` that depended on them carried `baseline: null` with the note
+"No tier-1 run has been scored against a toolchain yet." That note is now false,
+and the diff replaces it with numbers.
+
+## Verdict
+
+**CONDITIONAL** — no `high` findings survive. Three defects were found by
+_running_ the thing rather than reading it, and all three are fixed in this
+branch.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                          | Refs                               |
+| ------- | -------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| FND-001 | high     | `catch-all-universal` scored precision 11% because all nine corpora carried the defect, control included — fixed | evals/fixtures/bench/build.mjs:92  |
+| FND-002 | medium   | `hollow-denominator` scored precision 50%: collateral was declared one-way for a symmetric consequence — fixed   | evals/fixtures/bench/build.mjs:143 |
+| FND-003 | medium   | A family present in the baseline and absent from a run was silently no-news — fixed, and now a regression        | scripts/bench-tier1.mjs:262        |
+| FND-004 | low      | `validate` has no JSON payload; path, line and reason are parsed out of a message string                         | bench/tier1-mapping.json:12        |
+
+## Detail
+
+### FND-001 — the control carried the defect
+
+The first scored run put `catch-all-universal` at **1 true positive and 8 false
+positives**. Reading the eight showed they were not the tool being wrong: every
+corpus's only acceptance criterion was `universal`-shaped, so
+`coverage.specific_shaped` read 0 across all nine — including `clean-control`.
+
+The signal was a **constant**. A check that cannot stay silent on healthy input
+is not a check, and a control that carries the defect is not a control; that is
+the rule `clean-control` exists to enforce, and the corpus set was violating it
+one level down. Every corpus but `catch-all-properties` now carries a criterion
+the FR-052 classifier shapes as `idempotence`, and precision reads 100%.
+
+This is the finding the whole programme is about, found by its own benchmark on
+its first run, in the benchmark's own fixtures.
+
+### FND-002 — collateral has to be symmetric
+
+`hollow-denominator` scored 1 TP and 1 FP. The false positive came from
+`marker-mismatch`: an unread marker makes `coverage.backed` a ratio over an
+unread population, so it fires `hollow-denominator` too.
+
+`hollow-metric` declared `no-symbol-bound` as collateral; `marker-mismatch` did
+not declare the reverse. A symmetric consequence declared one way gets scored as
+an error against whichever corpus forgot, so both now declare it.
+
+### FND-003 — a deleted corpus read as a clean run
+
+`ratchet` iterated the CURRENT report's families. A family in the baseline and
+absent from the run — corpus deleted, mapping dropped, label removed — produced
+no verdict at all, so the row simply vanished and the gate passed.
+
+An absent row is indistinguishable from an absence of news, which is the same
+shape as a check that cannot fail. A vanished family is now a `regressed`
+verdict carrying `observed: null`, the reason why, and the baseline held so
+`--update` cannot ratify the deletion. TC-960 covers it through the real
+`ratchet`.
+
+### FND-004 — the parse is the weak seam, and it is declared
+
+`quire validate` has no `--json` payload. `--diagnostics-format json` emits
+`{kind, message, severity}` with the path, the line and the reason embedded in
+`message`, so the runner extracts them with a regex. A message-format change
+would silently stop every `validate`-sourced family scoring.
+
+Not silently, here: a `ValidationError` whose message looks like a finding
+(`<path>: line N:`) and cannot be parsed **throws**, rather than being skipped.
+The fragility is declared in `bench/tier1-mapping.json` under `parse_fragility`
+and tracked as `agent-ix/quire-cli#65`.
+
+## First scored tier-1 run
+
+`quire` built from `quire-rs@8c4928a`, 9 corpora, 7 findings mapped:
+
+| family                    | TP  | FP  | miss | precision | recall |
+| ------------------------- | --- | --- | ---- | --------- | ------ |
+| `catch-all-universal`     | 1   | 0   | 0    | 100%      | 100%   |
+| `gate-that-gates-nothing` | 0   | 0   | 1    | n/a       | **0%** |
+| `hollow-denominator`      | 1   | 0   | 0    | 100%      | 100%   |
+| `marker-form-mismatch`    | 1   | 0   | 0    | 100%      | 100%   |
+| `mocked-confirmation`     | 0   | 0   | 1    | n/a       | **0%** |
+| `oracle-is-code-copy`     | 0   | 0   | 1    | n/a       | **0%** |
+| `undeclared-type-value`   | 1   | 0   | 0    | 100%      | 100%   |
+| `vacuous-under-guard`     | 1   | 0   | 0    | 100%      | 100%   |
+
+**`finding_localisation_rate` 40%** — 2 of 5 true positives named where. The
+three that did not: `hollow-denominator` (the diagnostic names a metric, not a
+file), `catch-all-universal` (an aggregate, not a located finding), and
+`marker-form-mismatch` (`no-symbol-bound` names the language `rust`, not the
+marker's line). All three are quoin#197 workstream 4, and this is the number
+that measures whether that work lands.
+
+`actionability_rate` reads 29% against tier 2's 3.02% — a small clean corpus
+flatters it, which is why both tiers are kept.
+
+## Deliberate choices
+
+- **The mapping is data, not code.** `bench/tier1-mapping.json` is the contract
+  between what a tool emits and what the benchmark calls a finding, and it is
+  reviewable in a diff. TC-958 enforces that every declared family is mapped and
+  no mapping names an undeclared one.
+- **`source: none` is a declared hole.** `gate-that-gates-nothing` maps to
+  nothing because nothing detects it. Omitting it would read as an oversight;
+  declaring it makes the recall of 0 a fact the file states. TC-959 requires a
+  note on any such entry.
+- **The ratchet is quire-rs `bench.py`'s, not a new one.** Same one-way compare,
+  same `gate-zero` handling, same discipline of omitting an unreadable metric
+  rather than reporting 0. Two ratchets with two behaviours is one ratchet
+  nobody trusts.

--- a/reviews/26-08-23-tier1-runner-gap-analysis.md
+++ b/reviews/26-08-23-tier1-runner-gap-analysis.md
@@ -1,0 +1,95 @@
+---
+id: SR-019
+title: "Gap analysis — the tier-1 runner and its ratchet (quoin#199)"
+type: SpecReview
+analysis: gap-analysis
+scope: "scripts/bench-tier1.mjs, bench/, tests/bench-tier1.test.ts, spec/matrix.md"
+review_set: subset
+---
+
+# SR-019: Gap analysis — the tier-1 runner and its ratchet (quoin#199)
+
+## Summary
+
+Post-implementation gate over `feat/199-tier1-runner`. Steps 2 and 3 ran in full;
+step 1 has no target (`#199` is a ticket, not a plan bundle); a targeted semantic
+pass ran over the eight requirement↔test↔code triples the diff adds. All eight
+new Test Cases are backed by the engine's own reconciliation, and the gate itself
+was mutation-verified end to end rather than assumed.
+
+## Verdict
+
+**CONDITIONAL** — no `high` findings. FND-001 is a real scoring hole with a named
+owner and a declared state in the mapping table, not a silent one.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                    | Refs                       |
+| ------- | -------- | ---------------------------------------------------------------------------------------------------------- | -------------------------- |
+| FND-001 | medium   | `mocked-confirmation` is mapped to `audit.findings` and the runner never calls `quoin evidence audit`      | scripts/bench-tier1.mjs:79 |
+| FND-002 | medium   | `cost_per_confirmed_insight` is declared and still uncomputed — the runner records no tokens or tool calls | bench/metrics.json         |
+| FND-003 | low      | `span_grounding_rate` remains uncomputed; quoin#219 is unblocked by quire-cli#63 but not yet done          | bench/metrics.json         |
+| FND-004 | low      | The gate is not wired into `make lint`/`make test`, so it runs only when invoked                           | Makefile                   |
+
+## Detail
+
+### FND-001 — a mapped family the runner cannot reach
+
+`bench/tier1-mapping.json` maps `mocked-confirmation` to `audit.findings`, and
+`findingsFor` calls `quire coverage` and `quire validate` only. So the family
+scores recall 0 for a reason the table names and the runner does not act on.
+
+This is deliberate and bounded, not an oversight: the detector **cannot fire at
+all** (`agent-ix/quoin#204`, reopened — `AuditInput.injections` is never supplied
+by any caller and nothing produces a `MockInjection`), so wiring the third command
+today would add a subprocess per corpus and change no number. The mapping declares
+the intended source so the wiring has a contract to satisfy when #204 lands.
+
+The gap is recorded rather than hidden, which is the standard this programme
+holds everything else to.
+
+### FND-002 / FND-003 — two metrics still declared and uncomputed
+
+`cost_per_confirmed_insight` needs a token and tool-call count per run;
+`scoreCost` exists and the runner passes it nothing, because a `make` target
+invoking two binaries has no agent-harness accounting to read. `span_grounding_rate`
+needs a runner over `quire properties --json` — that is `quoin#219`, unblocked by
+the quire-cli#63 scope fix and not yet done.
+
+Both carry a `baseline_note` saying so. A declared-and-uncomputed metric is
+honest; a declared metric silently reported as 0 is the failure the dictionary
+exists to prevent.
+
+### FND-004 — the gate runs when asked
+
+`make bench-tier1` is not part of `make lint` or `make test`. That is the right
+default for now — it shells out to a `quire` binary whose version is a variable,
+and a gate that fails on a clean checkout because the host's CLI lags gets
+disabled within a week. It belongs in the release gauntlet once the binary is
+pinned; recorded so the choice is visible.
+
+## Coverage
+
+**Step 1 — plan completion.** Not applicable: `#199` is a ticket.
+
+**Step 2 — matrix verification.** `quire coverage --scope .` with `quire` built
+from `quire-rs@8c4928a`: 332/686 backed, and **none** of TC-953..TC-960 appears in
+`unbacked_rows`. Every one is bound by the engine's reconciliation, not by a grep.
+
+**Step 3 — underspecified code.** Every exported symbol the diff adds has an
+owning criterion and a test: `flattenLabels` → FR-043-AC-7 (TC-953),
+`localisationRate` → FR-043-AC-4 (TC-954), `compare` → FR-043-AC-10 and
+FR-043-AC-6 (TC-955, TC-956, TC-957), `ratchet` → FR-043-AC-10 (TC-960). The
+mapping table is data and is covered by TC-958 and TC-959. `findingsFor` and
+`render` are internal and covered indirectly by the mutation run below.
+
+**Step 4 — semantic review.** Run, scoped to the eight new triples. It is what
+produced FND-001: TC-958 asserts every declared family is _mapped_, which is
+weaker than every declared family being _reachable_, and `mocked-confirmation`
+sits in exactly that gap. The other seven agree with their criteria's intent.
+
+**The gate was verified, not assumed.** Retiring one mapping key — simulating a
+detector that stops emitting its signal — moved `vacuous-under-guard` recall
+1.00 → 0.00, printed `!!`, held the baseline at 1, and exited non-zero. Restoring
+the key returned the run to green. That is the property FR-043-AC-10 asks for,
+demonstrated rather than described.

--- a/scripts/bench-tier1.mjs
+++ b/scripts/bench-tier1.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+// The tier-1 benchmark runner (agent-ix/quoin#199, FR-043-AC-2/AC-7).
+//
+// `buildBenchCorpora` had no production caller. The corpora were built only by
+// a unit test, into a temp directory, and scored by nobody — so every metric in
+// `bench/metrics.json` that depends on them carried `baseline: null` with the
+// note "No tier-1 run has been scored against a toolchain yet."
+//
+// This is that runner. It materializes the seeded corpora, runs the real tools
+// over each, maps their payloads to findings through the committed table in
+// `bench/tier1-mapping.json`, and scores them against the labels the corpora
+// carry.
+//
+//   node scripts/bench-tier1.mjs                  # score and diff
+//   node scripts/bench-tier1.mjs --update         # deliberate re-baseline
+//   node scripts/bench-tier1.mjs --json           # the score, machine-readable
+//
+// Ratchet semantics are quire-rs `scripts/bench.py`'s, deliberately: a closed
+// metric dictionary that refuses an undeclared name, a one-way compare where a
+// regression keeps the OLD baseline so a bad run can never lower the bar, and
+// an unreadable metric OMITTED rather than reported as 0.
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildBenchCorpora } from "../evals/fixtures/bench/build.mjs";
+import { crossCheckFamilies, loadMetrics } from "../evals/lib/dictionary.mjs";
+import { scoreActionability, scoreFindings } from "../evals/lib/quality.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const MAPPING = join(ROOT, "bench", "tier1-mapping.json");
+const METRICS = join(ROOT, "bench", "metrics.json");
+const BASELINE = join(ROOT, "bench", "tier1-baseline.json");
+
+/**
+ * The bracketed reason a `validate` finding ends with, and the path and line it
+ * opens with.
+ *
+ * Parsed rather than read from a field because `validate` has no JSON payload —
+ * `--diagnostics-format json` wraps the whole human string in `message`. The
+ * fragility is declared in `bench/tier1-mapping.json` and tracked as
+ * agent-ix/quire-cli#65; a message this cannot parse is an ERROR here, never a
+ * skip, because a family that silently stops scoring looks identical to a
+ * family with nothing to report.
+ */
+const VALIDATE_LINE =
+  /^(?<path>.+?): line (?<line>\d+): (?<rest>.*) \[(?<reason>[a-z-]+)\]$/;
+
+/** Run a command, returning stdout, stderr and whether it exited zero. */
+function run(bin, args) {
+  try {
+    const stdout = execFileSync(bin, args, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout, stderr: "" };
+  } catch (error) {
+    // A non-zero exit is normal here: `validate` exits 1 when a document fails,
+    // which is exactly the case being measured. The output is what matters.
+    return {
+      ok: false,
+      stdout: String(error.stdout ?? ""),
+      stderr: String(error.stderr ?? error.message ?? ""),
+    };
+  }
+}
+
+/** Every finding one corpus produced, already mapped to a family. */
+function findingsFor(quire, corpusRoot, mapping) {
+  const module = join(corpusRoot, "module");
+  const out = [];
+  const bySource = (name) =>
+    Object.entries(mapping.families).filter(([, m]) => m.source === name);
+
+  // ── quire coverage ──
+  const cov = run(quire, [
+    "coverage",
+    "--scope",
+    corpusRoot,
+    "--module",
+    module,
+    "--json",
+  ]);
+  let payload = null;
+  try {
+    payload = JSON.parse(cov.stdout);
+  } catch {
+    throw new Error(
+      `bench-tier1: \`quire coverage\` produced no JSON for ${corpusRoot}. ` +
+        `Refusing to score a corpus whose payload could not be read — an ` +
+        `unreadable run and a clean run are the same zero.\n${cov.stderr.trim()}`,
+    );
+  }
+
+  for (const [family, m] of bySource("coverage.diagnostics")) {
+    for (const d of payload.diagnostics ?? []) {
+      if (d.reason !== m.key) continue;
+      out.push({ family, reason: d.reason, path: d.path ?? null, line: null });
+    }
+  }
+  for (const [family, m] of bySource("coverage.suspicions")) {
+    for (const s of payload.suspicions ?? []) {
+      if (s.kind !== m.key) continue;
+      out.push({
+        family,
+        reason: s.kind,
+        path: s.path ?? null,
+        line: typeof s.line === "number" ? s.line : null,
+      });
+    }
+  }
+  // A metric is a finding only when it sits at the value a label expects. The
+  // metric MOVING is the signal, so the expectation lives on the label and this
+  // stage carries the observed value for the caller to compare.
+  const metrics = new Map((payload.metrics ?? []).map((m) => [m.name, m]));
+  for (const [family, m] of bySource("coverage.metrics")) {
+    const metric = metrics.get(m.key);
+    if (!metric || metric.state !== "measured") continue;
+    out.push({
+      family,
+      reason: m.key,
+      path: null,
+      line: null,
+      metric: m.key,
+      value: Number(metric.value),
+    });
+  }
+
+  // ── quire validate ──
+  const val = run(quire, [
+    "validate",
+    "--diagnostics-format",
+    "json",
+    "--scope",
+    corpusRoot,
+    "--module",
+    module,
+    "spec/*.md",
+  ]);
+  const wanted = new Set(bySource("validate.findings").map(([, m]) => m.key));
+  const familyOfReason = new Map(
+    bySource("validate.findings").map(([family, m]) => [m.key, family]),
+  );
+  for (const raw of val.stderr.split("\n")) {
+    const text = raw.trim();
+    if (!text.startsWith("{")) continue;
+    let record;
+    try {
+      record = JSON.parse(text);
+    } catch {
+      continue;
+    }
+    if (record.kind !== "ValidationError") continue;
+    const parsed = VALIDATE_LINE.exec(record.message);
+    if (!parsed) {
+      // Not a locatable finding (the run summary is a ValidationError too).
+      // Only refuse when it LOOKS like a finding: `<path>: line N:`.
+      if (/^.+: line \d+:/.test(record.message)) {
+        throw new Error(
+          `bench-tier1: could not parse a validate finding's path, line and ` +
+            `reason from:\n  ${record.message}\n` +
+            `The message format is the only place they exist ` +
+            `(agent-ix/quire-cli#65). Refusing to skip it — a family that ` +
+            `silently stops scoring reads as a family with nothing to report.`,
+        );
+      }
+      continue;
+    }
+    const { path, line, reason } = parsed.groups;
+    if (!wanted.has(reason)) continue;
+    out.push({
+      family: familyOfReason.get(reason),
+      reason,
+      path,
+      line: Number(line),
+    });
+  }
+
+  return out;
+}
+
+/** Flatten `labels.json`'s `{corpora:[{defects}]}` into the flat array scoring takes. */
+export function flattenLabels(labels) {
+  // The shape mismatch that kept `buildBenchCorpora` and `scoreFindings` from
+  // ever meeting: the builder writes a wrapper keyed by corpus, the scorer
+  // consumes a flat list. Converted in ONE place so the two cannot drift.
+  return labels.corpora.flatMap((c) =>
+    c.defects.map((d) => ({ ...d, corpus: c.name })),
+  );
+}
+
+/**
+ * The fraction of true positives whose reported location matches the label's.
+ *
+ * The metric that encodes the actual requirement: an alert must say WHERE.
+ * `scoreFindings` already counts positional pairings; this is their share of
+ * the confirmed findings, and `null` — never 0 — when nothing was confirmed,
+ * because 0/0 is not 0%.
+ */
+export function localisationRate(score) {
+  const truePositives = score.families.reduce((n, f) => n + f.truePositives, 0);
+  if (truePositives === 0) return null;
+  return Number((score.positional / truePositives).toFixed(3));
+}
+
+/**
+ * quire-rs `bench.py`'s `compare`, in JS and with its semantics intact.
+ *
+ * A regression keeps the OLD baseline, so a bad run can never implicitly lower
+ * the bar; `gate-zero` carries no baseline and no tolerance, so `--update`
+ * cannot launder it; a missing baseline is `new`, never a pass by default.
+ */
+export function compare(direction, observed, baseline) {
+  if (direction === "gate-zero") {
+    return [observed === 0 ? "held" : "regressed", 0];
+  }
+  if (baseline === null || baseline === undefined) return ["new", observed];
+  const better =
+    direction === "higher-is-better"
+      ? observed > baseline
+      : observed < baseline;
+  if (better) return ["improved", observed];
+  if (observed === baseline) return ["held", baseline];
+  return ["regressed", baseline];
+}
+
+function main() {
+  const update = process.argv.includes("--update");
+  const asJson = process.argv.includes("--json");
+  const quire = argOf("--quire") ?? "quire";
+
+  const mapping = JSON.parse(readFileSync(MAPPING, "utf8"));
+  const dictionary = loadMetrics(METRICS);
+
+  const root = mkdtempSync(join(tmpdir(), "quoin-tier1-"));
+  let report;
+  try {
+    const labels = buildBenchCorpora(root);
+    const flat = flattenLabels(labels);
+
+    // Both directions, before anything is scored: a declared family with no
+    // corpus and a corpus family no metric governs are each a hole in the
+    // score, and finding them after a run wastes the run.
+    crossCheckFamilies(
+      dictionary.families,
+      labels.corpora.map((c) => c.family),
+      { path: "bench/metrics.json" },
+    );
+
+    const found = [];
+    for (const corpus of labels.corpora) {
+      found.push(...findingsFor(quire, join(root, corpus.name), mapping));
+    }
+
+    // A metric-sourced finding counts only at the value its label expects; the
+    // metric merely EXISTING says nothing. Filtered here rather than inside
+    // `findingsFor` so the mapping stage stays a pure payload read.
+    const expectedValues = new Map(
+      flat
+        .filter((l) => l.expect_metric !== undefined)
+        .map((l) => [l.expect_metric, Number(l.expect_value)]),
+    );
+    const scoredFindings = found.filter(
+      (f) => f.metric === undefined || expectedValues.get(f.metric) === f.value,
+    );
+
+    const score = scoreFindings(scoredFindings, flat);
+    report = {
+      families: score.families,
+      excluded: score.excluded,
+      collateral: score.collateral,
+      positional: score.positional,
+      finding_localisation_rate: localisationRate(score),
+      actionability: scoreActionability(scoredFindings),
+      corpora: labels.corpora.length,
+      findings: scoredFindings.length,
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  const previous = existsSync(BASELINE)
+    ? JSON.parse(readFileSync(BASELINE, "utf8"))
+    : null;
+  const verdicts = ratchet(report, previous, dictionary);
+
+  if (asJson) {
+    console.log(JSON.stringify({ ...report, verdicts }, null, 2));
+  } else {
+    console.log(render(report, verdicts));
+  }
+
+  if (update) {
+    writeFileSync(BASELINE, JSON.stringify(report, null, 2) + "\n");
+    console.error(`bench-tier1: baseline rewritten at ${BASELINE}`);
+    return 0;
+  }
+  return verdicts.some((v) => v.verdict === "regressed") ? 1 : 0;
+}
+
+/** Per-family precision and recall against the baseline, one-way. */
+export function ratchet(report, previous, dictionary) {
+  const out = [];
+  const before = new Map((previous?.families ?? []).map((f) => [f.family, f]));
+  for (const family of report.families) {
+    for (const metric of ["precision", "recall"]) {
+      const declared = dictionary.metrics[`finding_${metric}`];
+      // A metric this run could not read is OMITTED, never reported as 0 —
+      // `null` precision means no denominator, and calling that a regression
+      // would fail the build for a family nothing fired on.
+      if (family[metric] === null) continue;
+      const [verdict, kept] = compare(
+        declared.direction,
+        family[metric],
+        before.get(family.family)?.[metric] ?? null,
+      );
+      out.push({
+        metric: `finding_${metric}`,
+        family: family.family,
+        observed: family[metric],
+        baseline: kept,
+        verdict,
+      });
+    }
+  }
+  // A family the baseline scored and this run does not report AT ALL — its
+  // corpus deleted, its mapping dropped, its label removed. Without this the
+  // family simply vanishes from the table and the ratchet says nothing, so
+  // deleting a corpus reads as a clean run. That is the same shape as a check
+  // that cannot fail: the absence of a row is indistinguishable from an
+  // absence of news.
+  const now = new Set(report.families.map((f) => f.family));
+  for (const f of previous?.families ?? []) {
+    if (now.has(f.family)) continue;
+    out.push({
+      metric: "finding_recall",
+      family: f.family,
+      observed: null,
+      baseline: f.recall,
+      verdict: "regressed",
+      why: "the baseline scored this family and this run did not report it at all",
+    });
+  }
+
+  if (report.finding_localisation_rate !== null) {
+    const [verdict, kept] = compare(
+      "higher-is-better",
+      report.finding_localisation_rate,
+      previous?.finding_localisation_rate ?? null,
+    );
+    out.push({
+      metric: "finding_localisation_rate",
+      family: null,
+      observed: report.finding_localisation_rate,
+      baseline: kept,
+      verdict,
+    });
+  }
+  return out;
+}
+
+const MARK = { improved: "++", held: "ok", new: "**", regressed: "!!" };
+
+function render(report, verdicts) {
+  const pct = (v) =>
+    v === null ? "  n/a" : `${Math.round(v * 100)}%`.padStart(5);
+  const lines = [
+    `tier-1: ${report.corpora} corpora, ${report.findings} findings mapped`,
+    "",
+    "family                     TP  FP  miss   prec  recall",
+  ];
+  for (const f of report.families) {
+    lines.push(
+      `  ${f.family.padEnd(24)} ${String(f.truePositives).padStart(2)}  ` +
+        `${String(f.falsePositives).padStart(2)}  ${String(f.misses).padStart(4)}  ` +
+        `${pct(f.precision)}  ${pct(f.recall)}`,
+    );
+  }
+  lines.push(
+    "",
+    `finding_localisation_rate  ${pct(report.finding_localisation_rate)} ` +
+      `(${report.positional} of ${report.families.reduce((n, f) => n + f.truePositives, 0)} true positives named where)`,
+    `actionability_rate         ${pct(report.actionability.rate)} ` +
+      `(${report.actionability.actionable} of ${report.actionability.total} findings name a row or a line)`,
+  );
+  if (report.collateral.length) {
+    lines.push(
+      "",
+      "declared collateral, set aside from scoring:",
+      ...report.collateral.map((c) => `  ${c.family} (${c.reason})`),
+    );
+  }
+  if (report.excluded.length) {
+    lines.push(`excluded as not findable: ${report.excluded.join(", ")}`);
+  }
+  lines.push("", "ratchet:");
+  for (const v of verdicts) {
+    const name = v.family ? `${v.metric}[${v.family}]` : v.metric;
+    lines.push(
+      `  ${MARK[v.verdict]} ${name.padEnd(40)} ${v.observed} (baseline ${v.baseline})` +
+        (v.why ? ` — ${v.why}` : ""),
+    );
+  }
+  if (verdicts.some((v) => v.verdict === "regressed")) {
+    lines.push(
+      "",
+      "REGRESSED — the baseline is kept, never lowered by a bad run.",
+    );
+  } else if (verdicts.some((v) => v.verdict === "improved")) {
+    lines.push(
+      "",
+      "improved — run `make bench-tier1-update` to move the baseline.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function argOf(flag) {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? null : process.argv[i + 1];
+}
+
+if (
+  resolve(process.argv[1] ?? "") === resolve(fileURLToPath(import.meta.url))
+) {
+  process.exit(main());
+}

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -393,6 +393,14 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-950 | Declared collateral names a family, a reason and a note, and consumes ONE finding per declaration — so a consequence of the seeded defect is not scored as a false positive, and a duplicate cannot hide behind the same declaration (#199) | Unit | P0 | FR-043-AC-2, FR-043-AC-7 | ✅ |
 | TC-951 | A label whose family has no working detector records which of the three reasons applies and names its ticket, so a recall of 0 says whether the tool looked and missed or never looked (#199) | Unit | P0 | FR-043-AC-7 | ✅ |
 | TC-952 | Declared collateral is set aside from scoring, reported by name, and SPENT once per declaration — a second identical consequence is a false positive, and a declaration whose reason does not match absorbs nothing (#199) | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-953 | `labels.json`'s per-corpus wrapper is flattened into the array `scoreFindings` consumes, in one place, carrying the corpus name — the shape mismatch that kept `buildBenchCorpora` and the scorer from ever meeting (#199) | Unit | P0 | FR-043-AC-7 | ✅ |
+| TC-954 | `finding_localisation_rate` is positional pairings over true positives, and `null` — never 0 — when nothing was confirmed (#199) | Unit | P0 | FR-043-AC-4 | ✅ |
+| TC-955 | The ratchet is one-way: a regression keeps the OLD baseline in both directions, so a bad run can never lower the bar (#199) | Unit | P0 | FR-043-AC-10 | ✅ |
+| TC-956 | A missing baseline scores `new` — neither a pass by default nor a failure — and the observed value is proposed, not written (#199) | Unit | P0 | FR-043-AC-10 | ✅ |
+| TC-957 | `gate-zero` carries no baseline and no tolerance, and its proposed baseline is forced to 0 so `--update` cannot launder a non-zero value (#199) | Unit | P0 | FR-043-AC-6 | ✅ |
+| TC-958 | Every family the dictionary declares is mapped to a real payload source and key, and no mapping names a family nothing declares (#199) | Unit | P0 | FR-043-AC-2 | ✅ |
+| TC-959 | A family with no detector declares `source: none` with a note rather than being omitted, so a recall of 0 says whether anything looked (#199) | Unit | P0 | FR-043-AC-7 | ✅ |
+| TC-960 | A family the baseline scored and a run does not report AT ALL is a regression with the baseline kept — deleting a corpus must not read as a clean run (#199) | Unit | P0 | FR-043-AC-10 | ✅ |
 | TC-936 | An obligation discharged only by a mocked stand-in for its own subject is a `medium` `mocked-confirmation` finding naming the injected identifier (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-937 | A mock unrelated to the statement's subject (`FakeClock`) is not reported — tests legitimately mock clocks, filesystems and networks (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-938 | One real suite alongside a mocked one is not reported: standing in a dependency while another suite exercises the real path is ordinary test design (#204) | Unit | P0 | FR-032-AC-15 | ✅ |

--- a/tests/bench-tier1.test.ts
+++ b/tests/bench-tier1.test.ts
@@ -1,0 +1,194 @@
+/**
+ * The tier-1 runner (quoin#199, FR-043-AC-2/AC-9/AC-10).
+ *
+ * `buildBenchCorpora` had no production caller until this runner: the corpora
+ * were built by a unit test, into a temp directory, and scored by nobody. These
+ * tests cover the pure parts — the label flattening that made the two halves
+ * able to meet, the localisation rate, and the ratchet's one-way semantics.
+ * Whether a given corpus actually produces a given finding is verified by
+ * running the real engine and recorded per defect in `confirmed_at`; asserting
+ * it here would make the unit suite depend on a `quire` binary.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  compare,
+  flattenLabels,
+  localisationRate,
+  ratchet,
+} from "../scripts/bench-tier1.mjs";
+
+describe("tier-1 label flattening", () => {
+  test("TC-953 the builder's wrapper becomes the flat array scoring consumes", () => {
+    // TC-953
+    // The shape mismatch that kept the two halves from ever meeting:
+    // `buildBenchCorpora` writes `{corpora:[{name, defects}]}` and
+    // `scoreFindings` consumes a flat list of labels. Nothing converted, so
+    // nothing scored. The corpus name rides along, because a label that cannot
+    // say which corpus it came from cannot be argued with.
+    const flat = flattenLabels({
+      corpora: [
+        { name: "a", family: "f1", defects: [{ id: "A-1", family: "f1" }] },
+        { name: "b", family: "f2", defects: [{ id: "B-1", family: "f2" }] },
+        { name: "clean", family: "none", defects: [] },
+      ],
+    });
+    expect(flat).toEqual([
+      { id: "A-1", family: "f1", corpus: "a" },
+      { id: "B-1", family: "f2", corpus: "b" },
+    ]);
+  });
+});
+
+describe("finding localisation rate", () => {
+  test("TC-954 it is positional pairings over true positives, null when there are none", () => {
+    // TC-954
+    // The metric that encodes the actual requirement: an alert must say WHERE.
+    // Two of five is the first scored run — the three that did not name a place
+    // are an aggregate metric, a diagnostic that names a metric rather than a
+    // file, and one that names the LANGUAGE instead of the marker's line.
+    expect(
+      localisationRate({
+        positional: 2,
+        families: [
+          { truePositives: 3 },
+          { truePositives: 2 },
+          { truePositives: 0 },
+        ],
+      }),
+    ).toBe(0.4);
+
+    // `null`, never 0. A run that confirmed nothing has no localisation rate,
+    // and reporting 0 would claim every finding failed to name a place when no
+    // finding was confirmed at all — 0/0 is not 0%.
+    expect(
+      localisationRate({ positional: 0, families: [{ truePositives: 0 }] }),
+    ).toBeNull();
+  });
+});
+
+describe("the ratchet", () => {
+  test("TC-955 a regression keeps the OLD baseline, so a bad run cannot lower the bar", () => {
+    // TC-955
+    // quire-rs `scripts/bench.py`'s semantics, deliberately identical. The
+    // one-way property is the whole point: if a regression proposed its own
+    // value as the new baseline, `--update` after a bad run would quietly
+    // ratify it and the gate would track whatever the tool last did.
+    expect(compare("higher-is-better", 0.9, 0.5)).toEqual(["improved", 0.9]);
+    expect(compare("higher-is-better", 0.5, 0.5)).toEqual(["held", 0.5]);
+    expect(compare("higher-is-better", 0.2, 0.5)).toEqual(["regressed", 0.5]);
+    // Direction is honoured, not assumed.
+    expect(compare("lower-is-better", 0.2, 0.5)).toEqual(["improved", 0.2]);
+    expect(compare("lower-is-better", 0.9, 0.5)).toEqual(["regressed", 0.5]);
+  });
+
+  test("TC-956 a missing baseline is `new`, never a pass by default", () => {
+    // TC-956
+    // The first run of any metric. It must not read as a pass — nothing was
+    // compared — and it must not read as a failure either. The observed value
+    // is PROPOSED, and only `--update` writes it.
+    expect(compare("higher-is-better", 0.7, null)).toEqual(["new", 0.7]);
+    expect(compare("higher-is-better", 0.7, undefined)).toEqual(["new", 0.7]);
+  });
+
+  test("TC-957 gate-zero carries no baseline and no tolerance to spend", () => {
+    // TC-957
+    // A gate is not a score. Anything non-zero is a regression regardless of
+    // history, and the proposed baseline is forced back to 0 so `--update`
+    // cannot launder a non-zero value into the accepted state.
+    expect(compare("gate-zero", 0, null)).toEqual(["held", 0]);
+    expect(compare("gate-zero", 1, null)).toEqual(["regressed", 0]);
+    expect(compare("gate-zero", 3, 3)).toEqual(["regressed", 0]);
+  });
+});
+
+describe("a vanished family", () => {
+  test("TC-960 a family the baseline scored and this run does not report is a regression", () => {
+    // TC-960
+    // Delete a corpus, drop a mapping, remove a label — and without this the
+    // family simply stops appearing and the ratchet says nothing. An absent row
+    // is indistinguishable from an absence of news, which is the same shape as
+    // a check that cannot fail. Exercised through the runner's own ratchet
+    // rather than by hand, so the wiring is covered too.
+    const report = {
+      families: [
+        {
+          family: "kept",
+          truePositives: 1,
+          falsePositives: 0,
+          misses: 0,
+          precision: 1,
+          recall: 1,
+        },
+      ],
+      finding_localisation_rate: null,
+    };
+    const previous = {
+      families: [
+        { family: "kept", precision: 1, recall: 1 },
+        { family: "vanished", precision: 1, recall: 1 },
+      ],
+      finding_localisation_rate: null,
+    };
+    const verdicts = ratchet(report, previous, {
+      metrics: {
+        finding_precision: { direction: "higher-is-better" },
+        finding_recall: { direction: "higher-is-better" },
+      },
+    });
+    const gone = verdicts.find((v) => v.family === "vanished");
+    expect(gone?.verdict).toBe("regressed");
+    expect(gone?.observed).toBeNull();
+    // The baseline is kept, so `--update` after a deletion cannot ratify it.
+    expect(gone?.baseline).toBe(1);
+    expect(gone?.why).toMatch(/did not report it at all/);
+  });
+});
+
+describe("the committed mapping table", () => {
+  const mapping = JSON.parse(
+    readFileSync(join(__dirname, "..", "bench", "tier1-mapping.json"), "utf8"),
+  );
+  const dictionary = JSON.parse(
+    readFileSync(join(__dirname, "..", "bench", "metrics.json"), "utf8"),
+  );
+
+  test("TC-958 every declared family is mapped, and every mapping names a real source", () => {
+    // TC-958
+    // The mapping is the contract between what a tool emits and what the
+    // benchmark calls a finding. A family the dictionary declares but the table
+    // does not map scores 0 forever and looks like a detector failure; a
+    // mapping naming a payload section that does not exist is a rule that can
+    // never fire.
+    const sources = new Set([...Object.keys(mapping.sources), "none"]);
+    for (const family of dictionary.families) {
+      expect(
+        mapping.families[family],
+        `${family} is declared in bench/metrics.json and mapped nowhere`,
+      ).toBeDefined();
+      expect(sources).toContain(mapping.families[family].source);
+      expect(mapping.families[family].key).toBeTruthy();
+    }
+    // And no mapping for a family nothing declares.
+    for (const family of Object.keys(mapping.families)) {
+      expect(dictionary.families).toContain(family);
+    }
+  });
+
+  test("TC-959 a family with no detector declares `source: none` rather than being omitted", () => {
+    // TC-959
+    // The difference between "we looked and the tool said nothing" and "nothing
+    // looks for this" is the whole substance of a recall of 0. An omitted
+    // family reads as an oversight; `source: none` reads as a declared hole,
+    // and it is the state `gate-that-gates-nothing` is genuinely in.
+    const holes = Object.entries(mapping.families).filter(
+      ([, m]: [string, { source: string }]) => m.source === "none",
+    );
+    expect(holes.length).toBeGreaterThan(0);
+    for (const [, m] of holes as Array<[string, { $note?: string }]>) {
+      expect(m.$note).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Refs #199. Part of the #197 EPIC, workstream 2.

`buildBenchCorpora` had **no production caller**. The corpora were built by a unit test, into a temp directory, and scored by nobody — so every metric depending on them carried `baseline: null` with the note *"No tier-1 run has been scored against a toolchain yet."*

## The first scored run

`quire` built from `quire-rs@8c4928a`, 9 corpora, 7 findings mapped:

| family | TP | FP | miss | precision | recall |
| --- | --- | --- | --- | --- | --- |
| `catch-all-universal` | 1 | 0 | 0 | 100% | 100% |
| `gate-that-gates-nothing` | 0 | 0 | 1 | n/a | **0%** |
| `hollow-denominator` | 1 | 0 | 0 | 100% | 100% |
| `marker-form-mismatch` | 1 | 0 | 0 | 100% | 100% |
| `mocked-confirmation` | 0 | 0 | 1 | n/a | **0%** |
| `oracle-is-code-copy` | 0 | 0 | 1 | n/a | **0%** |
| `undeclared-type-value` | 1 | 0 | 0 | 100% | 100% |
| `vacuous-under-guard` | 1 | 0 | 0 | 100% | 100% |

**`finding_localisation_rate` 40%** — 2 of 5 true positives named *where*. The three that did not: `hollow-denominator`'s diagnostic names a metric rather than a file, `catch-all-universal` is an aggregate rather than a located finding, and `no-symbol-bound` names the **language** (`rust`) instead of the marker's line. All three are workstream 4, and this is the number that measures whether it lands.

`actionability_rate` reads 29% against tier 2's 3.02% — a small clean corpus flatters it, which is why both tiers are kept.

## Two corpus defects the first run exposed

**`catch-all-universal` scored precision 11%** — 1 true positive, 8 false. Reading the eight showed the tool was right: every corpus's only criterion was `universal`-shaped, so `coverage.specific_shaped` read 0 across all nine — **control included**. The signal was a constant.

A check that cannot stay silent on healthy input is not a check, and a control that carries the defect is not a control. That is the rule `clean-control` exists to enforce, being violated one level down, in the benchmark's own fixtures, found by the benchmark on its first run. Every corpus but `catch-all-properties` now carries an `idempotence`-shaped criterion; precision reads 100%.

**`hollow-denominator` scored 50%**, because collateral was declared one-way. An unread marker *is* a hollow denominator, so the relationship is symmetric and both corpora now declare it.

## The gate

`make bench-tier1`. Ratchet semantics are quire-rs `scripts/bench.py`'s, deliberately identical — a regression keeps the **old** baseline so a bad run can never lower the bar, `gate-zero` carries no tolerance `--update` could launder, and an unreadable metric is **omitted** rather than reported as 0.

Verified rather than described: retiring one mapping key takes `vacuous-under-guard` recall 1.00 → 0.00, prints `!!`, holds the baseline at 1 and exits non-zero. Restoring it returns the run to green.

A family present in the baseline and **absent** from a run is also a regression (TC-960). Without that, deleting a corpus read as a clean run — an absent row is indistinguishable from an absence of news.

## Declared, not hidden

- `validate` has no JSON payload, so path, line and reason are parsed out of a message string. The runner **throws** on a message it cannot parse rather than skipping it, and `parse_fragility` in the mapping records why. Filed as **agent-ix/quire-cli#65**.
- `gate-that-gates-nothing` maps to `source: none` — a declared hole, so its recall of 0 is a fact the file states rather than an oversight a reader has to infer.
- `mocked-confirmation` is mapped to `audit.findings` and the runner does not yet call `quoin evidence audit`, because the detector cannot fire at all (**quoin#204**, reopened). The mapping declares the intended source so the wiring has a contract to satisfy.

## Gates

`make lint`, `make test` (53 files) and `make bench-tier1` green. TC-953..TC-960 added to `spec/matrix.md`, all eight backed per `quire coverage`.

Reviews: **SR-018** (code review, CONDITIONAL) and **SR-019** (gap analysis, CONDITIONAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDbNXrE3G1UxPeCn7WfqrC