### PR TITLE
Score catch-all-universal from its located diagnostic: 60% → 80% (#199)

### DIFF
--- a/bench/metrics.json
+++ b/bench/metrics.json
@@ -68,8 +68,8 @@
       "population": "true positives from a scored tier-1 run",
       "method": "positional pairings over true positives, from evals/lib/quality.mjs scoreFindings. A finding pairs positionally only when it and its label BOTH name a place and the places agree, so this is the share of confirmed findings that said where. It is the metric that encodes the actual requirement \u2014 an alert nobody can locate is an alert nobody acts on \u2014 and it is deliberately not per-family: the question is about the toolchain's output, not about one detector",
       "direction": "higher-is-better",
-      "baseline": 0.4,
-      "baseline_note": "First scored tier-1 run (2026-08-23): 2 of 5 true positives named where. The three that did not are `hollow-denominator` (the diagnostic carries no path \u2014 it names a metric), `catch-all-universal` (an aggregate metric, not a located finding) and `marker-form-mismatch` (`no-symbol-bound` names the LANGUAGE, `rust`, not the marker's line). All three are quoin#197 workstream 4."
+      "baseline": 0.8,
+      "baseline_note": "0.40 on the first scored tier-1 run (2026-08-23): 2 of 5 true positives named where. 0.60 after quire-rs#256 gave `no-symbol-bound` an unbound symbol to name instead of a language. 0.80 after quire-rs#261 made `catch-all-universal` a located diagnostic instead of a moving aggregate. The one remaining miss is `hollow-denominator`, whose diagnostic names a METRIC and carries no path \u2014 arguably correct, since a hollow ratio is a fact about a corpus rather than about a file, and the label records that."
     }
   }
 }

--- a/bench/tier1-baseline.json
+++ b/bench/tier1-baseline.json
@@ -76,8 +76,8 @@
       "reason": "hollow-denominator"
     }
   ],
-  "positional": 2,
-  "finding_localisation_rate": 0.4,
+  "positional": 4,
+  "finding_localisation_rate": 0.8,
   "actionability": {
     "actionable": 2,
     "total": 7,

--- a/bench/tier1-mapping.json
+++ b/bench/tier1-mapping.json
@@ -1,9 +1,9 @@
 {
-  "$comment": "The tier-1 payload→family mapping (agent-ix/quoin#199, FR-043-AC-2). NORMATIVE and REVIEWABLE: this table is the contract between what a tool emits and what the benchmark calls a finding, and it belongs in the repository rather than in a script's head. A family the scorer reads out of a payload section this file does not name is a family nobody agreed on, and `scripts/bench-tier1.mjs` refuses a payload signal it cannot map rather than dropping it — an unmapped signal is a scoring hole, and a silent one reads exactly like a tool that found nothing.",
+  "$comment": "The tier-1 payload\u2192family mapping (agent-ix/quoin#199, FR-043-AC-2). NORMATIVE and REVIEWABLE: this table is the contract between what a tool emits and what the benchmark calls a finding, and it belongs in the repository rather than in a script's head. A family the scorer reads out of a payload section this file does not name is a family nobody agreed on, and `scripts/bench-tier1.mjs` refuses a payload signal it cannot map rather than dropping it \u2014 an unmapped signal is a scoring hole, and a silent one reads exactly like a tool that found nothing.",
   "sources": {
     "coverage.diagnostics": "quire coverage --json, `diagnostics[]`. Keyed on `reason`. Carries `path` sometimes and never a line.",
     "coverage.suspicions": "quire coverage --json, `suspicions[]`. Keyed on `kind`. Carries `path` and `line`.",
-    "coverage.metrics": "quire coverage --json, `metrics[]`. Keyed on `name`, matched against the label's `expect_value`. Carries no locus at all — a metric is a number about a corpus, not a place.",
+    "coverage.metrics": "quire coverage --json, `metrics[]`. Keyed on `name`, matched against the label's `expect_value`. Carries no locus at all \u2014 a metric is a number about a corpus, not a place.",
     "validate.findings": "quire validate --diagnostics-format json, one NDJSON object per finding. Keyed on the bracketed reason at the end of `message`. See `parse_fragility` below.",
     "audit.findings": "quoin evidence audit --json, `findings[]`. Keyed on `kind`. Carries an obligation id and NO locus."
   },
@@ -29,9 +29,10 @@
       "locus": "path-line"
     },
     "catch-all-universal": {
-      "source": "coverage.metrics",
-      "key": "coverage.specific_shaped",
-      "locus": "none"
+      "source": "coverage.diagnostics",
+      "key": "catch-all-universal",
+      "locus": "path",
+      "$note": "Was `coverage.metrics` / `coverage.specific_shaped`, which pairs on family alone and contributes nothing to `finding_localisation_rate` \u2014 a number that moved with nowhere to put a cursor. quire-rs#261 makes it a located diagnostic naming a criterion at `path:line`, so it now scores positionally like every other family whose finding says where."
     },
     "vacuous-under-guard": {
       "source": "coverage.suspicions",
@@ -42,13 +43,13 @@
       "source": "coverage.suspicions",
       "key": "oracle-resembles-implementation",
       "locus": "path-line",
-      "$note": "The comparison ships in quire-rs `src/skeptic.rs` and has NO production caller — `oracle_copies` is reached only by its own unit tests. Mapped anyway: the contract is what a detector must emit, and declaring it before the detector exists is what lets the detector be built against something. Recall reads 0 until agent-ix/quire-rs#236."
+      "$note": "The comparison ships in quire-rs `src/skeptic.rs` and has NO production caller \u2014 `oracle_copies` is reached only by its own unit tests. Mapped anyway: the contract is what a detector must emit, and declaring it before the detector exists is what lets the detector be built against something. Recall reads 0 until agent-ix/quire-rs#236."
     },
     "mocked-confirmation": {
       "source": "audit.findings",
       "key": "mocked-confirmation",
       "locus": "none",
-      "$note": "quoin's own auditor, not quire — `quire coverage` and `quire properties` cannot see this family, which is why the runner calls a third command. The detector additionally cannot fire: `AuditInput.injections` is never supplied by any caller (agent-ix/quoin#204, reopened)."
+      "$note": "quoin's own auditor, not quire \u2014 `quire coverage` and `quire properties` cannot see this family, which is why the runner calls a third command. The detector additionally cannot fire: `AuditInput.injections` is never supplied by any caller (agent-ix/quoin#204, reopened)."
     },
     "gate-that-gates-nothing": {
       "source": "none",


### PR DESCRIPTION
Refs #199. Consumes agent-ix/quire-rs#261.

`catch-all-universal` was scored from `coverage.specific_shaped`. A metric pairs on family alone and contributes nothing to `finding_localisation_rate` — a number that moved, with nowhere to put a cursor. quire-rs#261 makes it a located diagnostic naming a criterion at `path:line`, so the mapping moves to `coverage.diagnostics`.

## `finding_localisation_rate` across the programme

| | |
| --- | --- |
| **0.40** | first scored run — 2 of 5 true positives named where |
| **0.60** | quire-rs#256 — `no-symbol-bound` names an unbound symbol, not a language |
| **0.80** | quire-rs#261 — `catch-all-universal` names a criterion, not a ratio |

The one remaining miss is `hollow-denominator`, whose diagnostic names a **metric** and carries no path. That is arguably correct — a hollow ratio is a fact about a corpus rather than about a file — and the label records exactly that, so 80% is a ceiling this corpus can defend rather than a gap left open.

Every family that fires is at precision 1.00 and recall 1.00. The three at recall 0 are the three with no working detector, each naming its own ticket: quoin#224, quoin#204, quire-rs#236.

Baselines updated. `make bench-tier1`, `make lint` and `make test` (53 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDbNXrE3G1UxPeCn7WfqrC