### PR TITLE
fix(bench): an advisory family reports no precision (#234)

### DIFF
--- a/bench/tier1-baseline.json
+++ b/bench/tier1-baseline.json
@@ -5,7 +5,8 @@
       "truePositives": 2,
       "falsePositives": 10,
       "misses": 0,
-      "precision": 0.167,
+      "precision": null,
+      "shape": "advisory",
       "recall": 1
     },
     {
@@ -14,14 +15,16 @@
       "falsePositives": 0,
       "misses": 1,
       "precision": null,
+      "shape": "defect",
       "recall": 0
     },
     {
       "family": "hollow-denominator",
       "truePositives": 1,
-      "falsePositives": 1,
+      "falsePositives": 0,
       "misses": 0,
-      "precision": 0.5,
+      "precision": 1,
+      "shape": "defect",
       "recall": 1
     },
     {
@@ -30,6 +33,7 @@
       "falsePositives": 0,
       "misses": 0,
       "precision": 1,
+      "shape": "defect",
       "recall": 1
     },
     {
@@ -38,6 +42,7 @@
       "falsePositives": 0,
       "misses": 1,
       "precision": null,
+      "shape": "defect",
       "recall": 0
     },
     {
@@ -46,6 +51,7 @@
       "falsePositives": 0,
       "misses": 1,
       "precision": null,
+      "shape": "defect",
       "recall": 0
     },
     {
@@ -54,6 +60,7 @@
       "falsePositives": 0,
       "misses": 0,
       "precision": 1,
+      "shape": "defect",
       "recall": 1
     },
     {
@@ -62,6 +69,7 @@
       "falsePositives": 0,
       "misses": 0,
       "precision": 1,
+      "shape": "defect",
       "recall": 1
     }
   ],
@@ -70,6 +78,10 @@
     {
       "family": "marker-form-mismatch",
       "reason": "no-symbol-bound"
+    },
+    {
+      "family": "hollow-denominator",
+      "reason": "hollow-denominator"
     },
     {
       "family": "hollow-denominator",

--- a/bench/tier1-mapping.json
+++ b/bench/tier1-mapping.json
@@ -34,7 +34,9 @@
       "source": "coverage.diagnostics",
       "key": "catch-all-universal",
       "locus": "path",
-      "$note": "Was `coverage.metrics` / `coverage.specific_shaped`, which pairs on family alone and contributes nothing to `finding_localisation_rate` \u2014 a number that moved with nowhere to put a cursor. quire-rs#261 makes it a located diagnostic naming a criterion at `path:line`, so it now scores positionally like every other family whose finding says where."
+      "$note": "Was `coverage.metrics` / `coverage.specific_shaped`, which pairs on family alone and contributes nothing to `finding_localisation_rate` \u2014 a number that moved with nowhere to put a cursor. quire-rs#261 makes it a located diagnostic naming a criterion at `path:line`, so it now scores positionally like every other family whose finding says where.",
+      "shape": "advisory",
+      "shape_note": "A CORPUS-LEVEL advisory, not a defect-shaped finding: one per corpus, fired whenever a document's criteria are all the catch-all. Precision is not a meaningful quantity over a population where the finding is expected almost everywhere \u2014 measured, it fired on 10 of 21 cases and EVERY ONE was correct (`by_property: {universal: 1}` on each), yet scored 0.167. That number read as 'wrong five times in six' while being wrong zero times in twelve. Scored on recall and localisation only (agent-ix/quoin#234)."
     },
     "vacuous-under-guard": {
       "source": "coverage.suspicions",

--- a/evals/lib/quality.mjs
+++ b/evals/lib/quality.mjs
@@ -22,7 +22,7 @@
  * whole reason for existing: a scored miss must be distinguishable from a
  * defect nobody claimed was findable.
  */
-export function scoreFindings(found, labels) {
+export function scoreFindings(found, labels, shapes = {}) {
   const families = new Map();
   const bucket = (family) => {
     if (!families.has(family)) {
@@ -143,7 +143,23 @@ export function scoreFindings(found, labels) {
   const rows = [...families.values()]
     .map((f) => ({
       ...f,
-      precision: ratio(f.truePositives, f.truePositives + f.falsePositives),
+      // An ADVISORY family reports no precision. It is a corpus-level
+      // observation — one finding per corpus whenever a shape holds — so it
+      // fires on nearly every fixture, correctly, and the defect-shaped FP
+      // definition ("a finding on a case that does not seed this family")
+      // counts each correct firing against it.
+      //
+      // Measured before this: `catch-all-universal` fired on 10 of 21 cases,
+      // every one verified correct, and scored precision 0.167 — a number that
+      // read as "wrong five times in six" while being wrong zero times in
+      // twelve. `null`, never 0, for the same reason a 0/0 ratio is null
+      // elsewhere here: not-measured and zero are different claims
+      // (agent-ix/quoin#234).
+      precision:
+        shapes[f.family] === "advisory"
+          ? null
+          : ratio(f.truePositives, f.truePositives + f.falsePositives),
+      shape: shapes[f.family] ?? "defect",
       recall: ratio(f.truePositives, f.truePositives + f.misses),
     }))
     .sort((a, b) => a.family.localeCompare(b.family));

--- a/scripts/bench-tier1.mjs
+++ b/scripts/bench-tier1.mjs
@@ -298,6 +298,39 @@ function defectsFrom(meta, expect, mapping) {
         findable: meta.findable !== false,
         expect_reason: reason,
         confirmed_at: "derived from the case's own expect.yaml",
+        // The REMAINING expected reasons are collateral, not second seeded
+        // defects. Making one fire makes the others fire by construction — an
+        // unreadable marker makes `coverage.backed` a ratio over an unread
+        // population, so `no-symbol-bound` and `hollow-denominator` are one
+        // situation seen through two lenses. Dropping them (the first fix for
+        // the one-family-per-case violation) left each correct collateral
+        // firing counted as a false positive.
+        collateral: (expect.diagnostic_reasons ?? [])
+          .filter((r) => r !== reason)
+          .map((r) => {
+            const e = Object.entries(mapping?.families ?? {}).find(
+              ([, m]) => m.key === r,
+            );
+            return e
+              ? {
+                  family: e[0],
+                  reason: r,
+                  // Required by TC-950: collateral suppresses a finding from
+                  // the precision denominator, so a declaration with no stated
+                  // reason is a licence to launder false positives. This one is
+                  // DERIVED rather than adjudicated, and says so — the case
+                  // states both reasons in its own `expect.yaml`, so both are
+                  // expected consequences of the one situation it seeds, but
+                  // nobody has written down why they co-occur.
+                  note:
+                    `derived: the case's own expect.yaml expects both ` +
+                    `\`${reason}\` and \`${r}\`, so this is a consequence of ` +
+                    `the one defect it seeds, not a second seeded defect. Not ` +
+                    `separately adjudicated.`,
+                }
+              : null;
+          })
+          .filter(Boolean),
         note:
           "Derived, not adjudicated: the corpus states in `expect.yaml` what " +
           "should be found, and an unlabelled failure case is NOT healthy " +
@@ -495,7 +528,16 @@ function main() {
     (f) => f.metric === undefined || expectedValues.get(f.metric) === f.value,
   );
 
-  const score = scoreFindings(scoredFindings, flat);
+  // The shape a family is scored under is declared in the mapping, beside the
+  // key it reads — not inferred here, so a reader of the table can see why a
+  // family reports no precision without tracing the scorer.
+  const shapes = Object.fromEntries(
+    Object.entries(mapping.families).map(([family, m]) => [
+      family,
+      m.shape ?? "defect",
+    ]),
+  );
+  const score = scoreFindings(scoredFindings, flat, shapes);
   report = {
     families: score.families,
     excluded: score.excluded,

--- a/tests/eval-quality.test.ts
+++ b/tests/eval-quality.test.ts
@@ -126,6 +126,12 @@ describe("finding precision and recall", () => {
         misses: 0,
         precision: 1,
         recall: 1,
+        // Every row now carries the shape it was scored under, defaulting to
+        // `defect`. An ADVISORY family reports no precision — it fires on
+        // nearly every corpus by construction, so the defect-shaped false
+        // positive definition counts each correct firing against it
+        // (agent-ix/quoin#234).
+        shape: "defect",
       },
     ]);
     // Reported by name, never silently dropped: an unscored finding nobody


### PR DESCRIPTION
Closes #234, implementing its option 2.

## Why `catch-all-universal` reported a meaningless number

It is a **corpus-level advisory** — one finding per corpus, fired whenever a document's criteria are all the catch-all. Precision is not a meaningful quantity over a population where the finding is expected almost everywhere.

Measured: it fired on **10 of 21 cases and every one was correct** (`by_property: {universal: 1}`, verified on each), yet scored **0.167**. That read as *"wrong five times in six"* while being wrong **zero times in twelve** — and it was a `higher-is-better` ratchet floor, so a real regression to 0.05 would have failed the build over a quantity that measured nothing.

The mapping declares `shape: advisory` beside the key it reads, so a reader sees why a family reports no precision without tracing the scorer. Advisory families score **recall and localisation**; precision is `null`, never 0 — not-measured and zero are different claims, the same rule this file already applies to a 0/0 ratio. **The FP count stays visible**: it is data, just not folded into a number that misnames it.

**I did not take the other option.** Adding `catch-all-universal` to ten `expect.yaml` files would have made the number 1.0 by editing the corpus to satisfy the scorer — tuning to the number, which is the thing this programme keeps catching me doing.

## And the last false positive was mine

Derived defects carried no `collateral`, so the second marker-family case's `hollow-denominator` firing counted against it. That is the other half of the bug I half-fixed last round: one-defect-per-case was right, but the **remaining** expected reasons are collateral — an unreadable marker makes `coverage.backed` a ratio over an unread population, so the two are one situation through two lenses.

Every derived collateral carries a note saying it is *derived, not adjudicated* — TC-950 requires it, because collateral suppresses a finding from the precision denominator and a declaration with no stated reason is a licence to launder false positives.

## Result

| family | precision | recall |
|---|---|---|
| `marker-form-mismatch` | **1.0** | 1.0 |
| `hollow-denominator` | **1.0** | 1.0 |
| `undeclared-type-value` | **1.0** | 1.0 |
| `vacuous-under-guard` | **1.0** | 1.0 |
| `catch-all-universal` | n/a — advisory | 1.0 |

**Zero false positives across every defect-shaped family.** 589 tests, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qy3tcZEDwAoQRw3gRgYu37