### PR TITLE
Fix invalid spec-fuzz YAML frontmatter

### DIFF
--- a/reviews/2026-08-29-pr310-code-review.md
+++ b/reviews/2026-08-29-pr310-code-review.md
@@ -1,0 +1,50 @@
+---
+id: SR-036
+title: "Code review — PR #310 invalid spec-fuzz YAML frontmatter"
+type: SpecReview
+analysis: code-review
+scope: "skills/spec-fuzz/SKILL.md, tests/skill-contracts.test.ts"
+review_set: subset
+---
+
+# Code review — PR #310 invalid spec-fuzz YAML frontmatter
+
+## Summary
+
+Reviewed the complete `origin/main...task/309-fix-spec-fuzz-frontmatter` diff for
+Quoin #309. The skill correction uses an explicit YAML folded scalar, and the
+contract test exercises the repository's real YAML parser across every shipped
+skill while enforcing the required mapping, name, and description fields. No
+mock-boundary, implementation-completeness, security, or code-test-alignment gap
+was found.
+
+## Verdict
+
+**PASS** — the implementation and regression test satisfy the code-review gate
+with no findings.
+
+## Findings
+
+| ID      | Severity | Summary       | Refs |
+| ------- | -------- | ------------- | ---- |
+| FND-001 | low      | No gaps found | -    |
+
+## Method
+
+- Reviewed both changed files and the full branch diff for hidden scope,
+  placeholder logic, suppressed warnings, weakened thresholds, unsafe inputs,
+  and unrelated changes.
+- Confirmed the regression test uses `yaml.parse` directly rather than mocking
+  the consumer boundary, and that malformed YAML fails before field assertions.
+- Reproduced red before the fix and green after it for the YAML-frontmatter
+  contract; `make format` and `make lint` pass.
+- Cross-checked Quoin #309's acceptance criteria against the changed lines. The
+  deterministic all-skills parser gate is the issue's permitted equivalent to a
+  live Codex smoke assertion; publishing remains a post-merge release action.
+
+## Gap-analysis disposition
+
+Formal `gap-analysis` was not run because #309 is a fast-track bug with no plan
+bundle or Test Matrix; the workflow forbids inventing or selecting an unrelated
+plan. The issue acceptance criteria were reconciled directly against the diff
+and test instead. Semantic review was skipped because it was not requested.

--- a/skills/spec-fuzz/SKILL.md
+++ b/skills/spec-fuzz/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: spec-fuzz
-description: Turn Fuzz-kind obligations into runnable fuzz targets. Consumes `quoin advise
-  --json`, selects the obligations whose verification method carries `evidence_kind: Fuzz`,
-  grounds each one's entry-point symbol in the repository's source, and emits targets in the
-  repo's own harness (cargo-fuzz / atheris / fast-check) keyed on the obligation id. Writes
-  nothing where the tooling is absent or the entry point cannot be grounded — a finding
-  instead. Emits a validated SpecReview recording every obligation it could not serve.
+description: >-
+  Turn Fuzz-kind obligations into runnable fuzz targets. Consumes `quoin advise --json`,
+  selects the obligations whose verification method carries `evidence_kind: Fuzz`, grounds
+  each one's entry-point symbol in the repository's source, and emits targets in the repo's
+  own harness (cargo-fuzz / atheris / fast-check) keyed on the obligation id. Writes nothing
+  where the tooling is absent or the entry point cannot be grounded — a finding instead.
+  Emits a validated SpecReview recording every obligation it could not serve.
 ---
 
 # Spec Fuzz

--- a/tests/skill-contracts.test.ts
+++ b/tests/skill-contracts.test.ts
@@ -14,6 +14,7 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 const SKILLS_DIR = join(__dirname, "..", "skills");
 const MODULE_SCHEMA = join(
@@ -33,6 +34,14 @@ function skillText(name: string): string {
 
 function frontmatter(text: string): string {
   return /^---\n([\s\S]*?)\n---\n/.exec(text)?.[1] ?? "";
+}
+
+function parsedFrontmatter(text: string): Record<string, unknown> {
+  const parsed: unknown = parseYaml(frontmatter(text));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("skill frontmatter must be a YAML mapping");
+  }
+  return parsed as Record<string, unknown>;
 }
 
 /** Every `analysis: <value>` the skill mentions. */
@@ -55,15 +64,17 @@ function analysisEnum(): string[] | null {
 }
 
 describe("skill definitions", () => {
-  it("every skill ships a SKILL.md whose name matches its directory", () => {
-    // A skill whose declared name differs from its directory is invokable
-    // under one and referenced under the other.
+  it("every skill ships valid frontmatter whose name matches its directory", () => {
+    // Codex rejects the entire skill when its frontmatter is invalid YAML. A
+    // regex-only check missed spec-fuzz's `evidence_kind: Fuzz` plain-scalar
+    // continuation because it never exercised the parser used by consumers.
     const dirs = skillDirs();
     expect(dirs.length).toBeGreaterThanOrEqual(18);
     for (const dir of dirs) {
-      const fm = frontmatter(skillText(dir));
-      expect(/^name:\s*(\S+)/m.exec(fm)?.[1]).toBe(dir);
-      expect(/^description:\s*\S/m.test(fm)).toBe(true);
+      const fm = parsedFrontmatter(skillText(dir));
+      expect(fm.name).toBe(dir);
+      expect(typeof fm.description).toBe("string");
+      expect((fm.description as string).trim()).not.toBe("");
     }
   });
 

--- a/tests/skill-contracts.test.ts
+++ b/tests/skill-contracts.test.ts
@@ -8,8 +8,8 @@
  * These are deterministic contract tests over the skill definitions and the
  * module vocabulary they emit into. They do not drive an agent: an eval does
  * that, costs minutes, and cannot run on every commit. What is asserted here is
- * the part that silently drifts — the pairing between a skill and the declared
- * `analysis` value it writes.
+ * the part that silently drifts — loadable frontmatter and the pairing between
+ * a skill and the declared `analysis` value it writes.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";


### PR DESCRIPTION
## Summary

- fix `spec-fuzz` frontmatter by making its multiline description an explicit folded YAML scalar
- parse every shipped skill's frontmatter in the contract suite and assert its required mapping fields

## Verification

- `make format`
- `make lint`
- YAML-frontmatter contract: pass
- `make test-with-quire`: build, spec validation, and version agreement pass; the full Vitest gate is affected by unrelated ambient workspace state documented on #309

Closes #309
