### PR TITLE
feat(skills): add assurance status reporting

### DIFF
--- a/skills/assurance-status-report/SKILL.md
+++ b/skills/assurance-status-report/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: assurance-status-report
+description: Produce an evidence-backed status report for a Quoin/Quire epic, phase, or assurance campaign. Use when asked for progress, percent complete, before/after metrics, completed-ticket inventory, open-work classification, or readiness for the next phase. The workflow is read-only and does not comment on, close, or modify tickets or repositories.
+---
+
+# Assurance Status Report
+
+Report what the retained evidence proves about a named goal. Use Quoin for
+measurement meaning and history, Quire for producer provenance, git for local
+state, and GitHub for current ticket and promotion state. Do not recreate their
+analysis in the skill.
+
+Read [references/report-contract.md](references/report-contract.md) before
+assembling the report.
+
+## Boundary
+
+This workflow is read-only. It may inspect repositories, retained evidence, and
+remote ticket state. It must not run measurement producers, update baselines,
+modify evidence, push branches, or create/comment/close/reopen issues or pull
+requests unless the user separately authorizes that mutation.
+
+A closed ticket is workflow state, not proof of completion. Match each claimed
+result to its acceptance evidence, promoted commit, and relevant current-state
+check.
+
+## Inputs
+
+Establish these before collecting evidence:
+
+- the goal, epic, phase, or campaign being reported;
+- repositories and tickets in scope;
+- work the user explicitly excluded;
+- the baseline and current endpoint; and
+- whether the user also wants an intermediate phase boundary.
+
+If no baseline is named, use the earliest retained collection explicitly linked
+by the target epic. Use the latest compatible retained collection as current.
+State that selection instead of silently choosing favorable snapshots.
+
+## Collect exact evidence
+
+### Repository state
+
+For every participating repository, record:
+
+```bash
+git rev-parse HEAD
+git status --porcelain
+git remote get-url origin
+```
+
+Resolve revisions to full 40-character SHAs. Use the canonical remote and a
+versioned, read-only GitHub query to confirm current default-branch and commit
+reachability, for example:
+
+```bash
+gh api --header 'X-GitHub-Api-Version: 2022-11-28' \
+  repos/OWNER/REPO/commits/FULL_SHA
+```
+
+Validate required response fields rather than assuming a successful command
+returned the requested object. Record dirty, unreachable, ambiguous, or
+wrong-origin state as a limitation; never normalize it to clean.
+
+### Tool and measurement state
+
+Use existing machine-readable interfaces:
+
+```bash
+quoin report --format json
+quoin report --series METRIC --format json
+quoin report --since FULL_BASELINE_REVISION --format json
+quire provenance --json
+```
+
+Use `quoin report` to discover active MeasurementPlans and retained values. Use
+the series or comparison view for historical values; do not scrape rendered
+human output when JSON exists. Confirm Quire's provenance schema, full CLI and
+engine revisions, clean state, and required capabilities before attributing a
+measurement to it.
+
+Record the exact collection id, timestamp, source revision, corpus revision,
+tool identity/version, configuration digest, definition version, and population
+identity supporting each reported value. If the repository has a verification
+stack attestation, report its lock and executable digests.
+
+Do not regenerate evidence merely to answer a status question. A new run changes
+the evidence state and requires separate authorization.
+
+### Ticket and promotion state
+
+Use versioned read-only GitHub REST or GraphQL queries. For each issue capture at
+least number, title, state, URL, and closed time. For each delivery pull request
+capture state, base/head branches, merge time, merge commit, and URL. Confirm the
+current default-branch SHA separately.
+
+Follow relationships from the target epic and its retained implementation
+comments. Do not equate “mentioned nearby” with “child.” Classify every remaining
+item as blocking, non-blocking, downstream, excluded, or unknown and state the
+evidence for that disposition.
+
+## Interpret without hiding drift
+
+Define every project-specific term before its first use in the metrics section.
+Derive definitions from the active MeasurementPlan or other versioned contract.
+At minimum define any use of finding, controlled case, differential pair,
+localization, L1/L2/L3, actionability, span grounding, safe refusal, Tier 1,
+Tier 2, ratchet, drift mutation, comparability, or fail closed.
+
+For every percentage, report its numerator and denominator. Express rate changes
+as percentage points. Compare baseline and current numerically only when their
+definition versions and population identities are compatible. If either moved,
+show both values and explain the change, but mark the delta incomparable.
+
+Keep historical metrics visible when a stronger successor exists. Explain why
+the successor is more decision-relevant; do not relabel old evidence under the
+new definition.
+
+If the user asks for percent complete, use authored task weights when present.
+Otherwise report the unweighted count of proven-complete in-scope tasks and say
+that this is the method. Present verification and promotion gates separately so
+a high task percentage cannot conceal an unverified result.
+
+## Report and stop
+
+Follow the ordering in the report contract: status, definitions, metrics,
+completed work, open work, drift controls, limitations, and progress judgment.
+Lead with whether the named goal is complete, progressing, at risk, blocked, or
+not started, but put the glossary before the first detailed metric use.
+
+Link to the exact retained collections, issues, pull requests, and promoted
+commits. Distinguish evidence observed now from historical evidence retained by
+the campaign. If required evidence is missing or incompatible, say
+`unknown` or `not_computed` and identify what would resolve it.

--- a/skills/assurance-status-report/references/report-contract.md
+++ b/skills/assurance-status-report/references/report-contract.md
@@ -1,0 +1,110 @@
+# Assurance status report contract
+
+Use this contract for a detailed report. Short status requests may compress
+sections, but they retain the same evidence and comparison rules.
+
+## Evidence states
+
+- **Proven:** Direct current or retained evidence satisfies the requirement.
+- **Contradicted:** Direct evidence shows the requirement is not satisfied.
+- **Incomplete:** Some required evidence exists, but the full requirement is not
+  demonstrated.
+- **Missing:** No authoritative evidence was found.
+- **Incomparable:** Values exist, but their definitions or populations do not
+  permit a numeric delta.
+
+Never turn incomplete, missing, or incomparable evidence into zero, green, or
+complete.
+
+## Required order
+
+### 1. Executive status
+
+Name the goal, current disposition, as-of time and timezone, current promoted
+revision, scope boundary, and progress method. Distinguish completion of the
+named phase from progress of the larger program.
+
+### 2. Definitions
+
+Define each project-specific term before the metrics table. Definitions cite the
+active versioned contract. Prefer plain language, then state the exact counting
+rule where it matters.
+
+Examples of distinctions that must remain visible:
+
+- localization identifies the correct place; it does not prove the explanation
+  or remedy is correct;
+- actionability-field presence does not prove guidance correctness;
+- safe refusal preserves uncertainty and does not count as an exact span;
+- a controlled-corpus result does not estimate ecosystem-wide precision; and
+- a closed ticket does not by itself prove its acceptance criteria.
+
+### 3. Metric progression
+
+Use a table with these conceptual columns:
+
+| Metric | Baseline | Intermediate | Current | Delta | Comparability | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+
+Every ratio displays `matched/examined` beside the percentage. Each row retains
+the metric definition version and population identity, either inline or in its
+evidence link. Use `—` for a deliberately absent intermediate snapshot and
+`not_computed: REASON` for an unavailable value.
+
+Do not calculate a delta when:
+
+- the definition version changed;
+- the applicable population was redefined;
+- the source or corpus identity cannot be proved;
+- either value is not computed; or
+- a producer or required capability changed without an accepted comparison.
+
+When the population merely grows under the same contract, report both the count
+change and the rate change. A rate decline with a larger numerator can be scope
+growth rather than a product regression; explain which occurred.
+
+### 4. Completed work
+
+Enumerate every in-scope ticket/task with title, repository, final state, delivery
+PR or commit, and the evidence that proves acceptance. Group by workstream when
+the list is long. Separately enumerate promotion PRs and exact merge commits.
+
+### 5. Open work
+
+Enumerate unresolved items and assign exactly one disposition:
+
+- **blocking:** prevents the named goal;
+- **non-blocking:** retained limitation that does not prevent this goal;
+- **downstream:** belongs to a later goal or phase;
+- **excluded:** explicitly outside the user's scope; or
+- **unknown:** relationship or impact is not proven.
+
+Do not omit open work merely because the named phase is complete.
+
+### 6. Drift controls
+
+Report the guard and its proof for each relevant drift class: repository,
+submodule, tool/engine, executable bytes, package resolution, toolchain, workflow
+action, container, schema, configuration, corpus, metric definition, evidence
+overlay, and promotion topology. Distinguish a guard observed in code from a
+mutation test proving it fails before governed execution.
+
+### 7. Limitations and judgment
+
+State remaining evidence limitations, then answer whether the effort is moving
+toward the goal and why. Use one of:
+
+- **complete** — every requirement is proven and no in-scope work remains;
+- **on track** — incomplete, with no current blocking contradiction;
+- **at risk** — progress exists, but a named unresolved risk threatens the goal;
+- **blocked** — a named blocker prevents meaningful progress; or
+- **not started** — no implementation evidence exists.
+
+Close with the next decision or evidence-gathering point. Do not suggest starting
+explicitly excluded work.
+
+## Read-only rule
+
+Producing the report does not authorize ticket comments, issue state changes,
+branch updates, evidence regeneration, baseline updates, or new external
+messages. Ask separately before any such mutation.

--- a/tests/assurance-status-report-skill.test.ts
+++ b/tests/assurance-status-report-skill.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(__dirname, "..");
+const skill = readFileSync(
+  join(root, "skills/assurance-status-report/SKILL.md"),
+  "utf8",
+);
+const contract = readFileSync(
+  join(root, "skills/assurance-status-report/references/report-contract.md"),
+  "utf8",
+);
+
+describe("assurance status report skill", () => {
+  it("delegates measurement and provenance semantics to Quoin and Quire", () => {
+    expect(skill).toContain("quoin report --format json");
+    expect(skill).toContain("quoin report --series METRIC --format json");
+    expect(skill).toContain("quire provenance --json");
+    expect(skill).toMatch(/Do not recreate their\s+analysis in the skill/);
+  });
+
+  it("pins remote queries and requires exact source identity", () => {
+    expect(skill).toContain("X-GitHub-Api-Version: 2022-11-28");
+    expect(skill).toContain("full 40-character SHAs");
+    expect(skill).toContain("lock and executable digests");
+    expect(skill).toMatch(/dirty, unreachable, ambiguous, or\nwrong-origin/);
+  });
+
+  it("requires definitions before metrics and honest comparisons", () => {
+    expect(skill.indexOf("Define every project-specific term")).toBeLessThan(
+      skill.indexOf("For every percentage"),
+    );
+    expect(skill).toContain("numerator and denominator");
+    expect(skill).toContain("definition versions and population identities");
+    expect(contract).toContain("Incomparable");
+    expect(contract).toContain("Do not calculate a delta when:");
+  });
+
+  it("enumerates completed and open work without equating closure to proof", () => {
+    expect(skill).toContain("A closed ticket is workflow state, not proof");
+    for (const disposition of [
+      "blocking",
+      "non-blocking",
+      "downstream",
+      "excluded",
+      "unknown",
+    ]) {
+      expect(contract).toContain(`**${disposition}:**`);
+    }
+    expect(contract).toContain("Separately enumerate promotion PRs");
+  });
+
+  it("is read-only and fails visibly on unavailable evidence", () => {
+    expect(skill).toContain("This workflow is read-only");
+    expect(skill).toContain("must not run measurement producers");
+    expect(skill).toContain("must not");
+    expect(skill).toContain("create/comment/close/reopen issues");
+    expect(skill).toContain("`unknown` or `not_computed`");
+    expect(contract).toContain(
+      "Never turn incomplete, missing, or incomparable evidence into zero",
+    );
+  });
+});


### PR DESCRIPTION
Closes #294

Adds a thin, read-only assurance status-report skill that orchestrates existing Quoin, Quire, git, and GitHub interfaces. It defines report terminology before metric use, preserves numerator/denominator and comparison identity, enumerates completed and open work, and requires explicit tool/repository/schema/configuration drift reporting.

Architecture boundary:
- no production TypeScript source changes
- no runtime or lockfile changes
- no new command or report engine
- skill and reference contract are included by the existing package skills surface

Validation:
- skill validator: pass
- focused skill contracts: 10/10 pass
- full Quoin suite against locked Quire CLI bcface2714a958a328f3427714650ab2df71030f and engine ca7362d4dacecb96f01d74d1d971327118c25917: 731/731 pass
- lint, typecheck, and format: pass
- tool drift mutations: 33/33 rejected
- verification stack invariants: 23/23 pass
- npm package dry run includes both skill files

Target is the Phase 3 tracking branch, not main.