### PR TITLE
Re-adjudicate the answer key against the code, not against its notes (#200)

### DIFF
--- a/bench/answer-key.json
+++ b/bench/answer-key.json
@@ -1,14 +1,15 @@
 {
-  "$comment": "Tier-2 adjudicated answer key (agent-ix/quoin#200, FR-043-AC-8). The manual findings of battletest pass 2, made machine-readable and keyed to a pinned commit. This set is the RECALL DENOMINATOR for 'would the tools have found what humans found'. Every entry was adjudicated by reading the corpus, not inferred from tool output — which is the point, since the tools found none of them.",
+  "$comment": "Tier-2 adjudicated answer key (agent-ix/quoin#200, FR-043-AC-8). The manual findings of battletest pass 2, made machine-readable and keyed to a pinned commit. This set is the RECALL DENOMINATOR for 'would the tools have found what humans found'. Every entry was adjudicated by reading the corpus, not inferred from tool output \u2014 which is the point, since the tools found none of them. RE-ADJUDICATED 2026-08-23 against the code as it stands, not against the notes: every `now_detectable` claim was checked by locating the detector and its caller, and two were wrong.",
   "corpus": "agent-ix/filament-ide-rs",
   "pinned_sha": "fc5d644",
-  "adjudicated": "2026-08-22",
+  "adjudicated": "2026-08-23",
   "sources": [
     "agent-ix/filament-ide-rs#451 (pass-2 umbrella)",
-    "SR-153, SR-154, SR-155",
-    "agent-ix/filament-ide-rs#460 (owed corpus findings)"
+    "SR-153, SR-154, SR-155 \u2014 renumbered to SR-175, SR-176, SR-177 on merge (filament-ide-rs#505); main had published the original ids to unrelated work",
+    "agent-ix/filament-ide-rs#460 (owed corpus findings)",
+    "SR-016 through SR-019 (quoin#199) \u2014 the tier-1 evidence this re-adjudication is checked against"
   ],
-  "re_pin_policy": "Re-pinning requires RE-ADJUDICATION, not re-measurement. The findings below are claims about a specific tree; carrying them to a different commit without reading it again would assert something nobody checked. Use `make answer-key-repin`, whose diff belongs in the pull request — the same discipline as quire-rs/tests/fixtures/coverage_baseline/expected.json.",
+  "re_pin_policy": "Re-pinning requires RE-ADJUDICATION, not re-measurement. The findings below are claims about a specific tree; carrying them to a different commit without reading it again would assert something nobody checked. Use `make answer-key-repin`, whose diff belongs in the pull request \u2014 the same discipline as quire-rs/tests/fixtures/coverage_baseline/expected.json.",
   "findings": [
     {
       "id": "AK-001",
@@ -17,11 +18,13 @@
       "measured": "1,292 `fn tc_NNN_` sites against 0 of the declared `fn tcNNN_` spelling. Widening the pattern took coverage from 555/2389 (23%) to 1158/2389 (48%) with no test written.",
       "location": "declared in spec-artifacts-process; observed across 24 crates",
       "found_by_tools_at_pass_2": false,
-      "found_by": "controlled experiment — copy the module, widen one regex, diff the census",
+      "found_by": "controlled experiment \u2014 copy the module, widen one regex, diff the census",
       "expect_reason": "no-symbol-bound",
       "now_detectable": true,
       "detectable_since": "quire-rs v0.43.0 (FR-050-AC-27)",
-      "fixed_by": "agent-ix/spec-artifacts-process#65"
+      "fixed_by": "agent-ix/spec-artifacts-process#65",
+      "detection_strength": "located",
+      "$strength_note": "`no-symbol-bound` carries a `path` and names the declared forms to check. Confirmed on the tier-1 `marker-mismatch` corpus: precision 1.00, recall 1.00. It does NOT name the marker's line \u2014 the value is the language, `rust` \u2014 so it is located to a file and no further, which is one of the three misses behind the 40% localisation rate."
     },
     {
       "id": "AK-002",
@@ -30,11 +33,13 @@
       "measured": "0 of 1,292 evidence symbols bound; 0 of 643 trace lines matched. Three published SpecReviews (SR-150/151/152) cite figures computed under it.",
       "location": "spec/**/matrix/tests.md, all 12 module matrices",
       "found_by_tools_at_pass_2": false,
-      "found_by": "manual — noticing that a 23% figure and a 1,292-symbol repository were inconsistent",
+      "found_by": "manual \u2014 noticing that a 23% figure and a 1,292-symbol repository were inconsistent",
       "expect_reason": "hollow-denominator",
       "now_detectable": true,
       "detectable_since": "quire-rs v0.43.0 (FR-063-AC-5)",
-      "fixed_by": "agent-ix/quire-rs#239"
+      "fixed_by": "agent-ix/quire-rs#239",
+      "detection_strength": "aggregate",
+      "$strength_note": "The diagnostic names the METRIC (`coverage.backed`) and carries `path: null`. Confirmed on the tier-1 `hollow-metric` corpus: detected, precision 1.00, and contributing nothing to the localisation rate. Downgraded from the implicit `located` the old `now_detectable: true` suggested."
     },
     {
       "id": "AK-003",
@@ -43,13 +48,15 @@
       "measured": "515/951 extractable; 78/951 specifically shaped. 65 of 67 specific-shape non-`example` records carried zero spans.",
       "location": "274 spec files",
       "found_by_tools_at_pass_2": false,
-      "found_by": "manual — reading the per-shape breakdown the summary line omitted",
+      "found_by": "manual \u2014 reading the per-shape breakdown the summary line omitted",
       "expect_metric": "coverage.specific_shaped",
       "now_detectable": true,
       "detectable_since": "quire-rs v0.43.0 (FR-050-AC-28)",
       "fixed_by": "agent-ix/quire-rs#240",
       "expect_value": 78,
-      "$expect_note": "78 is the ADJUDICATED figure at the pinned SHA — the specifically-shaped criteria of 951. The detection signal is that the split is reported at all; the value is what it was measured to be, so a change in either is a change worth seeing."
+      "$expect_note": "78 is the ADJUDICATED figure at the pinned SHA \u2014 the specifically-shaped criteria of 951. The detection signal is that the split is reported at all; the value is what it was measured to be, so a change in either is a change worth seeing.",
+      "detection_strength": "aggregate",
+      "$strength_note": "Detectable ONLY as a number moving. `coverage.specific_shaped` is a ratio over the whole corpus; no criterion is named, so a reader who sees the metric fall still has 274 spec files to search. This is the distinct, weaker state the re-adjudication was for. Making it a located finding is quoin#197 workstream 4."
     },
     {
       "id": "AK-004",
@@ -62,7 +69,9 @@
       "expect_suspicion": "vacuous-under-guard",
       "now_detectable": true,
       "detectable_since": "quire-rs main, post v0.43.0 (FR-064-AC-1)",
-      "fixed_by": "agent-ix/quire-rs#247"
+      "fixed_by": "agent-ix/quire-rs#247",
+      "detection_strength": "located",
+      "$strength_note": "`vacuous-under-guard` carries `path` AND `line` \u2014 confirmed at `src/lib.rs:7` on the tier-1 corpus. One of the two findings behind the 40% localisation rate."
     },
     {
       "id": "AK-005",
@@ -71,11 +80,14 @@
       "measured": "Replacing it with a real oracle immediately exposed a genuine Windows containment gap.",
       "location": "TC-1598",
       "found_by_tools_at_pass_2": false,
-      "found_by": "manual semantic review — pass 2's highest-value finding",
+      "found_by": "manual semantic review \u2014 pass 2's highest-value finding",
       "expect_suspicion": "oracle-resembles-implementation",
-      "now_detectable": "partially",
-      "detectable_since": "quire-rs main, post v0.43.0 (FR-064-AC-2) — the COMPARISON is implemented; the join from an oracle span to the implementation it judges is not wired, so this is not yet detected end to end",
-      "fixed_by": "agent-ix/quire-rs#247"
+      "now_detectable": false,
+      "detectable_since": null,
+      "fixed_by": null,
+      "detection_strength": "none",
+      "tracked_by": "agent-ix/quire-rs#236",
+      "$strength_note": "Was `now_detectable: \"partially\"` with a `detectable_since` and a `fixed_by`. All three were wrong, and they were wrong in the direction that flatters the toolchain. The COMPARISON ships and is unit-tested (`quire-rs/src/skeptic.rs`, FR-064-AC-2); the join from an oracle span to the implementation it judges is not wired, and `grep -rn oracle_copies src/` returns the definition and two unit tests \u2014 no production caller. Confirmed on the tier-1 `oracle-copy` corpus: the engine reports nothing. `partially` read as 'some of it fires', and none of it does, so `detectable_since` and `fixed_by` are null: a capability nothing can reach has no date it became available and no PR that delivered it. agent-ix/quire-rs#236 owns the join."
     },
     {
       "id": "AK-006",
@@ -88,12 +100,14 @@
       "now_detectable": false,
       "detectable_since": null,
       "fixed_by": null,
-      "tracked_by": "agent-ix/quoin#204"
+      "tracked_by": "agent-ix/quoin#204",
+      "detection_strength": "none",
+      "$strength_note": "`now_detectable: false` was right and its RECORDED REASON was wrong: this was written before quoin#204 shipped a detector, and nobody re-checked afterwards. The detector now exists at `src/auditor/audit.ts:241` and still cannot fire \u2014 `mockedBindings` returns [] on every production call because `AuditInput.injections` is optional, no caller supplies it, and nothing in the tree produces a `MockInjection`. The 8 unit tests build `injections` inline, which is why a green suite sat over a dead path. #204 reopened."
     },
     {
       "id": "AK-007",
       "family": "gate-that-gates-nothing",
-      "summary": "Repository gates that gated nothing — wired, green, and asserting no condition that could fail.",
+      "summary": "Repository gates that gated nothing \u2014 wired, green, and asserting no condition that could fail.",
       "measured": "Observed across the repo's own CI configuration during pass 2.",
       "location": "pass-2 semantic review",
       "found_by_tools_at_pass_2": false,
@@ -101,7 +115,15 @@
       "now_detectable": false,
       "detectable_since": null,
       "fixed_by": null,
-      "tracked_by": "agent-ix/quoin#204"
+      "tracked_by": "agent-ix/quoin#224",
+      "detection_strength": "none",
+      "$strength_note": "Pointed at quoin#204 \u2014 the mocked-confirmation ticket \u2014 since it was written, so this family has never had an owner. quoin#224 filed in the re-adjudication. No detector exists anywhere in the ecosystem, and the tier-1 mapping declares `source: none` so the recall of 0 is a stated fact rather than an inferred absence."
     }
-  ]
+  ],
+  "detection_strength_scale": {
+    "$comment": "How strongly a finding is detected, distinct from WHETHER it is. Added in the re-adjudication because `now_detectable: true` was flattening two different states: AK-003 is 'a number moved' and AK-001 is 'here is the file and the line'. Counting them as one overstates the toolchain, and `finding_localisation_rate` \u2014 measured at 40% on the first scored tier-1 run \u2014 exists precisely because they are not the same.",
+    "located": "the finding names a path, and a line where the payload carries one",
+    "aggregate": "a declared metric moves; no criterion, row or line is named",
+    "none": "nothing in the toolchain reports it"
+  }
 }

--- a/reviews/26-08-23-answer-key-readjudication.md
+++ b/reviews/26-08-23-answer-key-readjudication.md
@@ -1,0 +1,134 @@
+---
+id: SR-020
+title: "Re-adjudication — the tier-2 answer key against the code as it stands (quoin#200)"
+type: SpecReview
+analysis: gap-analysis
+scope: "bench/answer-key.json, tests/bench-corpora.test.ts, spec/matrix.md"
+review_set: subset
+---
+
+# SR-020: Re-adjudication — the tier-2 answer key against the code as it stands (quoin#200)
+
+## Summary
+
+Re-adjudicated all seven entries of `bench/answer-key.json` by locating each
+detector **and its caller**, not by re-reading the notes. Two `now_detectable`
+claims were wrong, both in the direction that flatters the toolchain; one family
+had never had a tracking ticket of its own; and every entry was carrying a
+boolean where the honest answer needs three values.
+
+The key is the recall denominator for "would the tools have found what humans
+found". Every error corrected here made that denominator read better than the
+truth.
+
+## Verdict
+
+**CONDITIONAL** — no `high` findings. FND-001 and FND-002 are corrections to a
+published artifact rather than defects in shipped behaviour, and both are now
+pinned by tests that fail if the state is restored.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                            | Refs                  |
+| ------- | -------- | ------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| FND-001 | medium   | AK-005 claimed `now_detectable: "partially"` with a date and a fixing PR for a detector with no caller — corrected | bench/answer-key.json |
+| FND-002 | medium   | AK-006's `now_detectable: false` was right for a reason nobody had re-checked since the detector shipped           | bench/answer-key.json |
+| FND-003 | medium   | AK-007 pointed at quoin#204 — another family's ticket — so `gate-that-gates-nothing` had no owner                  | bench/answer-key.json |
+| FND-004 | low      | `now_detectable` is a boolean over a three-valued fact: located, aggregate, none                                   | bench/answer-key.json |
+
+## Detail
+
+### FND-001 — three fields, all wrong, all in the same direction
+
+AK-005 (`oracle-is-code-copy`) carried `now_detectable: "partially"`,
+`detectable_since: "quire-rs main, post v0.43.0"`, and `fixed_by:
+"agent-ix/quire-rs#247"`.
+
+`grep -rn oracle_copies src/` in quire-rs returns the definition and two unit
+tests. **There is no production caller.** The similarity comparison ships and is
+tested; the join from an oracle span to the implementation it judges needs the
+`Registry` and the `implements` relation, which the binder does not hold. The
+tier-1 `oracle-copy` corpus confirms it: the engine reports nothing at all.
+
+`partially` reads as "some of it fires", and none of it does. Now
+`now_detectable: false`, `detection_strength: "none"`, `detectable_since: null`,
+`fixed_by: null`, `tracked_by: agent-ix/quire-rs#236` — a capability nothing can
+reach has no date it became available and no PR that delivered it.
+
+That AK-005 was pass 2's **highest-value finding** and the key credited it as
+partly mechanised is the sharpest version of this programme's premise.
+
+### FND-002 — right answer, stale reason
+
+AK-006 (`mocked-confirmation`) said `now_detectable: false`. Correct — and the
+recorded reason was "no mechanized detector yet", written before quoin#204
+shipped one, and never re-checked after.
+
+The detector exists at `src/auditor/audit.ts:241` and **still cannot fire**.
+`mockedBindings` opens with `if (injections.length === 0) return []`, and
+`AuditInput.injections` is optional, supplied by none of the three production
+`audit()` callers, and produced by nothing in the tree. The 8 unit tests build
+`injections` inline, which is how a green suite sat over a dead path.
+
+The plan for this re-adjudication predicted the opposite — that AK-006
+_under-counted_ a capability that existed. Checking rather than assuming is what
+turned that around. quoin#204 reopened.
+
+### FND-003 — a family with no owner
+
+AK-007 (`gate-that-gates-nothing`) carried `tracked_by: agent-ix/quoin#204` from
+the day it was written. #204 is the mocked-confirmation ticket. Two findings
+sharing one ticket means closing it closes both, and only one was ever worked —
+so this family had no owner and nothing said so.
+
+`agent-ix/quoin#224` filed. TC-963 now requires every undetectable finding to
+name a distinct ticket.
+
+### FND-004 — a boolean over a three-valued fact
+
+`now_detectable: true` was flattening two genuinely different states:
+
+- **AK-001** — `no-symbol-bound` carries a `path`. A reader gets a file.
+- **AK-003** — `coverage.specific_shaped` is a ratio over the whole corpus. A
+  reader gets a number that moved, and 274 spec files to search.
+
+Counting those as one overstates the toolchain. `detection_strength` is now
+`located | aggregate | none`, declared with its scale in the file, and the
+re-adjudicated distribution is **2 located, 2 aggregate, 3 none** — against the
+old reading of "4 detectable, 1 partial, 2 not".
+
+It is the same conflation `finding_localisation_rate` exists to expose, and the
+two now agree: 40% on the first scored tier-1 run, 2 of 5.
+
+## The pin is unchanged
+
+`pinned_sha` stays at `fc5d644`. Re-pinning requires re-adjudicating against a
+re-read tree, and this pass re-adjudicated the **detectors**, not the corpus.
+The findings are still claims about that specific tree; the corrections are about
+whether the toolchain can see them.
+
+Note that `filament-ide-rs` main has since moved to `6f87a7e` (PR #505), which
+carries fixes for several of these findings. That does not touch the key: the
+pinned tree is immutable, and `make battletest` refuses to score a corpus sitting
+off its pin.
+
+## Coverage
+
+Re-adjudication method, per entry: locate the detector in source, locate its
+caller, and confirm the behaviour against the tier-1 corpus that seeds the
+family. Three entries changed state; four were confirmed unchanged with their
+strength recorded for the first time.
+
+| id     | family                    | was            | is                   | checked by                                              |
+| ------ | ------------------------- | -------------- | -------------------- | ------------------------------------------------------- |
+| AK-001 | `marker-form-mismatch`    | detectable     | **located**          | tier-1 `marker-mismatch`, precision 1.00                |
+| AK-002 | `hollow-denominator`      | detectable     | **aggregate**        | tier-1 `hollow-metric`; diagnostic carries `path: null` |
+| AK-003 | `catch-all-universal`     | detectable     | **aggregate**        | metric-only by construction                             |
+| AK-004 | `vacuous-under-guard`     | detectable     | **located**          | tier-1 corpus, `src/lib.rs:7`                           |
+| AK-005 | `oracle-is-code-copy`     | partially      | **none**             | no production caller for `oracle_copies`                |
+| AK-006 | `mocked-confirmation`     | not detectable | **none**, new reason | `injections` never supplied                             |
+| AK-007 | `gate-that-gates-nothing` | not detectable | **none**, new ticket | no detector exists                                      |
+
+TC-961, TC-962 and TC-963 pin all three corrections, and each fails if the prior
+state is restored: a strength disagreeing with `now_detectable`, a `false` entry
+carrying a date or a fix, and two findings sharing a ticket.

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -403,6 +403,9 @@ generated tests under `tests/props/` and `Unit` for the rest.
 | TC-960 | A family the baseline scored and a run does not report AT ALL is a regression with the baseline kept — deleting a corpus must not read as a clean run (#199) | Unit | P0 | FR-043-AC-10 | ✅ |
 | TC-936 | An obligation discharged only by a mocked stand-in for its own subject is a `medium` `mocked-confirmation` finding naming the injected identifier (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-937 | A mock unrelated to the statement's subject (`FakeClock`) is not reported — tests legitimately mock clocks, filesystems and networks (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
+| TC-961 | Every answer-key finding records HOW STRONGLY it is detected — located, aggregate or none — and the strength agrees with `now_detectable`, so "a number moved" is not counted as "here is the file" (#200) | Unit | P0 | FR-043-AC-8 | ✅ |
+| TC-962 | A finding recorded as not detectable claims no `detectable_since` and no `fixed_by`: a capability nothing can reach has no date it arrived and no PR that delivered it (#200) | Unit | P0 | FR-043-AC-8 | ✅ |
+| TC-963 | Each undetectable finding names its OWN tracking ticket, so closing one family's work cannot silently close another's (#200) | Unit | P0 | FR-043-AC-8 | ✅ |
 | TC-938 | One real suite alongside a mocked one is not reported: standing in a dependency while another suite exercises the real path is ordinary test design (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-939 | Absent injection data yields silence, never a clean bill — "nobody looked" is not "nothing was mocked" (#204) | Unit | P0 | FR-032-AC-15 | ✅ |
 | TC-940 | The finding ratchets through the existing `<kind>:<obligation>` key, so it is acceptable in a baseline like every other kind (#204) | Unit | P1 | FR-032-AC-15 | ✅ |

--- a/tests/bench-corpora.test.ts
+++ b/tests/bench-corpora.test.ts
@@ -250,6 +250,61 @@ describe("tier-2 adjudicated answer key", () => {
     }
   });
 
+  test("TC-961 every finding records how strongly it is detected, not just whether", () => {
+    // TC-961
+    // `now_detectable: true` was flattening two different states: AK-003 is "a
+    // number moved somewhere in 274 spec files" and AK-001 is "here is the
+    // file". Counting them as one overstates the toolchain, and it is the same
+    // conflation `finding_localisation_rate` exists to expose — measured at 40%
+    // on the first scored tier-1 run.
+    const scale = Object.keys(key.detection_strength_scale).filter(
+      (k: string) => !k.startsWith("$"),
+    );
+    expect(scale.sort()).toEqual(["aggregate", "located", "none"]);
+    for (const f of key.findings) {
+      expect(scale, `${f.id} declares no detection_strength`).toContain(
+        f.detection_strength,
+      );
+      // The two must agree. A finding nothing reports cannot be `located`, and
+      // a finding something reports cannot be `none` — a disagreement here is
+      // exactly how the recall denominator becomes fiction.
+      if (f.now_detectable === false) {
+        expect(f.detection_strength, `${f.id}`).toBe("none");
+      } else {
+        expect(f.detection_strength, `${f.id}`).not.toBe("none");
+      }
+      // Why this strength, checked against the code rather than carried over.
+      expect(f.$strength_note, `${f.id} states no reason`).toBeTruthy();
+    }
+  });
+
+  test("TC-962 an undetectable finding claims no date and no fix", () => {
+    // TC-962
+    // AK-005 carried `now_detectable: "partially"` with both a
+    // `detectable_since` and a `fixed_by`, for a detector with no production
+    // caller. Every one of those errors flattered the toolchain, which is the
+    // direction that matters: a capability nothing can reach has no date it
+    // became available and no PR that delivered it.
+    for (const f of key.findings) {
+      if (f.now_detectable !== false) continue;
+      expect(f.detectable_since, `${f.id}`).toBeNull();
+      expect(f.fixed_by ?? null, `${f.id}`).toBeNull();
+      expect(f.tracked_by, `${f.id}`).toMatch(/#\d+$/);
+    }
+  });
+
+  test("TC-963 every untracked family has its OWN ticket", () => {
+    // TC-963
+    // AK-007 (`gate-that-gates-nothing`) pointed at quoin#204 — the
+    // mocked-confirmation ticket — from the day it was written, so the family
+    // had no owner and nobody could tell. Two findings sharing a ticket means
+    // closing it closes both, and only one of them was ever worked.
+    const tickets = key.findings
+      .filter((f: { now_detectable: unknown }) => f.now_detectable === false)
+      .map((f: { tracked_by: string }) => f.tracked_by);
+    expect(new Set(tickets).size).toBe(tickets.length);
+  });
+
   test("finding ids are unique", () => {
     const ids = key.findings.map((f: { id: string }) => f.id);
     expect(new Set(ids).size).toBe(ids.length);


### PR DESCRIPTION
Refs #200. Part of the #197 EPIC, workstream 2.

All seven entries of `bench/answer-key.json` re-checked by locating each detector **and its caller**, not by re-reading the notes. Two `now_detectable` claims were wrong, both in the direction that flatters the toolchain; one family had never had a ticket of its own; and every entry carried a boolean where the honest answer needs three values.

This file is the **recall denominator** for "would the tools have found what humans found". Every error corrected here made that denominator read better than the truth.

## AK-005 — three fields wrong, all the same way

Carried `now_detectable: "partially"`, a `detectable_since`, and `fixed_by: quire-rs#247`.

`grep -rn oracle_copies src/` in quire-rs returns the definition and two unit tests. **There is no production caller.** The tier-1 `oracle-copy` corpus confirms it — the engine reports nothing. `partially` reads as "some of it fires", and none of it does.

Now `false` / `none`, with `detectable_since` and `fixed_by` **nulled**: a capability nothing can reach has no date it arrived and no PR that delivered it.

That this was pass 2's *highest-value* finding, and the key credited it as partly mechanised, is the sharpest version of the premise this programme runs on.

## AK-006 — right answer, stale reason

`now_detectable: false` was correct, and its recorded reason ("no mechanized detector yet") predated quoin#204 shipping one. The detector exists at `src/auditor/audit.ts:241` and **still cannot fire** — `mockedBindings` returns `[]` on every production call because `AuditInput.injections` is optional, no caller supplies it, and nothing produces a `MockInjection`.

The plan for this pass predicted the opposite: that AK-006 *under-counted* a capability that existed. Checking rather than assuming is what turned it around.

## AK-007 — a family with no owner

Pointed at quoin#204 — the mocked-confirmation ticket — from the day it was written. Two findings sharing a ticket means closing it closes both, and only one was ever worked. **quoin#224** filed.

## `detection_strength`: located | aggregate | none

`now_detectable: true` was flattening two genuinely different states:

- **AK-001** — `no-symbol-bound` carries a `path`. A reader gets a file.
- **AK-003** — `coverage.specific_shaped` is a ratio over the whole corpus. A reader gets a number that moved, and 274 spec files to search.

Re-adjudicated distribution: **2 located, 2 aggregate, 3 none**, against the old reading of "4 detectable, 1 partial, 2 not". It is the same conflation `finding_localisation_rate` exists to expose, and the two now agree — 40%, 2 of 5, on the first scored tier-1 run.

## The pin is unchanged

`pinned_sha` stays at `fc5d644`. This pass re-adjudicated the **detectors**, not the corpus; the findings are still claims about that specific tree. `filament-ide-rs` main has since moved to `6f87a7e` (#505), which does not touch the key — the pinned tree is immutable and `make battletest` refuses to score a corpus off its pin.

## Gates

TC-961..TC-963 pin all three corrections and each fails if the prior state is restored: a strength disagreeing with `now_detectable`, a `false` entry carrying a date or a fix, and two findings sharing a ticket. `make lint` and `make test` (53 files) green; all three backed per `quire coverage`.

Review: **SR-020** (CONDITIONAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDbNXrE3G1UxPeCn7WfqrC