### PR TITLE
Refuse inherited property names as declared adapter statuses

### DIFF
--- a/src/evidence/adapters/contract-conformance.ts
+++ b/src/evidence/adapters/contract-conformance.ts
@@ -16,10 +16,10 @@ import {
 const PROTOCOL = "quire.contract.conformance-jsonl/v1";
 
 /** Every status the protocol declares. An unknown one is refused, not skipped. */
-const STATUS: Record<string, RunEntry["outcome"]> = {
-  match: "pass",
-  mismatch: "fail",
-};
+const STATUS = new Map<string, RunEntry["outcome"]>([
+  ["match", "pass"],
+  ["mismatch", "fail"],
+]);
 
 interface ConformanceRow {
   protocol?: unknown;
@@ -87,7 +87,11 @@ export const contractConformanceAdapter: EvidenceAdapter = {
           );
         }
       }
-      const outcome = STATUS[row.status as string];
+      // `Map`, not an object literal — see the same guard in
+      // differential-report.ts. An object literal resolves inherited property
+      // names like `valueOf`, so `"status": "valueOf"` would have been read as
+      // a declared status.
+      const outcome = STATUS.get(row.status as string);
       if (outcome === undefined) {
         throw new AdapterError(
           "contract-conformance",

--- a/src/evidence/adapters/differential-report.ts
+++ b/src/evidence/adapters/differential-report.ts
@@ -21,11 +21,11 @@ const SCHEMA = /^[a-z0-9][a-z0-9-]*\.differential-summary\/v1$/;
  *
  * `unsupported` is deliberately absent — see {@link UnrepresentedResult}.
  */
-const STATUS: Record<string, RunEntry["outcome"]> = {
-  agreement: "pass",
-  mismatch: "fail",
-  "tool-error": "error",
-};
+const STATUS = new Map<string, RunEntry["outcome"]>([
+  ["agreement", "pass"],
+  ["mismatch", "fail"],
+  ["tool-error", "error"],
+]);
 
 interface DifferentialCase {
   id?: unknown;
@@ -117,7 +117,12 @@ export const differentialReportAdapter: EvidenceAdapter = {
         });
         return;
       }
-      const outcome = STATUS[entry.status];
+      // `Map`, not an object literal: `STATUS["valueOf"]` on a literal
+      // resolves through the prototype chain and is not `undefined`, so an
+      // inherited property name was accepted as a declared status and
+      // transcribed with a function as its outcome. CI's property test found
+      // it with the counterexample "valueOf".
+      const outcome = STATUS.get(entry.status);
       if (outcome === undefined) {
         throw new AdapterError(
           "differential-report",

--- a/tests/campaign-adapters.test.ts
+++ b/tests/campaign-adapters.test.ts
@@ -238,6 +238,36 @@ describe("FR-069 contract conformance", () => {
       expect(() => differentialReportAdapter.parse(input)).toThrow(message);
     }
 
+    // The inherited property names an object literal would have resolved.
+    // CI found this with the counterexample "valueOf" after a local run of the
+    // same property passed on a different seed — the reason the property is
+    // here rather than a fixed list of statuses I thought of.
+    for (const inherited of [
+      "valueOf",
+      "toString",
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      expect(
+        () =>
+          differentialReportAdapter.parse(
+            JSON.stringify({
+              schemaVersion: "tl-mltl.differential-summary/v1",
+              cases: [{ id: "case", status: inherited }],
+            }),
+          ),
+        inherited,
+      ).toThrow(AdapterError);
+      expect(
+        () =>
+          contractConformanceAdapter.parse(
+            JSON.stringify({ ...parsed, status: inherited }),
+          ),
+        inherited,
+      ).toThrow(AdapterError);
+    }
+
     // No status outside the declared vocabularies is ever accepted, however
     // plausible it looks.
     fc.assert(


### PR DESCRIPTION
Closes #329.

The `v0.23.0` release run failed before publishing, with the counterexample `["valueOf"]` from TC-1331.

Both adapters added in #323 resolved their status through an object literal:

```ts
const STATUS = { agreement: "pass", mismatch: "fail" };
const outcome = STATUS[entry.status];   // STATUS["valueOf"] is a function, not undefined
```

So `"status": "valueOf"` was accepted as a declared status and transcribed into a run entry whose `outcome` was `Object.prototype.valueOf`. Same for `toString`, `constructor`, `hasOwnProperty`, `__proto__`.

Both lookups become `Map.get`. A `Map` has no prototype chain to fall through, so an inherited name is simply absent.

TC-1331 keeps the property and gains explicit probes for the five inherited names — the specific case pinned as well as the general one. The property is the reason this was caught at all: my local run passed on a different fast-check seed, and CI's seed found it. A fixed list of statuses I thought of would not have contained `valueOf`.

`v0.23.0` is tagged and was never published. The tag is bumped, not deleted: the fix ships as `v0.23.1`.

## Gates

- `tsc --noEmit`, `eslint`, `prettier --check .` — clean.
- `vitest run` — 926 of 927; the one failure is `quire-contract` TC-118 against my locally installed quire. It passes in CI, which runs against the exact governed Quire — worth noting on #326, since that narrows the finding further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EqxTnd7CWjB3NwfBdRFhj