### PR TITLE
Make gap analysis planless by default (#365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,22 @@ Call `/implement-plan` to trigger your coding agent to begin work on the plan.
 
 #### 5. Gap review
 
-`/gap-analysis` validates that the `UserStory` and `Functional Requirements` are implemented and tested using the `traceability matrix`
-as the guide. `/gap-analysis` will optionally perform a _semantic_ comparison of `spec`, `code`, and `tests` to ensure the
-`plan` is faithfully implemented.
+`/gap-analysis` audits the repository: `UserStory` and `Functional Requirements` implemented and tested,
+using the `traceability matrix` as the guide, plus the reverse gap — code with no owning requirement — and
+stubs standing behind a covered row. It is **planless by default**, so a repository whose work predates
+planning can still be audited; the review it emits records `Plan completion: not assessed`.
+`/gap-analysis` will optionally perform a _semantic_ comparison of `spec`, `code`, and `tests`.
 
 ```
 > /gap-analysis
+```
+
+Pass a plan to add completion bookkeeping — every `Task` done, done tasks in dependency order, and
+`plan.md` checkboxes matching task status. The repository audit is unchanged by it: a plan never narrows
+the scope or suppresses a finding outside its tasks.
+
+```
+> /gap-analysis --plan Plan-001
 ```
 
 ## What's included

--- a/reviews/2026-09-10-planless-gap-analysis-code-review.md
+++ b/reviews/2026-09-10-planless-gap-analysis-code-review.md
@@ -1,0 +1,86 @@
+---
+id: SR-149
+title: "Code review — gap-analysis planless by default (#365, PR #366)"
+type: SpecReview
+analysis: code-review
+scope: "skills/gap-analysis/, tests/gap-analysis-skill.test.ts, README.md"
+review_set: subset
+relationships:
+  - { target: "ix://agent-ix/quoin/TM-001", type: references }
+---
+
+## Summary
+
+Reviewed the nine files on `365-planless-gap-analysis` (PR #366): the `gap-analysis` skill
+and its six references, the new `tests/gap-analysis-skill.test.ts`, and the README section.
+The change is prose plus one test file — no source modules, no mocks, no database access —
+so the Python, Rust and React lanes do not apply and the applicable checks are Integrity,
+Completeness (test code), Code-Test Alignment and the reverse gap. No `high` finding. Four
+of the five findings were fixed on the branch during the review; FND-002 stands and is
+recorded rather than silently accepted.
+
+## Verdict
+
+**CONDITIONAL** — two `medium` findings, one of which (FND-002, an untracked test file) is
+left open with a stated reason; no `high` finding.
+
+## Findings
+
+| ID      | Severity | Summary                                                                             | Refs                                                            |
+| ------- | -------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| FND-001 | medium   | Test assertions were coupled to Prettier's line wrapping, not to the claims — fixed | tests/gap-analysis-skill.test.ts:31                             |
+| FND-002 | medium   | New test file carries no `TC-` tracking tag and mints no Test Matrix row — open     | tests/gap-analysis-skill.test.ts:1                              |
+| FND-003 | low      | Stale numbered cross-references survived the step reordering — fixed                | skills/gap-analysis/references/step-3-matrix-verification.md:54 |
+| FND-004 | low      | `## Modes` said the opt-in semantic review "runs in full" in planless mode — fixed  | skills/gap-analysis/SKILL.md:42                                 |
+| FND-005 | low      | Two prose lines exceeded the files' wrap width after editing — fixed                | skills/gap-analysis/SKILL.md:137                                |
+
+### FND-001 — assertions coupled to the wrap, not the claim
+
+Fourteen assertions matched across newlines (`"The\npresence of a `plan/` directory…"`) or
+used `\s+` to bridge one. Prettier owns the wrapping in these files, so re-flowing a
+paragraph — or changing `proseWrap` — would have failed tests whose subject had not changed,
+and the usual repair for that is to weaken the assertion. **Fixed**: every file is read
+through a whitespace-flattening reader, so the coupling sits on the sentence. Re-verified
+red against `main`'s skill (12/12 fail) and green on the branch (12/12 pass).
+
+### FND-002 — the test file is untracked (open)
+
+`quire coverage` classes a test carrying no declared trace id as an untracked symbol, and
+the repo's convention is one `TC-NNN` row in `spec/matrix.md` per unit test (TC-271 for
+`tests/skills-vocab-drift.test.ts`, TC-272 for `tests/quire-types-conformance.test.ts`). The
+new file has neither.
+
+It is left open rather than fixed because **no requirement owns it**. quoin's spec states no
+behavioural requirement for any skill's workflow; NFR-005 covers vocabulary coupling only.
+Minting a `TC-` row means first authoring the requirement that a skill's audit is
+repository-driven, which is spec work, not a tag. The precedent is the same: `quoin#202`'s
+`tests/skill-contracts.test.ts` — the contract gate for all 18 skills — is equally untracked.
+Recorded here so the absence is a decision on the record rather than an oversight.
+
+### FND-003 — stale step numbers
+
+Reordering the audit left two numbered references pointing at positions that no longer exist:
+`step-3-matrix-verification.md:54` cited "Step 6" after the reference headings dropped their
+numbers, and `SKILL.md`'s list stayed 0-indexed with the plan overlay labelled "Step 4" while
+living in `step-2-plan-completion.md`. **Fixed**: the steps are no longer numbered at all;
+each is labelled by when it runs (`Always`, `Only when the user opts in`, `Only with an
+explicit plan`), which also removes the numbering coupling from the test.
+
+## Coverage
+
+- Lanes run: Integrity, Completeness (test code), Code-Test Alignment, reverse gap. Python /
+  Rust / React lanes not applicable — the change adds no source module.
+- Files reviewed: 9 (8 markdown, 1 TypeScript test).
+- Test stubs, weak-only assertions, skip markers, mock-only tests: 0. No mock is used; the
+  test reads real files and asserts on their content.
+- Suppressed warnings, lowered thresholds, coverage pragmas: 0.
+- Gates run: `make lint` clean; full suite 1181/1181 (105 files) via the `test-with-quire`
+  inner target with quire 0.31.0.
+- Gates not run, with reasons: `make test` (quire evidence-overlay relock) and `make validate`
+  (duplicate `## Impact Scenarios` heading in `spec/assurance/AP-201-finding-quality.md`)
+  fail on pre-existing repository state; both reproduce on a clean tree with this branch's
+  changes stashed.
+- Near-miss caught by an existing gate, before the first commit: the rewritten SKILL.md
+  frontmatter used a plain scalar containing `: `, which is invalid YAML and would have made
+  the whole skill unloadable. `tests/skill-contracts.test.ts` failed on it, which is exactly
+  the drift that test was written for.

--- a/reviews/2026-09-10-quoin-repository-gap-analysis.md
+++ b/reviews/2026-09-10-quoin-repository-gap-analysis.md
@@ -1,0 +1,107 @@
+---
+id: SR-150
+title: "Gap analysis — quoin repository audit (planless)"
+type: SpecReview
+analysis: gap-analysis
+scope: "spec/, src/, tests/, templates/, spec/matrix.md"
+review_set: subset
+relationships:
+  - { target: "ix://agent-ix/quoin/TM-001", type: references }
+---
+
+## Summary
+
+Planless repository audit of quoin at `365-planless-gap-analysis`, run with the branch's own
+skill definition (the installed plugin cache is quoin 0.13.0, which still carries the
+plan-first workflow). `quire coverage` reconciles 1013 of 1727 declared rows as backed,
+leaving 207 unbacked rows, 9 status lies and 40 untracked symbols. Sampling the 9 status
+lies splits them 6 rule / 2 real / 1 binding-form: six are caused by a quire tokenizer
+defect that abandons any TypeScript file containing a regex literal with brace quantifiers,
+so every tracking tag in that file binds nothing. **Every finding below is pre-existing
+repository state.** None is introduced by PR #366, which adds no source module and whose one
+new test file does not appear anywhere in the coverage report.
+
+## Verdict
+
+**FAIL** — 207 unbacked rows, 9 status lies, and a `high` finding in the reconciliation
+engine itself. This verdict describes the quoin repository, not PR #366.
+
+## Findings
+
+| ID      | Severity | Summary                                                                                  | Refs                                                     |
+| ------- | -------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| FND-001 | high     | quire's brace scanner counts regex-literal braces, abandoning three files and their tags | tests/spec-review-vocab-drift.test.ts:37                 |
+| FND-002 | high     | TC-1096 and TC-1097 claim ✅ with no tag anywhere in `tests/` or `src/`                  | spec/matrix.md:864                                       |
+| FND-003 | high     | 207 declared reference rows have no backing `verifies` relation                          | spec/matrix.md, spec/evals.md                            |
+| FND-004 | medium   | TC-1124's id sits second in a two-id `it()` title and does not bind                      | tests/evidence-audit-command.test.ts:257                 |
+| FND-005 | medium   | 40 tagged tests carry a trace id that resolves to no declared row                        | templates/semantic-module/.../test_skeletons_semantic.py |
+| FND-006 | medium   | 91 declarations selected nothing; 30 are tags on non-binding symbols                     | spec/matrix.md                                           |
+
+### FND-001 — the engine cannot read a file with a regex quantifier (high)
+
+`quire coverage` emitted three parse diagnostics on stderr:
+
+```
+src/evidence/mock-inspection.ts: unbalanced braces: a `}` closes no block
+src/semantic/sweep.ts: unbalanced braces: 1 block(s) left open
+tests/spec-review-vocab-drift.test.ts: unbalanced braces: 1 block(s) left open
+```
+
+All three files compile under `tsc --noEmit` and pass eslint, so the braces are balanced.
+The cause is the same in each: a **regex literal** the scanner reads as source.
+
+- `tests/spec-review-vocab-drift.test.ts:37` — `/^import \{ specInvariants \} from [^;]+;/m`
+- `src/evidence/mock-inspection.ts:121` — `[\s\S]{0,240}?`
+- `src/semantic/sweep.ts:87` — `-{3,}`
+
+Escaped braces and `{n,m}` quantifiers are counted as block delimiters, the file's depth
+never returns to zero, and the binder abandons it. `tests/spec-review-vocab-drift.test.ts`
+holds 9 tag-bearing lines, so **TC-279 through TC-284 report as status lies while their
+tests exist, are tagged, and pass.**
+
+This is the worst shape a reconciliation defect can take: it under-reports coverage silently
+and manufactures false accusations against correct specs, in a direction that punishes
+authors for writing a regex. It belongs upstream in quire-rs, not here. The three quoin files
+are correct as written and must not be edited to appease the scanner.
+
+### FND-002 — two rows are genuinely unbacked (high)
+
+`TC-1096` and `TC-1097` (`spec/matrix.md:864`, `FR-043-AC-27`) are marked `✅` and neither id
+appears in `tests/` or `src/`. Unlike FND-001 these are real: the matrix asserts a passing
+test that does not exist.
+
+### FND-003 — the unbacked-row backlog (high)
+
+207 rows across `spec/matrix.md` (76), `spec/evals.md` (52) and eleven requirement documents.
+`spec/evals.md` dominating is expected — eval rows mint through the eval harness, and 49 rows
+are separately reported under `no_symbol_rows` as exempt by their declared verification
+method. The remaining balance is a real backlog, not an artifact.
+
+**This finding is a census, not a precision estimate.** The 9 status lies were sampled at
+100%; the 207 unbacked rows were not, so the rule/corpus split above is established only for
+the status lies.
+
+## Coverage
+
+- Reconciliation: `quire coverage` (quire 0.31.0, cli 4f6ed024, engine 0.46.0@ca7362d4),
+  module `spec-artifacts-process`. Not the grep fallback.
+- **Plan completion: not assessed**
+- Rows backed by a tagged test: 1013 / 1727
+- Evidence symbols: 1109 matched of 1396 examined
+- Status lies: 9 — sampled 9 of 9: 6 rule (FND-001), 2 real (FND-002), 1 binding-form (FND-004)
+- Untracked symbols: 40; rows exempt by declared method (`no_symbol_rows`): 49
+- Diagnostics that selected nothing: 91 — 30 `tag-on-non-binding-symbol`,
+  24 `untracked-id-has-minted-children`, 17 `uncatalogued-verification-method`,
+  16 `section-matches-nothing`, 4 other
+- Acceptance criteria: 803 bound, 388 property-shaped, 69 specific-shaped
+- Engine suspicions: 4, all `oracle-resembles-implementation` inside `corpus/cases/skeptic/`,
+  where a copied oracle is the fixture's purpose. Not findings.
+- Semantic review: skipped — not opted into.
+- **Reverse gap: branch surface only.** PR #366 adds no source module, so its reverse gap is
+  empty by construction. A repository-wide behaviour inventory was **not** performed in this
+  run, and no reverse-gap finding above rests on one. The verdict stands on the matrix
+  evidence alone, which is sufficient for FAIL on its own.
+- Suite execution: `make lint` clean; 1181/1181 tests pass (105 files) via the
+  `test-with-quire` inner target. `make test` and `make validate` fail on pre-existing state
+  (quire evidence-overlay relock; a duplicate heading in
+  `spec/assurance/AP-201-finding-quality.md`), both reproducing on a clean tree.

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -41,8 +41,8 @@ and a validated **Findings** table.
 ## Modes
 
 **Planless (the default).** No plan is selected, discovered, or asked for. The repository
-audit — matrix verification, reverse gaps, stubs, and the opt-in semantic review — runs in
-full. The SpecReview records, verbatim:
+audit — matrix verification, reverse gaps, and stubs — runs in full, and the semantic review
+is offered on the same terms as ever. The SpecReview records, verbatim:
 
 ```
 Plan completion: not assessed
@@ -90,28 +90,34 @@ code, edit the plan, or change the matrix.
 
 ## Steps
 
-0.  **[Target selection](references/step-1-target-selection.md)**: Resolve the repository
-    root, spec root, Test Matrix, and `org`/`component` for `ix://` URIs. Record whether a
-    plan was explicitly supplied.
-1.  **[Matrix verification](references/step-3-matrix-verification.md)**: Run
-    `quire coverage --scope <root> --json` and interpret the report — unbacked rows, status
-    lies, untracked tests, and the backed/total rollup. The reconciliation is the engine's;
-    the severity and the verdict stay here. A repo whose module set declares no
-    `traceability:` model falls back to a grep index, declared as such.
-2.  **[Underspecified code](references/step-4-underspecified-code.md)**: Find code/behavior
-    with no owning requirement (reverse gap), plus stubs and coverage inflation
-    masquerading as complete.
-3.  **[Semantic review](references/step-5-semantic-review.md)** *(OPTIONAL — ask first)*:
-    Judge intent↔test↔code agreement per requirement. Skip unless the user opts in. Opt-in
-    works the same way in both modes.
-4.  **[Plan completeness](references/step-2-plan-completion.md)** *(ONLY with an explicit
-    plan)*: Assert every `Task` is `done`, check done-task dependency order, and reconcile
-    `plan.md` checkboxes against task status.
-5.  **[SpecReview artifact](references/step-6-specreview-artifact.md)**: Write and validate
-    the `SpecReview` to `reviews/YY-MM-DD-<slug>.md`.
+Each step says when it runs. Nothing here is numbered, because the plan step is an overlay
+rather than a position in a sequence, and a number would imply the audit waits on it.
 
-Steps 0–2 and 5 always run. Step 3 is gated on user opt-in. Step 4 runs only when the
-caller supplied a plan.
+**Always — [Target selection](references/step-1-target-selection.md).** Resolve the
+repository root, spec root, Test Matrix, and `org`/`component` for `ix://` URIs. Record
+whether a plan was explicitly supplied.
+
+**Always — [Matrix verification](references/step-3-matrix-verification.md).** Run
+`quire coverage --scope <root> --json` and interpret the report — unbacked rows, status
+lies, untracked tests, and the backed/total rollup. The reconciliation is the engine's;
+the severity and the verdict stay here. A repo whose module set declares no
+`traceability:` model falls back to a grep index, declared as such.
+
+**Always — [Underspecified code](references/step-4-underspecified-code.md).** Find
+code/behavior with no owning requirement (reverse gap), plus stubs and coverage inflation
+masquerading as complete.
+
+**Only when the user opts in — [Semantic review](references/step-5-semantic-review.md).**
+Judge intent↔test↔code agreement per requirement. Ask first; skip unless the user says yes.
+Opt-in works the same way in both modes.
+
+**Only with an explicit plan — [Plan completeness](references/step-2-plan-completion.md).**
+Assert every `Task` is `done`, check done-task dependency order, and reconcile `plan.md`
+checkboxes against task status. This is bookkeeping added to the audit, not a gate in front
+of it.
+
+**Always — [SpecReview artifact](references/step-6-specreview-artifact.md).** Write and
+validate the `SpecReview` to `reviews/YY-MM-DD-<slug>.md`.
 
 > **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
 > v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
@@ -127,9 +133,9 @@ caller supplied a plan.
 
 ## The optional semantic review
 
-The matrix, reverse-gap, and plan-completeness steps are mechanical and cheap. The semantic review is an expensive,
-judgment-heavy LLM pass. **Before running it**, ask the user explicitly (e.g. with a yes/no
-choice):
+The matrix, reverse-gap, and plan-completeness steps are mechanical and cheap. The semantic
+review is an expensive, judgment-heavy LLM pass. **Before running it**, ask the user
+explicitly (e.g. with a yes/no choice):
 
 > Run the optional semantic review (intent↔test↔code)? It's slower but verifies that tests
 > actually validate requirement intent and exercise real code.

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -1,66 +1,117 @@
 ---
 name: gap-analysis
-description: Verify a targeted plan is complete and validated — every task done, the Test
-  Matrix backed by real tracking tags in tests, and code fully traced to spec (flagging
-  underspecified code with no owning requirement). Optional semantic review checks that
-  intent↔test↔code actually agree. Emits a quire-validated SpecReview artifact to
-  reviews/YY-MM-DD-<slug>.md.
+description: >-
+  Audit a repository end to end — spec requirements, Test Matrix, tagged tests, and source
+  code. Planless by default; it verifies the matrix is backed by real tracking tags, finds
+  code with no owning requirement, and catches stubs and coverage inflation, reporting
+  "Plan completion: not assessed". An explicitly supplied plan adds optional
+  plan-completeness bookkeeping only. Optional semantic review checks whether intent, test
+  and code agree. Emits a quire-validated SpecReview artifact to reviews/YY-MM-DD-<slug>.md.
 ---
 
 # Gap Analysis
 
-Use this skill as a **post-implementation verification gate** for one targeted plan.
-It answers three questions and, on request, a fourth:
+Use this skill as a **repository assurance audit**. The chain it verifies is always the
+same, with or without a plan:
 
-1. **Is the plan done?** Every `Task` in the targeted plan bundle is `status: done`.
-2. **Is the Test Matrix real?** Every Test Case in the matrix is backed by an actual test
+```
+spec requirements  ↔  Test Matrix  ↔  tagged tests  ↔  source code
+```
+
+It answers three questions by default, a fourth on request, and a fifth only when the
+caller explicitly hands it a plan:
+
+1. **Is the Test Matrix real?** Every Test Case in the matrix is backed by an actual test
    carrying a matching **tracking tag** (`TC-xxx`, `FR-xxx-AC-x`) in the test code.
-3. **Is anything unspecified?** Code/behavior exists with **no owning** StR/US/FR/NFR
+2. **Is anything unspecified?** Code/behavior exists with **no owning** StR/US/FR/NFR
    (the reverse, code→spec gap).
-4. **(optional) Does intent match reality?** For each requirement↔test↔code triple — does
-   the test validate the requirement's *intent*, does the test actually exercise the code,
-   and does the code match the requirement's intent.
+3. **Is the evidence hollow?** Source or test stubs, and coverage inflation, standing
+   behind a ✅ row.
+4. **(optional, opt-in) Does intent match reality?** For each requirement↔test↔code triple —
+   does the test validate the requirement's *intent*, does the test actually exercise the
+   code, and does the code match the requirement's intent.
+5. **(only with an explicit plan) Is that plan complete?** Every `Task` is `status: done`,
+   done tasks did not complete out of dependency order, and `plan.md` checkboxes agree with
+   task status.
 
 The result is a single **quire-validated `SpecReview`** document (`analysis: gap-analysis`)
 written to `reviews/YY-MM-DD-<slug>.md`, with a **Verdict** (PASS / CONDITIONAL / FAIL)
 and a validated **Findings** table.
 
+## Modes
+
+**Planless (the default).** No plan is selected, discovered, or asked for. The repository
+audit — matrix verification, reverse gaps, stubs, and the opt-in semantic review — runs in
+full. The SpecReview records, verbatim:
+
+```
+Plan completion: not assessed
+```
+
+**Plan-assisted (opt-in).** The caller names a plan — `gap-analysis --plan Plan-001`, or
+says so in the request. The same repository audit runs **identically and over the same
+repository scope**, and plan-completeness bookkeeping is added on top.
+
+A plan is an *addition*, never a lens. It does not choose the scope, does not narrow the
+requirement set, does not bound the code surface inventoried, and does not suppress a
+finding for sitting outside its tasks.
+
+## Non-negotiables
+
+- **Never author.** A gap-analysis run does not create or edit a plan, a `Task`, a
+  requirement, or an acceptance criterion. Its only write is the SpecReview artifact.
+- **Never manufacture a plan to satisfy the audit.** An absent plan bundle is the default
+  case, not a blocker. Do not offer to run `spec-to-plan` first as a precondition.
+- **Never auto-select a plan.** A `plan/` directory containing bundles does not make this a
+  plan-assisted run. Only an explicit caller instruction does.
+- **A missing Test Matrix stays a `high` finding.** Do not invent one, and do not downgrade
+  it because the repository never had a plan either.
+- **A planless PASS is a repository claim only.** It means traceability, reverse-gap, and
+  stub checks passed. It never means the work was planned, tracked, or completed against a
+  plan. Do not let the Summary or Verdict imply otherwise.
+
 ## When to use
 
-- After `implement-plan` (or any implementation effort) to confirm a plan is genuinely
-  complete and verified before closing it.
-- To audit drift between spec, tests, and code for an existing component.
+- To audit drift between spec, tests, and code for any existing component — including one
+  whose work predates planning, or whose scope was never organized as a plan.
 - As a release/merge gate that produces a durable, traceable review artifact.
+- After `implement-plan`, with `--plan <Plan-id>`, to additionally confirm that plan is
+  genuinely complete.
 
 This skill is **read-only over the codebase** — it inspects and reports; it does not fix
-code, edit the plan, or change the matrix. Its only write is the SpecReview artifact.
+code, edit the plan, or change the matrix.
 
 ## Inputs
 
-- A target **plan bundle** `plan/<Plan-id>-<slug>/` (the user may name it; otherwise pick).
+- The **repository** under audit (required): its spec root, source tree, and test tree.
 - The component **spec** (`spec/spec.md` for `org`/`name`) and **Test Matrix**
   (`spec/matrix.md` or `spec/tests.md`).
-- The **source** and **test** trees of the component.
+- *Optional:* a **plan bundle** `plan/<Plan-id>-<slug>/`, only when the caller names one.
 
 ## Steps
 
-0.  **[Target selection](references/step-1-target-selection.md)**: Resolve the plan bundle,
-    spec root, Test Matrix, and `org`/`component` for `ix://` URIs.
-1.  **[Plan completion](references/step-2-plan-completion.md)**: Assert every `Task` is
-    `done`; report incomplete/blocked tasks and stale `plan.md` checkboxes.
-2.  **[Matrix verification](references/step-3-matrix-verification.md)**: Run
+0.  **[Target selection](references/step-1-target-selection.md)**: Resolve the repository
+    root, spec root, Test Matrix, and `org`/`component` for `ix://` URIs. Record whether a
+    plan was explicitly supplied.
+1.  **[Matrix verification](references/step-3-matrix-verification.md)**: Run
     `quire coverage --scope <root> --json` and interpret the report — unbacked rows, status
     lies, untracked tests, and the backed/total rollup. The reconciliation is the engine's;
     the severity and the verdict stay here. A repo whose module set declares no
     `traceability:` model falls back to a grep index, declared as such.
-3.  **[Underspecified code](references/step-4-underspecified-code.md)**: Find code/behavior
-    with no owning requirement (reverse gap), plus stubs masquerading as complete.
-4.  **[Semantic review](references/step-5-semantic-review.md)** *(OPTIONAL — ask first)*:
-    Judge intent↔test↔code agreement per requirement. Skip unless the user opts in.
+2.  **[Underspecified code](references/step-4-underspecified-code.md)**: Find code/behavior
+    with no owning requirement (reverse gap), plus stubs and coverage inflation
+    masquerading as complete.
+3.  **[Semantic review](references/step-5-semantic-review.md)** *(OPTIONAL — ask first)*:
+    Judge intent↔test↔code agreement per requirement. Skip unless the user opts in. Opt-in
+    works the same way in both modes.
+4.  **[Plan completeness](references/step-2-plan-completion.md)** *(ONLY with an explicit
+    plan)*: Assert every `Task` is `done`, check done-task dependency order, and reconcile
+    `plan.md` checkboxes against task status.
 5.  **[SpecReview artifact](references/step-6-specreview-artifact.md)**: Write and validate
     the `SpecReview` to `reviews/YY-MM-DD-<slug>.md`.
 
-All steps required except Step 4, which is gated on user choice.
+Steps 0–2 and 5 always run. Step 3 is gated on user opt-in. Step 4 runs only when the
+caller supplied a plan.
 
 > **`--scope` is the repository root, and must be passed explicitly.** Since quire-cli
 > v0.16.0 (quire-rs CR-045) the command derives **two roots** from it and never
@@ -76,8 +127,9 @@ All steps required except Step 4, which is gated on user choice.
 
 ## The optional semantic review
 
-Steps 1–3 are mechanical and cheap. Step 4 is an expensive, judgment-heavy LLM pass.
-**Before running it**, ask the user explicitly (e.g. with a yes/no choice):
+The matrix, reverse-gap, and plan-completeness steps are mechanical and cheap. The semantic review is an expensive,
+judgment-heavy LLM pass. **Before running it**, ask the user explicitly (e.g. with a yes/no
+choice):
 
 > Run the optional semantic review (intent↔test↔code)? It's slower but verifies that tests
 > actually validate requirement intent and exercise real code.
@@ -90,9 +142,11 @@ the SpecReview's Coverage section that semantic review was skipped.
 A `SpecReview` (`spec-artifacts-process` archetype) at `<project_root>/reviews/YY-MM-DD-<slug>.md`:
 
 - Frontmatter `type: SpecReview`, `analysis: gap-analysis`, `id: SR-NNN`, `scope`,
-  `review_set: subset`, and `relationships:` (`reviews` → the plan, `references` → the matrix).
+  `review_set: subset`, and `relationships:` (`references` → the matrix; plus `reviews` →
+  the plan **only** in plan-assisted mode).
 - Body: `## Summary`, `## Verdict` (PASS/CONDITIONAL/FAIL), `## Findings`
-  (validated table `ID | Severity | Summary | Refs`), `## Coverage` (rollup).
+  (validated table `ID | Severity | Summary | Refs`), `## Coverage` (rollup, including the
+  plan-completion line).
 
 > **Note:** `reviews/` is at the **repo root** by deliberate choice for this skill, not
 > `spec/reviews/`. quire validation is path-agnostic, so this is fine.
@@ -105,7 +159,12 @@ quire validate --scope <project_root> "reviews/**/*.md"
 
 ## Verdict rule
 
-- **FAIL** — any incomplete/blocked task, any matrix Test Case with no backing tagged test,
-  or any `high`-severity finding.
+- **FAIL** — any matrix Test Case with no backing tagged test, any `high`-severity finding,
+  or (plan-assisted only) any incomplete/blocked task.
 - **CONDITIONAL** — only `medium`/`low` findings (e.g. untracked tests, minor drift).
 - **PASS** — no gaps; record the single `FND-001 | low | No gaps found | -` row.
+
+A planless run can reach PASS. That PASS asserts repository assurance — matrix traceability,
+reverse-gap, and stub checks — and nothing about whether the work was ever planned. The
+`Plan completion: not assessed` line in `## Coverage` is what keeps the two apart, and it is
+mandatory.

--- a/skills/gap-analysis/references/step-1-target-selection.md
+++ b/skills/gap-analysis/references/step-1-target-selection.md
@@ -1,53 +1,60 @@
-# Step 1: Target Selection
+# Target Selection
 
-**Goal**: Resolve exactly what this run audits — one plan bundle, its spec, its Test
-Matrix — and the `ix://` identity used in the output artifact.
+**Goal**: Resolve exactly what this run audits — one **repository**, its spec, its Test
+Matrix, its source and test trees — and the `ix://` identity used in the output artifact.
+Record whether the caller explicitly supplied a plan.
+
+The target of gap-analysis is a repository, not a plan. A plan is an optional extra input.
 
 ## Process
 
-### 1. Resolve the target plan
+### 1. Resolve the repository scope
 
-Mirror `spec-to-plan/references/step-0-plan-selection.md`:
+1. **Repository root.** The repo under audit (`--scope <project_root>` for every `quire`
+   invocation later). Default to the repository the session is working in unless the user
+   names another.
+2. **Spec root.** Single-repo: `spec/`. Multi-repo: `specs/<category>/<component>/spec/`.
+3. **`org` / `component`.** Read from `spec/spec.md` frontmatter (`org`, `name`). These build
+   the `ix://<org>/<component>/<id>` URIs used in the SpecReview `relationships:`.
+4. **Test Matrix.** Look for `spec/matrix.md` first, then `spec/tests.md` (both names are in
+   use across the ecosystem). Note its frontmatter `id` (e.g. `TestMatrix-001` / `TM-001`)
+   for the `references` edge.
+5. **Requirements.** Note the requirement files under `spec/functional/`,
+   `spec/non-functional/`, `spec/usecase/`, `spec/stakeholder/` — the matrix and reverse-gap
+   steps trace against these ids.
+6. **Source / test trees.** Identify where implementation and tests live (e.g. `src/` +
+   `tests/`, or language-specific layout).
 
-1. **Named in context?** If the user passed a plan id (`Plan-002`) or one was established
-   earlier this session, use it.
-2. **Otherwise discover.** Glob `plan/*/plan.md`, read each frontmatter `id`/`title`/`status`,
-   and present the list:
+### 2. Determine the mode
 
-   ```
-   Plans available to gap-analyze:
-   - Plan-001  electron-hello core app    (active)
-   - Plan-002  packaging & distribution   (active)
-   ```
+**Planless is the default.** Do not glob `plan/`, do not present a plan menu, and do not ask
+which plan to audit. The run is plan-assisted **only** when the caller explicitly names a
+plan — `--plan Plan-001`, "gap-analyse Plan-002", or a plan established as the target earlier
+in the session.
 
-   Ask which one. One run targets **one** bundle.
+When a plan *is* supplied:
 
-### 2. Locate the spec and Test Matrix
-
-- **Spec root.** Single-repo: `spec/`. Multi-repo: `specs/<category>/<component>/spec/`.
-- **`org` / `component`.** Read from `spec/spec.md` frontmatter (`org`, `name`). These build
-  the `ix://<org>/<component>/<id>` URIs used in the SpecReview `relationships:`.
-- **Test Matrix.** Look for `spec/matrix.md` first, then `spec/tests.md` (both names are in
-  use across the ecosystem). Note its frontmatter `id` (e.g. `TestMatrix-001` / `TM-001`)
-  for the `references` edge.
-- **Requirements.** Note the requirement files under `spec/functional/`,
-  `spec/non-functional/`, `spec/usecase/`, `spec/stakeholder/` — Steps 3 and 4 trace against
-  these ids.
-- **Source / test trees.** Identify where implementation and tests live (e.g. `src/` +
-  `tests/`, or language-specific layout). Used in Steps 2–4.
+- Resolve its bundle path `plan/<Plan-id>-<slug>/` and confirm it exists. If the named plan
+  does not exist, say so and ask — do not silently fall back to planless, and do not
+  substitute a different bundle.
+- Record the `<Plan-id>` for the SpecReview `reviews` edge and the plan-completeness step.
+- **The bundle does not change anything resolved in section 1.** Scope stays the repository.
+  The requirement set stays the full spec. The code surface stays the whole source tree.
 
 ### 3. Hand off
 
 State explicitly, so later steps and the artifact agree:
 
-- target bundle path (e.g. `plan/Plan-002-packaging-distribution/`)
-- spec root, matrix path + id
+- repository root, spec root, matrix path + id
 - `ix://<org>/<component>` prefix
 - where source and tests live
+- **mode**: `planless` or `plan-assisted (<Plan-id>)`
 
 ## Notes
 
-- If there is **no** plan bundle, stop and tell the user — gap-analysis audits a plan; it
-  does not invent one (use `spec-to-plan` first).
-- If there is **no** Test Matrix, Step 2 a/Plan checks still run, but record a `high`
-  finding that the matrix is missing and Step 3 cannot verify coverage.
+- If there is **no** plan bundle, that is the normal case. Proceed planless; the SpecReview
+  will record `Plan completion: not assessed`. Never tell the user to run `spec-to-plan`
+  first, and never author a retrospective plan to make the audit possible — that reverses
+  the assurance order the skill exists to enforce.
+- If there is **no** Test Matrix, the remaining steps still run, but record a `high` finding
+  that the matrix is missing and that coverage cannot be verified. Do not create a matrix.

--- a/skills/gap-analysis/references/step-2-plan-completion.md
+++ b/skills/gap-analysis/references/step-2-plan-completion.md
@@ -1,6 +1,29 @@
-# Step 2: Plan Completion
+# Plan Completeness (OPTIONAL — explicit plan only)
 
-**Goal**: Confirm every unit of work in the targeted plan is actually finished.
+**Goal**: When — and only when — the caller explicitly supplied a plan, confirm that plan's
+bookkeeping is sound: every unit of work is finished, done work completed in dependency
+order, and `plan.md` agrees with its tasks.
+
+## Gate first
+
+**Skip this step entirely unless the caller named a plan** (`--plan Plan-001`, or an
+equivalent explicit instruction — see [target selection](step-1-target-selection.md)). The
+presence of a `plan/` directory is not an instruction. A planless run records
+`Plan completion: not assessed` in `## Coverage` and produces no finding from this step.
+
+## What this step is, and is not
+
+This is **bookkeeping on top of a completed repository audit**, not the audit itself. It may
+only add findings. It must never:
+
+- narrow the matrix, reverse-gap, stub, or semantic steps to the plan's task set;
+- suppress, downgrade, or omit a repository finding because it falls outside the plan;
+- supply the scope, the requirement set, or the code surface for any other step;
+- stand in for repository assurance — a plan whose tasks are all `done` says nothing about
+  whether the matrix is backed or the code is traced.
+
+Nor does it author: do not create or edit a plan, a `Task`, a requirement, or an acceptance
+criterion, and do not fix a status you believe is stale.
 
 ## The Task contract
 
@@ -21,21 +44,22 @@ relationships:
 ---
 ```
 
-## Process
+## The three checks
 
-1. **Enumerate tasks.** Read every `plan/<Plan-id>-<slug>/tasks/Task-*.md`.
-2. **Assert completion.** For each task, check `status`:
+1. **All tasks done.** Read every `plan/<Plan-id>-<slug>/tasks/Task-*.md` and check `status`:
    - `done` → OK.
    - `not_started` / `in_progress` / `blocked` → **finding**. Severity:
      - `high` if `priority: P0`/`P1` or it is on the critical path (`track: A`/`S`).
      - `medium` otherwise. `blocked` → note the blocker (its unmet `depends_on`).
-3. **Check dependency sanity.** Flag a `done` task whose `depends_on` target is **not**
+2. **Done-task dependency sanity.** Flag a `done` task whose `depends_on` target is **not**
    `done` (out-of-order completion) as a `medium` finding.
-4. **Cross-check `plan.md` checkboxes.** `plan.md` mirrors requirements/tests as
+3. **Task status vs plan checkbox consistency.** `plan.md` mirrors requirements/tests as
    `- [ ]` / `- [x]`. Flag (`low`) any checkbox state that contradicts task status
    (e.g. an unchecked requirement whose owning task is `done`, or vice-versa) — the plan
    doc is drifting from its tasks.
-5. **Record the rollup.** Count tasks `done` / total — feeds the SpecReview `## Coverage`.
+
+Record the rollup: tasks `done` / total — feeds the SpecReview `## Coverage` line
+`Plan completion: assessed (<Plan-id>) — tasks done X / Y`.
 
 ## Output of this step
 
@@ -47,3 +71,6 @@ the tasks-done/total count.
 
 - Do not edit task files or `plan.md` — gap-analysis only reports. If the user wants the
   plan reconciled, that's `spec-to-plan` (update flow) or `implement-plan`.
+- A plan-assisted PASS still means the repository checks passed *and* the plan's books
+  balance. The two claims stay separate in the artifact; do not merge them into one
+  sentence that implies either proves the other.

--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -1,8 +1,13 @@
-# Step 3: Test-Matrix Verification
+# Test-Matrix Verification
 
 **Goal**: Prove the Test Matrix is *real* — every Test Case it claims is backed by an actual
 test in the suite, identified by a matching **tracking tag** in the test code. This is the
 heart of gap-analysis: a matrix row marked ✅ means nothing unless a tagged test exists.
+
+**Scope: the whole repository, always.** This step runs identically in planless and
+plan-assisted mode. `--scope` is the repository root and the row set is whatever the matrix
+declares — never the subset a plan's tasks happen to touch. A supplied plan neither selects
+rows nor excuses an unbacked one.
 
 **This step no longer greps.** `quire coverage` computes the reconciliation deterministically
 and reports it; this skill interprets the report and owns the judgement. Severity and verdict
@@ -75,7 +80,7 @@ The report carries exactly the findings this step produces:
 for an untracked symbol. Do not re-derive them.
 
 Marker drift is the one judgement the report cannot make — it needs the suite to have
-actually run (step 4 below).
+actually run (see "Optionally run the suite" below).
 
 ## Two ways the report can mislead, and how to read it
 
@@ -142,6 +147,6 @@ report, the backed/total count, and which reconciliation path ran.
 ## Notes
 
 - A backed row proves *traceability*, not *correctness* — whether the test is a good test is
-  Step 4 (underspecified/stub) and Step 5 (semantic). Keep this step about presence + trace.
+  the [reverse-gap step](step-4-underspecified-code.md) and the [semantic review](step-5-semantic-review.md). Keep this step about presence + trace.
 - The command performs no network or service I/O and executes none of the code it reads
   (FR-050-CON-2, FR-051-CON-1), so it is safe to run in any repo.

--- a/skills/gap-analysis/references/step-3-matrix-verification.md
+++ b/skills/gap-analysis/references/step-3-matrix-verification.md
@@ -51,8 +51,8 @@ quire --version    # expect >= 0.16.0; on an older build the roots are not split
 If it is older, say so in `## Coverage` rather than reading the report as if the split
 applied.
 
-Do **not** pass `--strict`. Whether a gap blocks is this skill's verdict rule (Step 6), not
-the command's exit code.
+Do **not** pass `--strict`. Whether a gap blocks is this skill's verdict rule (see the
+[SpecReview artifact](step-6-specreview-artifact.md) step), not the command's exit code.
 
 The report carries exactly the findings this step produces:
 

--- a/skills/gap-analysis/references/step-4-underspecified-code.md
+++ b/skills/gap-analysis/references/step-4-underspecified-code.md
@@ -1,9 +1,14 @@
-# Step 4: Underspecified Code (reverse gap)
+# Underspecified Code (reverse gap)
 
 **Goal**: Find the *reverse* gap — code and behavior that exist with **no owning
-requirement**, plus stubs that masquerade as complete. Steps 2–3 verify spec→code/test
-coverage; this step verifies code→spec, catching scope that was implemented but never
-specified.
+requirement**, plus stubs that masquerade as complete. Matrix verification checks
+spec→code/test coverage; this step verifies code→spec, catching scope that was implemented
+but never specified.
+
+**Scope: the whole source tree, always.** This step runs identically in planless and
+plan-assisted mode. The inventory in section A is the component's real surface, not the
+surface a plan's tasks claim. Untraced behavior stays a finding whether or not any plan ever
+mentioned it — a plan bounds nothing here.
 
 This reference is the authoritative, self-contained reverse-gap procedure. Do not
 consult a private repository, user-home path, or separately installed skill for the
@@ -50,7 +55,8 @@ done:
 | Re-export-only module | structure | medium (may be intentional) |
 | Trivially-covered stub (≤5 lines @ 100% cov) | coverage + size | medium |
 
-A stub behind a `done` task or a ✅ matrix row is a `high` finding (false completion).
+A stub behind a ✅ matrix row is a `high` finding (false completion) — and likewise behind a
+`done` task, when a plan was supplied.
 
 Inspect test files as well as source. A passing test can still be a stub:
 
@@ -77,8 +83,8 @@ Treat coverage as evidence only after checking what the covered lines do:
 - A threshold dominated by imports, declarations, or re-exports does not establish that
   the promised behavior exists.
 
-Record these as `high` when they support a `done` task or ✅ matrix claim, otherwise
-`medium`. Cite both the hollow source and the test or coverage artifact.
+Record these as `high` when they support a ✅ matrix claim (or, in plan-assisted mode, a
+`done` task), otherwise `medium`. Cite both the hollow source and the test or coverage artifact.
 
 ## Output of this step
 

--- a/skills/gap-analysis/references/step-5-semantic-review.md
+++ b/skills/gap-analysis/references/step-5-semantic-review.md
@@ -1,11 +1,13 @@
-# Step 5: Semantic Review (OPTIONAL)
+# Semantic Review (OPTIONAL — opt-in)
 
 **Goal**: Go beyond presence and traceability to *meaning* — for each requirement↔test↔code
 triple, judge whether they actually agree. This is the expensive, judgment-heavy pass.
 
 ## Gate first
 
-**Do not run this step unless the user opts in.** Ask explicitly:
+**Do not run this step unless the user opts in.** Opt-in works the same way in both modes —
+a planless run can have a semantic review, and a plan-assisted run does not get one for free.
+Ask explicitly:
 
 > Run the optional semantic review (intent↔test↔code)? It's slower but verifies tests truly
 > validate requirement intent and exercise real code, and that code matches intent.
@@ -14,14 +16,14 @@ If declined, skip and note "semantic review: skipped" in the SpecReview `## Cove
 
 ## What to judge (per requirement)
 
-For each requirement (FR/US/StR) in scope, with its tagged test(s) (from Step 3) and the
-code it governs (from Step 4), assess three axes:
+For each requirement (FR/US/StR) in scope, with its tagged test(s) (from [matrix verification](step-3-matrix-verification.md)) and the
+code it governs (from the [reverse-gap step](step-4-underspecified-code.md)), assess three axes:
 
 1. **(a) Test validates intent** — does the test actually check the *behavior the
    requirement describes*, including its acceptance criteria, or only an incidental/trivial
    aspect? A test tagged `FR-007-AC-1` that asserts something unrelated to AC-1 fails here.
 2. **(b) Test exercises the code** — does the test run the real implementation, or is it
-   hollow? Reuse Step 4's **test-stub / coverage-inflation** heuristics: no assertions,
+   hollow? Reuse the reverse-gap step's **test-stub / coverage-inflation** heuristics: no assertions,
    weak-only assertions (`is not None`, `isinstance`),
    mock-everything (no real code path), import-only, circular-mock-of-a-stub.
 3. **(c) Code matches intent** — does the implementation actually do what the requirement

--- a/skills/gap-analysis/references/step-5-semantic-review.md
+++ b/skills/gap-analysis/references/step-5-semantic-review.md
@@ -16,16 +16,17 @@ If declined, skip and note "semantic review: skipped" in the SpecReview `## Cove
 
 ## What to judge (per requirement)
 
-For each requirement (FR/US/StR) in scope, with its tagged test(s) (from [matrix verification](step-3-matrix-verification.md)) and the
-code it governs (from the [reverse-gap step](step-4-underspecified-code.md)), assess three axes:
+For each requirement (FR/US/StR) in scope, with its tagged test(s) (from
+[matrix verification](step-3-matrix-verification.md)) and the code it governs (from the
+[reverse-gap step](step-4-underspecified-code.md)), assess three axes:
 
 1. **(a) Test validates intent** — does the test actually check the *behavior the
    requirement describes*, including its acceptance criteria, or only an incidental/trivial
    aspect? A test tagged `FR-007-AC-1` that asserts something unrelated to AC-1 fails here.
 2. **(b) Test exercises the code** — does the test run the real implementation, or is it
-   hollow? Reuse the reverse-gap step's **test-stub / coverage-inflation** heuristics: no assertions,
-   weak-only assertions (`is not None`, `isinstance`),
-   mock-everything (no real code path), import-only, circular-mock-of-a-stub.
+   hollow? Reuse the reverse-gap step's **test-stub / coverage-inflation** heuristics:
+   no assertions, weak-only assertions (`is not None`, `isinstance`), mock-everything
+   (no real code path), import-only, circular-mock-of-a-stub.
 3. **(c) Code matches intent** — does the implementation actually do what the requirement
    says (semantics, edge cases, error behavior), or has it drifted?
 

--- a/skills/gap-analysis/references/step-6-specreview-artifact.md
+++ b/skills/gap-analysis/references/step-6-specreview-artifact.md
@@ -1,7 +1,11 @@
-# Step 6: SpecReview Artifact
+# SpecReview Artifact
 
-**Goal**: Emit the findings from Steps 1–5 as a single **quire-validated `SpecReview`**
-document with a Verdict, at `reviews/YY-MM-DD-<slug>.md`.
+**Goal**: Emit the findings from the preceding steps as a single **quire-validated
+`SpecReview`** document with a Verdict, at `reviews/YY-MM-DD-<slug>.md`.
+
+The artifact must make the mode unambiguous. A reader who sees only this document has to be
+able to tell whether plan completion was assessed or skipped, and must not be able to read a
+planless PASS as evidence that planned work was completed.
 
 ## Render the template, then author (guardrail)
 
@@ -18,13 +22,30 @@ separately installed template.
 
 ## Frontmatter
 
+**Planless (the default).** No plan id appears anywhere in the frontmatter:
+
 ```yaml
 ---
 id: SR-001                      # ^[A-Z]{2,4}-[0-9]+$ — SR- default is fine; bump if SR-001 exists
-title: "Gap analysis — <Plan-id> <slug>"
+title: "Gap analysis — <component> repository audit"
 type: SpecReview
 analysis: gap-analysis          # the dedicated analysis value
-scope: "plan/<Plan-id>-<slug>/, spec/matrix.md"
+scope: "spec/, src/, tests/, spec/matrix.md"
+review_set: subset
+relationships:
+  - { target: "ix://<org>/<component>/<TestMatrix-id>", type: references }
+---
+```
+
+**Plan-assisted.** Identical, plus the `reviews` edge to the supplied plan:
+
+```yaml
+---
+id: SR-001
+title: "Gap analysis — <component> repository audit (with <Plan-id>)"
+type: SpecReview
+analysis: gap-analysis
+scope: "spec/, src/, tests/, spec/matrix.md, plan/<Plan-id>-<slug>/"
 review_set: subset
 relationships:
   - { target: "ix://<org>/<component>/<Plan-id>",       type: reviews }
@@ -32,8 +53,9 @@ relationships:
 ---
 ```
 
-`<org>`/`<component>` come from `spec/spec.md` (`org`, `name`); the `<Plan-id>` and
-`<TestMatrix-id>` from Step 1.
+`<org>`/`<component>` come from `spec/spec.md` (`org`, `name`); the `<TestMatrix-id>` and
+the optional `<Plan-id>` from target selection. Never emit a `reviews` edge to a plan in a
+planless run — a relationship to a plan nobody audited is a fabricated claim.
 
 ## Body
 
@@ -43,7 +65,10 @@ are extra sections (allowed).
 ```markdown
 ## Summary
 
-<1–2 sentences: what plan/matrix/code was audited and the headline result.>
+<1–2 sentences: which repository's spec, matrix, tests and code were audited, and the
+headline result. In planless mode, say the audit was repository-driven and that plan
+completion was not assessed. Do not describe the result as work being "complete" or
+"delivered as planned".>
 
 ## Verdict
 
@@ -53,18 +78,31 @@ are extra sections (allowed).
 
 | ID      | Severity | Summary                                          | Refs               |
 | ------- | -------- | ------------------------------------------------ | ------------------ |
-| FND-001 | high     | Task-007 still in_progress (P0, critical path)   | Task-007, FR-004   |
-| FND-002 | high     | Matrix TC-012 has no backing tagged test         | TC-012, FR-006     |
-| FND-003 | medium   | `cli.ts::--force` flag has no owning requirement | cli.ts::--force    |
+| FND-001 | high     | Matrix TC-012 has no backing tagged test         | TC-012, FR-006     |
+| FND-002 | medium   | `cli.ts::--force` flag has no owning requirement | cli.ts::--force    |
+| FND-003 | high     | Task-007 still in_progress (P0) — plan-assisted  | Task-007, FR-004   |
 
 ## Coverage
 
 - Reconciliation: quire coverage (module <name> <version>) | grep fallback — no active module declares a traceability model
-- Tasks done: X / Y
+- Plan completion: not assessed
 - Rows backed by a tagged test: X / Y   (from `totals`; `0 / 0` means the model matched nothing, not full coverage)
 - Untraced behaviors / stubs: N
 - Semantic review: ran over N requirements | skipped
 ```
+
+### The plan-completion line (mandatory, both modes)
+
+`## Coverage` always carries exactly one plan-completion line, and it is not optional:
+
+| Mode | Line |
+| --- | --- |
+| Planless | `Plan completion: not assessed` |
+| Plan-assisted | `Plan completion: assessed (<Plan-id>) — tasks done X / Y` |
+
+`Plan completion: not assessed` is the literal wording. Do not soften it to "n/a", "none",
+or "no plan required", and never write `Tasks done: 0 / 0` in a planless run — a zero
+denominator reads as a completed plan and asserts something nobody checked.
 
 The reconciliation line is not optional. A number from the engine and a number from a grep
 are not the same claim — grep matches a tag wherever it sits, including places the engine
@@ -79,9 +117,19 @@ will not bind it — and a reader cannot tell which they are looking at unless i
 
 ## Verdict rule
 
-- **FAIL** — any incomplete/blocked task, any unbacked matrix Test Case, or any `high` finding.
+- **FAIL** — any unbacked matrix Test Case, any `high` finding, or (plan-assisted only) any
+  incomplete/blocked task.
 - **CONDITIONAL** — only `medium`/`low` findings.
 - **PASS** — no gaps (single `No gaps found` row).
+
+### What a planless PASS means
+
+A planless PASS asserts **repository assurance only**: the matrix rows are backed by tagged
+tests, no meaningful code lacks an owning requirement, and no stub or inflated coverage
+stands behind a claim. It asserts nothing about whether the work was planned, tracked, or
+completed against a plan — that question was not asked. Keep the Summary and Verdict lines
+consistent with that, and leave `Plan completion: not assessed` visible in `## Coverage` as
+the record of what the PASS does not cover.
 
 ## Validate
 
@@ -101,8 +149,12 @@ before reporting completion. Then tell the user the artifact path and the Verdic
 
 ## Notes
 
-- File name: `reviews/<YYYY-MM-DD>-<short-slug>.md` (today's real date; slug from the plan,
-  e.g. `2026-06-22-plan-002-packaging`).
+- File name: `reviews/<YYYY-MM-DD>-<short-slug>.md` (today's real date; slug from the
+  component or area audited, e.g. `2026-06-22-observation-gap-analysis`, or from the plan in
+  plan-assisted mode, e.g. `2026-06-22-plan-002-packaging`).
 - `reviews/` is **repo root** for this skill (deliberate); validation is path-agnostic.
 - One run → one SpecReview doc (the `analysis: gap-analysis` lens), matching the one-doc-per-
   analysis model used by `quoin:spec-review`.
+- This document is the run's **only** write. Do not also create a plan, a `Task`, a
+  requirement, or an acceptance criterion to make the findings actionable — filing that work
+  is a separate, later decision.

--- a/tests/gap-analysis-skill.test.ts
+++ b/tests/gap-analysis-skill.test.ts
@@ -12,6 +12,12 @@
  * that the emitted SpecReview says which of the two it did. These are prose
  * contracts because the skill is prose — an agent eval drives the behaviour,
  * costs minutes, and cannot run on every commit.
+ *
+ * **Every assertion runs against whitespace-flattened text.** Prettier owns the
+ * line wrapping in these files, so a match anchored on a newline asserts the
+ * wrap rather than the claim: re-flowing a paragraph, or changing `proseWrap`,
+ * would fail a test whose subject did not change. Flattening keeps the coupling
+ * on the sentence.
  */
 
 import { readFileSync } from "node:fs";
@@ -23,8 +29,9 @@ import { describe, expect, it } from "vitest";
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const skillDir = join(repoRoot, "skills", "gap-analysis");
 
+/** File contents with every whitespace run collapsed to a single space. */
 const read = (...parts: string[]): string =>
-  readFileSync(join(skillDir, ...parts), "utf8");
+  readFileSync(join(skillDir, ...parts), "utf8").replace(/\s+/g, " ");
 
 const skill = read("SKILL.md");
 const targetSelection = read("references", "step-1-target-selection.md");
@@ -44,46 +51,62 @@ const all = [
   artifact,
 ];
 
+/** Raw frontmatter of the skill, which is not whitespace-flattened above. */
+const skillFrontmatter =
+  /^---\n([\s\S]*?)\n---\n/.exec(
+    readFileSync(join(skillDir, "SKILL.md"), "utf8"),
+  )?.[1] ?? "";
+
 describe("gap-analysis: planless mode is the default", () => {
   it("declares the repository audit chain, not a plan, as the subject", () => {
     expect(skill).toContain("repository assurance audit");
-    expect(skill).toMatch(
-      /spec requirements\s+↔\s+Test Matrix\s+↔\s+tagged tests\s+↔\s+source code/,
+    expect(skill).toContain(
+      "spec requirements ↔ Test Matrix ↔ tagged tests ↔ source code",
     );
     expect(skill).toContain("**Planless (the default).**");
     // The frontmatter description is what a host shows when choosing a skill;
     // if it still promised a plan audit, callers would never reach the body.
-    const description = /^---\n([\s\S]*?)\n---\n/.exec(skill)?.[1] ?? "";
-    expect(description).toMatch(/planless by default/i);
+    expect(skillFrontmatter).not.toBe("");
+    expect(skillFrontmatter).toMatch(/planless by default/i);
   });
 
-  it("requires the four repository checks without a plan", () => {
+  it("runs all four repository checks with no plan", () => {
     // Matrix traceability, reverse code-to-spec gaps, stub / coverage
-    // inflation, and the opt-in semantic review.
+    // inflation, and the opt-in semantic review. The first three are
+    // unconditional, so each is asserted with its "Always" label attached —
+    // the claim is not that the step is mentioned but that nothing gates it.
+    expect(skill).toContain(
+      "**Always — [Matrix verification](references/step-3-matrix-verification.md).**",
+    );
     expect(skill).toContain("quire coverage --scope <root> --json");
-    expect(skill).toContain("no owning");
+    expect(skill).toContain(
+      "**Always — [Underspecified code](references/step-4-underspecified-code.md).**",
+    );
+    expect(skill).toContain("code/behavior with no owning requirement");
     expect(skill).toContain("coverage inflation");
-    expect(skill).toContain("Semantic review");
-    expect(skill).toMatch(
-      /Steps 0–2 and 5 always run\. Step 3 is gated on user opt-in\./,
+    expect(skill).toContain(
+      "**Only when the user opts in — [Semantic review](references/step-5-semantic-review.md).**",
+    );
+    expect(skill).toContain(
+      "**Always — [SpecReview artifact](references/step-6-specreview-artifact.md).**",
     );
   });
 
   it("never discovers, prompts for, or auto-selects a plan", () => {
     expect(targetSelection).toContain("**Planless is the default.**");
-    expect(targetSelection).toMatch(
-      /Do not glob `plan\/`, do not present a plan menu, and do not ask\s+which plan to audit/,
+    expect(targetSelection).toContain(
+      "Do not glob `plan/`, do not present a plan menu, and do not ask which plan to audit",
     );
     expect(skill).toContain("**Never auto-select a plan.**");
     // The old instruction: "If there is no plan bundle, stop and tell the
     // user — gap-analysis audits a plan". It must not come back.
     for (const text of all) {
-      expect(text).not.toMatch(
-        /stop and tell the user — gap-analysis audits a plan/,
+      expect(text).not.toContain(
+        "stop and tell the user — gap-analysis audits a plan",
       );
     }
-    expect(targetSelection).toMatch(
-      /If there is \*\*no\*\* plan bundle, that is the normal case/,
+    expect(targetSelection).toContain(
+      "If there is **no** plan bundle, that is the normal case",
     );
   });
 
@@ -91,8 +114,8 @@ describe("gap-analysis: planless mode is the default", () => {
     expect(skill).toContain(
       "**A missing Test Matrix stays a `high` finding.**",
     );
-    expect(targetSelection).toMatch(
-      /record a `high` finding\s+that the matrix is missing/,
+    expect(targetSelection).toContain(
+      "record a `high` finding that the matrix is missing",
     );
     expect(targetSelection).toContain("Do not create a matrix.");
   });
@@ -103,11 +126,14 @@ describe("gap-analysis: an explicit plan only adds bookkeeping", () => {
     expect(planCompletion).toContain(
       "# Plan Completeness (OPTIONAL — explicit plan only)",
     );
-    expect(planCompletion).toMatch(
-      /\*\*Skip this step entirely unless the caller named a plan\*\*/,
+    expect(planCompletion).toContain(
+      "**Skip this step entirely unless the caller named a plan**",
     );
     expect(planCompletion).toContain(
-      "The\npresence of a `plan/` directory is not an instruction.",
+      "The presence of a `plan/` directory is not an instruction.",
+    );
+    expect(skill).toContain(
+      "**Only with an explicit plan — [Plan completeness](references/step-2-plan-completion.md).**",
     );
     expect(skill).toContain("`gap-analysis --plan Plan-001`");
   });
@@ -122,17 +148,17 @@ describe("gap-analysis: an explicit plan only adds bookkeeping", () => {
 
   it("forbids a plan narrowing, driving, or suppressing the audit", () => {
     expect(skill).toContain("A plan is an *addition*, never a lens.");
-    expect(planCompletion).toMatch(
-      /narrow the matrix, reverse-gap, stub, or semantic steps to the plan's task set/,
+    expect(planCompletion).toContain(
+      "narrow the matrix, reverse-gap, stub, or semantic steps to the plan's task set",
     );
-    expect(planCompletion).toMatch(
-      /suppress, downgrade, or omit a repository finding because it falls outside the plan/,
+    expect(planCompletion).toContain(
+      "suppress, downgrade, or omit a repository finding because it falls outside the plan",
     );
     // Each repository step restates its own scope, because a step is read in
     // isolation by a subagent that never saw SKILL.md.
     expect(matrix).toContain("**Scope: the whole repository, always.**");
     expect(reverseGap).toContain("**Scope: the whole source tree, always.**");
-    expect(semantic).toMatch(/Opt-in works the same way in both modes/);
+    expect(semantic).toContain("Opt-in works the same way in both modes");
   });
 });
 
@@ -145,32 +171,37 @@ describe("gap-analysis: the SpecReview states what it assessed", () => {
     expect(artifact).toContain(
       "| Plan-assisted | `Plan completion: assessed (<Plan-id>) — tasks done X / Y` |",
     );
-    expect(artifact).toMatch(
-      /`Plan completion: not assessed` is the literal wording/,
+    expect(artifact).toContain(
+      "`Plan completion: not assessed` is the literal wording",
     );
-    expect(artifact).toMatch(
-      /never write `Tasks done: 0 \/ 0` in a planless run/,
+    // A zero denominator reads as a completed plan, which is the exact
+    // overclaim #365 exists to prevent.
+    expect(artifact).toContain(
+      "never write `Tasks done: 0 / 0` in a planless run",
     );
   });
 
   it("emits no plan relationship in a planless run", () => {
-    expect(artifact).toMatch(
-      /Never emit a `reviews` edge to a plan in a\s+planless run/,
+    expect(artifact).toContain(
+      "Never emit a `reviews` edge to a plan in a planless run",
     );
   });
 
   it("keeps planless PASS from claiming planned work was completed", () => {
     expect(skill).toContain("**A planless PASS is a repository claim only.**");
     expect(artifact).toContain("### What a planless PASS means");
-    expect(artifact).toMatch(
-      /asserts nothing about whether the work was planned, tracked, or\s+completed against a plan/,
+    expect(artifact).toContain(
+      "asserts nothing about whether the work was planned, tracked, or completed against a plan",
     );
   });
 
   it("makes incomplete tasks a FAIL only in plan-assisted mode", () => {
+    // Both verdict rules — SKILL.md's and the artifact step's — must carry the
+    // qualifier. An unqualified copy is how a planless run starts failing on a
+    // plan it was never given.
     for (const text of [skill, artifact]) {
-      expect(text).toMatch(
-        /\(plan-assisted only\)\s+any\s+incomplete\/blocked task|\(plan-assisted only\) any\s+incomplete\/blocked task/,
+      expect(text).toContain(
+        "(plan-assisted only) any incomplete/blocked task",
       );
     }
   });
@@ -179,15 +210,15 @@ describe("gap-analysis: the SpecReview states what it assessed", () => {
 describe("gap-analysis: authors nothing", () => {
   it("forbids creating a plan, Task, requirement, or acceptance criterion", () => {
     expect(skill).toContain("**Never author.**");
-    expect(skill).toMatch(
-      /does not create or edit a plan, a `Task`, a\s+requirement, or an acceptance criterion/,
+    expect(skill).toContain(
+      "does not create or edit a plan, a `Task`, a requirement, or an acceptance criterion",
     );
     expect(skill).toContain(
       "**Never manufacture a plan to satisfy the audit.**",
     );
-    expect(artifact).toMatch(/This document is the run's \*\*only\*\* write\./);
-    expect(planCompletion).toMatch(
-      /do not create or edit a plan, a `Task`, a requirement, or an acceptance\s+criterion/,
+    expect(artifact).toContain("This document is the run's **only** write.");
+    expect(planCompletion).toContain(
+      "do not create or edit a plan, a `Task`, a requirement, or an acceptance criterion",
     );
   });
 });

--- a/tests/gap-analysis-skill.test.ts
+++ b/tests/gap-analysis-skill.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Gap analysis is planless by default (agent-ix/quoin#365).
+ *
+ * The skill used to target a plan bundle: target selection globbed `plan/*`,
+ * asked which one, and stopped when there was none — so a repository whose work
+ * predated planning could not be audited at all without first manufacturing a
+ * retrospective plan. That reverses the assurance order the skill exists to
+ * enforce, and turns a repository check into bookkeeping.
+ *
+ * What is asserted here is the part that silently drifts: that the default path
+ * is repository-driven, that a plan may only ADD completion bookkeeping, and
+ * that the emitted SpecReview says which of the two it did. These are prose
+ * contracts because the skill is prose — an agent eval drives the behaviour,
+ * costs minutes, and cannot run on every commit.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const skillDir = join(repoRoot, "skills", "gap-analysis");
+
+const read = (...parts: string[]): string =>
+  readFileSync(join(skillDir, ...parts), "utf8");
+
+const skill = read("SKILL.md");
+const targetSelection = read("references", "step-1-target-selection.md");
+const planCompletion = read("references", "step-2-plan-completion.md");
+const matrix = read("references", "step-3-matrix-verification.md");
+const reverseGap = read("references", "step-4-underspecified-code.md");
+const semantic = read("references", "step-5-semantic-review.md");
+const artifact = read("references", "step-6-specreview-artifact.md");
+
+const all = [
+  skill,
+  targetSelection,
+  planCompletion,
+  matrix,
+  reverseGap,
+  semantic,
+  artifact,
+];
+
+describe("gap-analysis: planless mode is the default", () => {
+  it("declares the repository audit chain, not a plan, as the subject", () => {
+    expect(skill).toContain("repository assurance audit");
+    expect(skill).toMatch(
+      /spec requirements\s+↔\s+Test Matrix\s+↔\s+tagged tests\s+↔\s+source code/,
+    );
+    expect(skill).toContain("**Planless (the default).**");
+    // The frontmatter description is what a host shows when choosing a skill;
+    // if it still promised a plan audit, callers would never reach the body.
+    const description = /^---\n([\s\S]*?)\n---\n/.exec(skill)?.[1] ?? "";
+    expect(description).toMatch(/planless by default/i);
+  });
+
+  it("requires the four repository checks without a plan", () => {
+    // Matrix traceability, reverse code-to-spec gaps, stub / coverage
+    // inflation, and the opt-in semantic review.
+    expect(skill).toContain("quire coverage --scope <root> --json");
+    expect(skill).toContain("no owning");
+    expect(skill).toContain("coverage inflation");
+    expect(skill).toContain("Semantic review");
+    expect(skill).toMatch(
+      /Steps 0–2 and 5 always run\. Step 3 is gated on user opt-in\./,
+    );
+  });
+
+  it("never discovers, prompts for, or auto-selects a plan", () => {
+    expect(targetSelection).toContain("**Planless is the default.**");
+    expect(targetSelection).toMatch(
+      /Do not glob `plan\/`, do not present a plan menu, and do not ask\s+which plan to audit/,
+    );
+    expect(skill).toContain("**Never auto-select a plan.**");
+    // The old instruction: "If there is no plan bundle, stop and tell the
+    // user — gap-analysis audits a plan". It must not come back.
+    for (const text of all) {
+      expect(text).not.toMatch(
+        /stop and tell the user — gap-analysis audits a plan/,
+      );
+    }
+    expect(targetSelection).toMatch(
+      /If there is \*\*no\*\* plan bundle, that is the normal case/,
+    );
+  });
+
+  it("keeps a missing Test Matrix a high finding rather than an excuse", () => {
+    expect(skill).toContain(
+      "**A missing Test Matrix stays a `high` finding.**",
+    );
+    expect(targetSelection).toMatch(
+      /record a `high` finding\s+that the matrix is missing/,
+    );
+    expect(targetSelection).toContain("Do not create a matrix.");
+  });
+});
+
+describe("gap-analysis: an explicit plan only adds bookkeeping", () => {
+  it("gates the plan-completeness step on an explicit instruction", () => {
+    expect(planCompletion).toContain(
+      "# Plan Completeness (OPTIONAL — explicit plan only)",
+    );
+    expect(planCompletion).toMatch(
+      /\*\*Skip this step entirely unless the caller named a plan\*\*/,
+    );
+    expect(planCompletion).toContain(
+      "The\npresence of a `plan/` directory is not an instruction.",
+    );
+    expect(skill).toContain("`gap-analysis --plan Plan-001`");
+  });
+
+  it("carries exactly the three plan-completeness checks", () => {
+    expect(planCompletion).toContain("**All tasks done.**");
+    expect(planCompletion).toContain("**Done-task dependency sanity.**");
+    expect(planCompletion).toContain(
+      "**Task status vs plan checkbox consistency.**",
+    );
+  });
+
+  it("forbids a plan narrowing, driving, or suppressing the audit", () => {
+    expect(skill).toContain("A plan is an *addition*, never a lens.");
+    expect(planCompletion).toMatch(
+      /narrow the matrix, reverse-gap, stub, or semantic steps to the plan's task set/,
+    );
+    expect(planCompletion).toMatch(
+      /suppress, downgrade, or omit a repository finding because it falls outside the plan/,
+    );
+    // Each repository step restates its own scope, because a step is read in
+    // isolation by a subagent that never saw SKILL.md.
+    expect(matrix).toContain("**Scope: the whole repository, always.**");
+    expect(reverseGap).toContain("**Scope: the whole source tree, always.**");
+    expect(semantic).toMatch(/Opt-in works the same way in both modes/);
+  });
+});
+
+describe("gap-analysis: the SpecReview states what it assessed", () => {
+  it("mandates the literal planless plan-completion line", () => {
+    expect(skill).toContain("Plan completion: not assessed");
+    expect(artifact).toContain(
+      "| Planless | `Plan completion: not assessed` |",
+    );
+    expect(artifact).toContain(
+      "| Plan-assisted | `Plan completion: assessed (<Plan-id>) — tasks done X / Y` |",
+    );
+    expect(artifact).toMatch(
+      /`Plan completion: not assessed` is the literal wording/,
+    );
+    expect(artifact).toMatch(
+      /never write `Tasks done: 0 \/ 0` in a planless run/,
+    );
+  });
+
+  it("emits no plan relationship in a planless run", () => {
+    expect(artifact).toMatch(
+      /Never emit a `reviews` edge to a plan in a\s+planless run/,
+    );
+  });
+
+  it("keeps planless PASS from claiming planned work was completed", () => {
+    expect(skill).toContain("**A planless PASS is a repository claim only.**");
+    expect(artifact).toContain("### What a planless PASS means");
+    expect(artifact).toMatch(
+      /asserts nothing about whether the work was planned, tracked, or\s+completed against a plan/,
+    );
+  });
+
+  it("makes incomplete tasks a FAIL only in plan-assisted mode", () => {
+    for (const text of [skill, artifact]) {
+      expect(text).toMatch(
+        /\(plan-assisted only\)\s+any\s+incomplete\/blocked task|\(plan-assisted only\) any\s+incomplete\/blocked task/,
+      );
+    }
+  });
+});
+
+describe("gap-analysis: authors nothing", () => {
+  it("forbids creating a plan, Task, requirement, or acceptance criterion", () => {
+    expect(skill).toContain("**Never author.**");
+    expect(skill).toMatch(
+      /does not create or edit a plan, a `Task`, a\s+requirement, or an acceptance criterion/,
+    );
+    expect(skill).toContain(
+      "**Never manufacture a plan to satisfy the audit.**",
+    );
+    expect(artifact).toMatch(/This document is the run's \*\*only\*\* write\./);
+    expect(planCompletion).toMatch(
+      /do not create or edit a plan, a `Task`, a requirement, or an acceptance\s+criterion/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #365.

## What changed

Gap analysis targeted a plan bundle: target selection globbed `plan/*`, asked which one, and stopped when there was none. A repository whose work predated planning — quire-observation — could not be audited without first manufacturing a retrospective plan, which reverses the assurance order and turns a repository check into bookkeeping.

The audit is now repository-driven in both modes:

```
spec requirements <-> Test Matrix <-> tagged tests <-> source code
```

**Planless (default).** Matrix traceability, reverse code-to-spec gaps, stub and coverage-inflation checks, and the opt-in semantic review all run with no plan. The SpecReview records the literal line `Plan completion: not assessed` — never `Tasks done: 0 / 0` (a zero denominator reads as a completed plan), and never a `reviews` edge to a plan nobody audited.

**Plan-assisted (`--plan Plan-001`).** Adds only completion bookkeeping: all tasks done, done-task dependency sanity, and task-status vs `plan.md` checkbox consistency. A plan is an addition, never a lens — it cannot narrow the requirement set, bound the code surface, or suppress a finding for sitting outside its tasks. The matrix and reverse-gap references each restate their own scope, because a step is read in isolation by a subagent that never saw `SKILL.md`.

**Verdict semantics.** A planless PASS asserts repository assurance only — it never claims historical work was planned or completed. Incomplete tasks are a FAIL in plan-assisted mode only. A missing Test Matrix remains a `high` finding, and the run authors no plan, Task, requirement, or acceptance criterion.

Reference headings lost their stale step numbers (the order changed); filenames are unchanged, since `spec-correctness` and past reviews cite them by path.

## Coverage

`tests/gap-analysis-skill.test.ts` — 12 assertions across both modes: planless defaults, no plan discovery/auto-selection, the three plan-completeness checks, the non-narrowing guarantees, the mandatory plan-completion line, and the authors-nothing guardrail. All 12 fail against the pre-change skill.

## Gates

- `make lint` — clean.
- Full suite — 1181/1181 passing (105 files), run as `make test-with-quire`'s inner target with quire 0.31.0.
- `make test` and `make validate` fail on **pre-existing** repo state unrelated to this change: the quire evidence-overlay relock, and a duplicate heading in `spec/assurance/AP-201-finding-quality.md`. Both reproduce on a clean tree with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnyTBL852zcrrrubLkxqoJ