### PR TITLE
Make the public gap-analysis skill self-contained

### DIFF
--- a/reviews/2026-08-31-plan-005-self-contained-gap-analysis.md
+++ b/reviews/2026-08-31-plan-005-self-contained-gap-analysis.md
@@ -1,0 +1,73 @@
+---
+id: SR-113
+title: "Gap analysis — PLAN-005 using the self-contained public workflow"
+type: SpecReview
+analysis: gap-analysis
+scope: "plan/PLAN-005-change-assurance-contracts/, spec/matrix.md, src/change-assurance/, tests/change-assurance*.test.ts"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/PLAN-005"
+    type: reviews
+  - target: "ix://agent-ix/quoin/TM-001"
+    type: references
+---
+
+# Gap analysis — PLAN-005 using the self-contained public workflow
+
+## Summary
+
+Re-ran the required PLAN-005 mechanical gap analysis solely from the public Quoin skill
+instructions. Every task is done, every target test case is backed, and the implemented
+change-assurance surface remains owned by FR-063 through FR-065.
+
+## Verdict
+
+**PASS** — no incomplete task, unbacked target row, status lie, untraced behavior, or
+completed stub was found in the targeted plan.
+
+## Findings
+
+| ID      | Severity | Summary       | Refs |
+| ------- | -------- | ------------- | ---- |
+| FND-001 | low      | No gaps found | -    |
+
+## Coverage
+
+- Target bundle: `plan/PLAN-005-change-assurance-contracts/`
+- Spec root: `spec/`; matrix: `spec/matrix.md` (`TM-001`)
+- Identity prefix: `ix://agent-ix/quoin`
+- Source and tests: `src/change-assurance/`, `src/evidence/index.ts`, `src/index.ts`,
+  and `tests/change-assurance*.test.ts`
+- Tasks done: **7 / 7** (`TASK-025..TASK-031`), with every dependency also done
+- Plan requirement/test checkboxes reconciled: **36 / 36**
+- Reconciliation: `quire coverage` 0.31.0 (engine `ca7362d4`); the repository-wide
+  report was filtered to the named plan's `TC-1261..TC-1292` slice
+- Target matrix rows backed by tagged executable tests: **32 / 32**
+- Target unbacked rows, status lies, and no-symbol rows: **0 / 0 / 0**
+- Inventoried behavior families: **4** (record integrity and lineage, attestation intake,
+  receipt evaluation/integration, and compatibility/export glue)
+- Untraced public behaviors: **0**
+- Source stubs or test stubs masquerading as complete: **0**
+- Existing repository gate: typecheck, ESLint, Prettier, build, Quire validation,
+  version agreement, and **75 / 75 test files; 908 / 908 tests passed**
+- Optional semantic review: **skipped**; the separate targeted code review is SR-112
+
+## Reverse trace inventory
+
+- Strict raw JSON, JCS, BLAKE3, schema assets, record sealing/lineage/storage, and retained
+  ix-flow chain verification are owned by FR-063.
+- Attestation sealing, exact-output verification, durable paired intake, recovery, and the
+  distinct store family are owned by FR-064.
+- Retained FR-032 adaptation, explicit selection, proof bindings,
+  valid/invalid/incomplete aggregation, receipt validation, determinism, and compatibility
+  boundaries are owned by FR-065.
+- Package/export glue and schema-copy tooling implement PLAN-005's declared public seams
+  and versioned-schema deliverables; they add no separate command, configuration, network,
+  or destructive behavior.
+
+## Method boundary
+
+The run used the public `skills/gap-analysis/` instructions only. It did not consult a
+private repository, a user-home skill checkout, or an external implementation-gap skill.
+The repository-wide coverage report contains rows outside PLAN-005; this targeted verdict
+does not reclassify or conceal those unrelated rows.

--- a/reviews/2026-08-31-public-gap-analysis-skill-code-review.md
+++ b/reviews/2026-08-31-public-gap-analysis-skill-code-review.md
@@ -1,0 +1,56 @@
+---
+id: SR-112
+title: "Code review — public self-contained gap-analysis skill"
+type: SpecReview
+analysis: code-review
+scope: "skills/gap-analysis/SKILL.md and skills/gap-analysis/references/step-4-underspecified-code.md through step-6-specreview-artifact.md"
+review_set: subset
+relationships:
+  - target: "ix://agent-ix/quoin/PLAN-005"
+    type: references
+  - target: "ix://agent-ix/quoin/TM-001"
+    type: references
+---
+
+# Code review — public self-contained gap-analysis skill
+
+## Summary
+
+Reviewed the public gap-analysis skill change for portability, internal consistency,
+review-gate behavior, and fidelity to its existing output contract. The change now owns
+its reverse-gap, test-stub, and coverage-inflation procedure without requiring a private
+skills checkout or user-specific filesystem layout.
+
+## Verdict
+
+**PASS** — the one portability finding was fixed; no unresolved correctness, dependency,
+scope, or documentation-contract issue remains.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                                                                                                | Refs                                                           |
+| ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| FND-081 | medium   | Fixed: Step 6 retained a user-home fallback for the SpecReview skeleton, contradicting the self-contained contract. It now provides a complete in-repository fallback. | `skills/gap-analysis/references/step-6-specreview-artifact.md` |
+
+## Review evidence
+
+- Read the complete skill and all six referenced workflow steps, including both the
+  required mechanical pass and the optional semantic-review gate.
+- Confirmed Step 4 contains the reverse-trace, source-stub, test-stub, and
+  coverage-inflation heuristics formerly delegated to a private skill.
+- Confirmed Step 5 routes only to the public Step 4 procedure.
+- Confirmed Step 6 can be followed when `quoin write` is unavailable without consulting
+  a private repository, user-home path, or separately installed template.
+- Searched the complete `skills/gap-analysis/` tree for private `agent-skills` names,
+  the former `implementation-gap-analysis` dependency, and user-home paths; no matches
+  remain.
+- Restored the existing `<slug>` filename notation so this dependency correction carries
+  no unrelated frontmatter wording change.
+- Quire validation, typecheck, ESLint, Prettier, build, version agreement, and the full
+  existing suite pass: **75 / 75 test files; 908 / 908 tests**.
+
+## Boundary
+
+This is a documentation and workflow-dependency correction. It does not alter Quoin
+runtime behavior, the requirements model, the Test Matrix, or executable tests. The
+optional semantic review was not run because it was not requested.

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Verify a targeted plan is complete and validated — every task don
   Matrix backed by real tracking tags in tests, and code fully traced to spec (flagging
   underspecified code with no owning requirement). Optional semantic review checks that
   intent↔test↔code actually agree. Emits a quire-validated SpecReview artifact to
-  reviews/YY-MM-DD-slug.md.
+  reviews/YY-MM-DD-<slug>.md.
 ---
 
 # Gap Analysis

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -4,7 +4,7 @@ description: Verify a targeted plan is complete and validated — every task don
   Matrix backed by real tracking tags in tests, and code fully traced to spec (flagging
   underspecified code with no owning requirement). Optional semantic review checks that
   intent↔test↔code actually agree. Emits a quire-validated SpecReview artifact to
-  reviews/YY-MM-DD-<slug>.md.
+  reviews/YY-MM-DD-slug.md.
 ---
 
 # Gap Analysis

--- a/skills/gap-analysis/references/step-4-underspecified-code.md
+++ b/skills/gap-analysis/references/step-4-underspecified-code.md
@@ -25,8 +25,7 @@ detection heuristics below.
 
 ## B. Implied requirements from code patterns
 
-Map suspicious patterns to the requirement that *should* exist (per the
-implementation-gap-analysis table):
+Map suspicious patterns to the requirement that *should* exist using the table below:
 
 | Code pattern | Missing requirement type |
 | --- | --- |
@@ -46,7 +45,7 @@ done:
 | Stub | Detect | Severity |
 | --- | --- | --- |
 | Tiny file (≤5 lines, excl. `__init__`) | line count | high |
-| `pass` / placeholder return (`{}`,`[]`,`None`,`"not implemented"`) body | grep/AST | high |
+| `pass` / placeholder return (`{}`, `[]`, `""`, `None`, `"not implemented"`) body | grep/AST | high |
 | Protocol/ABC-only with no concrete impl | structure | high |
 | Re-export-only module | structure | medium (may be intentional) |
 | Trivially-covered stub (≤5 lines @ 100% cov) | coverage + size | medium |

--- a/skills/gap-analysis/references/step-4-underspecified-code.md
+++ b/skills/gap-analysis/references/step-4-underspecified-code.md
@@ -5,8 +5,9 @@ requirement**, plus stubs that masquerade as complete. Steps 2–3 verify spec�
 coverage; this step verifies code→spec, catching scope that was implemented but never
 specified.
 
-Reuse the detection heuristics in
-`~/dev/agent_skills/implementation-gap-analysis/SKILL.md` — don't reinvent them.
+This reference is the authoritative, self-contained reverse-gap procedure. Do not
+consult a private repository, user-home path, or separately installed skill for the
+detection heuristics below.
 
 ## A. Untraced behavior (code with no requirement)
 
@@ -52,10 +53,39 @@ done:
 
 A stub behind a `done` task or a ✅ matrix row is a `high` finding (false completion).
 
+Inspect test files as well as source. A passing test can still be a stub:
+
+| Test stub | Detect | Severity |
+| --- | --- | --- |
+| Empty body or unconditional skip | `pass`, empty callback, or skip without a tracked reason | high |
+| No behavioral assertion | no assertion, rejection, snapshot, or observable-effect check | high |
+| Weak-only assertion | only existence/type checks for behavior with a stronger contract | high |
+| Mock-everything | all meaningful collaborators replaced so production behavior is never exercised | high |
+| Import-only smoke test | verifies only that a module imports | medium |
+
+Do not flag an abstract declaration, generated file, intentional compatibility re-export,
+or a test whose assertion is expressed through the repository's harness merely because it
+matches a textual pattern. Confirm the behavior is hollow before recording a finding.
+
+## D. Coverage inflation
+
+Treat coverage as evidence only after checking what the covered lines do:
+
+- A source file with five or fewer substantive lines and 100% coverage can still be a
+  trivially covered stub.
+- A test that mocks a source module which is itself hollow is circular evidence, not
+  implementation coverage.
+- A threshold dominated by imports, declarations, or re-exports does not establish that
+  the promised behavior exists.
+
+Record these as `high` when they support a `done` task or ✅ matrix claim, otherwise
+`medium`. Cite both the hollow source and the test or coverage artifact.
+
 ## Output of this step
 
-Findings for untraced behavior, implied-but-missing requirements, and stubs, each with
-`Refs` = code location, plus a count of untraced behaviors/stubs for `## Coverage`.
+Findings for untraced behavior, implied-but-missing requirements, source/test stubs, and
+coverage inflation, each with `Refs` = concrete code/test location. Include counts of
+inventoried behaviors, untraced behaviors, source stubs, and test stubs in `## Coverage`.
 
 ## Notes
 

--- a/skills/gap-analysis/references/step-5-semantic-review.md
+++ b/skills/gap-analysis/references/step-5-semantic-review.md
@@ -21,8 +21,8 @@ code it governs (from Step 4), assess three axes:
    requirement describes*, including its acceptance criteria, or only an incidental/trivial
    aspect? A test tagged `FR-007-AC-1` that asserts something unrelated to AC-1 fails here.
 2. **(b) Test exercises the code** — does the test run the real implementation, or is it
-   hollow? Reuse the implementation-gap-analysis **test-stub / coverage-inflation**
-   heuristics: no assertions, weak-only assertions (`is not None`, `isinstance`),
+   hollow? Reuse Step 4's **test-stub / coverage-inflation** heuristics: no assertions,
+   weak-only assertions (`is not None`, `isinstance`),
    mock-everything (no real code path), import-only, circular-mock-of-a-stub.
 3. **(c) Code matches intent** — does the implementation actually do what the requirement
    says (semantics, edge cases, error behavior), or has it drifted?

--- a/skills/gap-analysis/references/step-6-specreview-artifact.md
+++ b/skills/gap-analysis/references/step-6-specreview-artifact.md
@@ -3,17 +3,18 @@
 **Goal**: Emit the findings from Steps 1–5 as a single **quire-validated `SpecReview`**
 document with a Verdict, at `reviews/YY-MM-DD-<slug>.md`.
 
-## Fetch the template, then author (guardrail)
+## Render the template, then author (guardrail)
 
-The `SpecReview` archetype lives in `spec-artifacts-process`. Fetch its skeleton first, then
-author, then validate (the ecosystem direct-render-then-validate model):
+The `SpecReview` archetype lives in `spec-artifacts-process`. Render its skeleton first,
+then author, then validate (the ecosystem direct-render-then-validate model):
 
 ```
 quoin write --types SpecReview
 ```
 
-If `quoin write` is unavailable in the working tree, read the skeleton directly from
-`~/.ix/filament/modules/spec-artifacts-process/skeletons/SpecReview.md`.
+If `quoin write` is unavailable, use the complete frontmatter, body, findings-table, and
+validation contract below. Do not consult a private repository, user-home path, or
+separately installed template.
 
 ## Frontmatter
 


### PR DESCRIPTION
Summary
- remove the private agent-skills dependency from the public Quoin gap-analysis workflow
- include reverse-gap, source-stub, test-stub, and coverage-inflation heuristics in the owning public repository
- route semantic review to the public Step 4 procedure
- make the SpecReview fallback self-contained when quoin write is unavailable

Review evidence
- code review: reviews/2026-08-31-public-gap-analysis-skill-code-review.md (SR-112, PASS)
- gap analysis: reviews/2026-08-31-plan-005-self-contained-gap-analysis.md (SR-113, PASS)
- PLAN-005: 7/7 tasks done; TC-1261..TC-1292 32/32 backed

Verification
- Quire document validation
- typecheck, ESLint, and Prettier
- Quoin build and version agreement
- 75/75 test files; 908/908 tests passed
- diff check passed