### PR TITLE
fix: emit and enforce one Status column

### DIFF
--- a/default-modules.yaml
+++ b/default-modules.yaml
@@ -44,13 +44,13 @@ entries:
       ref: v0.5.0
 
   - name: spec-artifacts-process
-    version: "0.24.0+d605caa"
+    version: "0.24.0+375fc2a"
     defaultEnabled: true
     source:
       type: git-subdir
       url: agent-ix/spec-artifacts-process
       path: spec_artifacts_process
-      ref: d605caad70a8c09884ef22525d532e01330f763f
+      ref: 375fc2a9c49c37cce0f43384878b8ede16b162a3
 
   - name: spec-objects-business
     version: "0.6.0"

--- a/skills/spec-matrix/assets/test-matrix-example.md
+++ b/skills/spec-matrix/assets/test-matrix-example.md
@@ -14,14 +14,14 @@ This is an example test matrix demonstrating comprehensive test coverage for the
 ## Requirements Traceability
 
 ### User Story Coverage
-| User Story | Acceptance Criteria | Test Cases | Coverage Status |
+| User Story | Acceptance Criteria | Test Cases | Status |
 |------------|---------------------|------------|-----------------|
 | US-001 | US-001-AC-1 | TC-001, TC-002, TC-003 | ✅ Complete |
 | US-001 | US-001-AC-2 | TC-004, TC-005 | ✅ Complete |
 | US-001 | US-001-AC-3 | TC-006, TC-007, TC-008 | ✅ Complete |
 
 ### Functional Requirement Coverage
-| Functional Req | Acceptance Criteria | Test Cases | Coverage Status |
+| Functional Req | Acceptance Criteria | Test Cases | Status |
 |----------------|---------------------|------------|-----------------|
 | FR-001 | FR-001-AC-1 | TC-001 | ✅ Complete |
 | FR-001 | FR-001-AC-2 | TC-002 | ✅ Complete |

--- a/skills/spec-matrix/assets/test-matrix-template.md
+++ b/skills/spec-matrix/assets/test-matrix-template.md
@@ -14,18 +14,18 @@ This matrix ensures comprehensive test coverage by transforming requirements int
 ## Requirements Traceability
 
 ### Stakeholder Requirement Coverage
-| Stakeholder Req | Trace to US/FR | Test/Validation | Coverage Status |
+| Stakeholder Req | Trace to US/FR | Test/Validation | Status |
 |-----------------|----------------|-----------------|-----------------|
 | StR-XXX | US-XXX, FR-XXX | Review | ✅ Complete |
 
 ### User Story Coverage
-| User Story | Acceptance Criteria | Test Cases | Coverage Status |
+| User Story | Acceptance Criteria | Test Cases | Status |
 |------------|---------------------|------------|-----------------|
 | US-XXX | US-XXX-AC-1 | TC-001, TC-002 | ✅ Complete |
 | US-XXX | US-XXX-AC-2 | TC-003 | ✅ Complete |
 
 ### Functional Requirement Coverage
-| Functional Req | Acceptance Criteria | Test Cases | Coverage Status |
+| Functional Req | Acceptance Criteria | Test Cases | Status |
 |----------------|---------------------|------------|-----------------|
 | FR-XXX | FR-XXX-AC-1 | TC-004, TC-005 | ✅ Complete |
 

--- a/spec/evals.md
+++ b/spec/evals.md
@@ -83,7 +83,7 @@ carry a story out end to end, not whether a unit behaves. The archetype's column
 is named `Functional Req`; the ids below are the US ids each scenario drives.
 Per-FR coverage lives in TM-001 (`spec/matrix.md`).
 
-| Functional Req | Acceptance Criteria | Test Cases | Coverage Status |
+| Functional Req | Acceptance Criteria | Test Cases | Status |
 | --- | --- | --- | --- |
 | US-001 | US-001-AC-1 | TC-EV-001, TC-EV-006, TC-EV-014, TC-EV-015, TC-EV-016, TC-EV-017, TC-EV-018, TC-EV-021, TC-EV-022, TC-EV-024, TC-EV-025, TC-EV-040, TC-EV-042 | ✅ Covered |
 | US-002 | US-002-AC-1 | TC-EV-002, TC-EV-007, TC-EV-011, TC-EV-014, TC-EV-017, TC-EV-023 | ✅ Covered |

--- a/spec/matrix.md
+++ b/spec/matrix.md
@@ -178,7 +178,7 @@ cannot hold, and are kept for that reason.
 Criteria absent here are verified by a method that produces no test — see
 "Tracking-tag coverage".
 
-| Functional Req | Acceptance Criteria | Test Cases | Coverage Status |
+| Functional Req | Acceptance Criteria | Test Cases | Status |
 | --- | --- | --- | --- |
 | FR-001 | FR-001-AC-1, FR-001-AC-2, FR-001-AC-3, FR-001-AC-4 | TC-001, TC-002, TC-003, TC-004 | ✅ Covered |
 | FR-002 | FR-002-AC-1, FR-002-AC-2, FR-002-AC-3, FR-002-AC-4 | TC-005, TC-006, TC-007, TC-008 | ✅ Covered |
@@ -1127,12 +1127,12 @@ inspection rather than by a unit test — so these rows carry no tracking tag by
 design (see "Tracking-tag coverage"). Added in response to SR-003 FND-002, which
 found the stakeholder layer had no rows here at all.
 
-| Stakeholder Req | Trace to US/FR         | Test/Validation                                                                                       | Coverage Status |
+| Stakeholder Req | Trace to US/FR         | Test/Validation                                                                                       | Status |
 | --------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- | --------------- |
 | StR-001-VC-1    | US-009; FR-004, FR-023 | Demonstration — TC-EV-001…TC-EV-013 run the real CLI from an isolated `IX_HOME`; NFR-004 inspects the deps    | ✅ Covered      |
 | StR-002-VC-1    | US-003; FR-018, FR-019 | Demonstration — TC-EV-003/TC-EV-009/TC-EV-010/TC-EV-020 install from local, GitHub and subdir sources              | ✅ Covered      |
 | StR-003-VC-1    | US-004; FR-014, FR-015 | Demonstration — TC-EV-001/TC-EV-004/TC-EV-008 author to the skeleton and validate with a real `quire`           | ✅ Covered      |
-| StR-004-VC-1    | US-005; FR-020, FR-021 | Inspection — TC-EV-005/TC-EV-013 start runs and inspect status; resume/advance/gate progression is untested  | ⚠️ Partial      |
+| StR-004-VC-1    | US-005; FR-020, FR-021 | Inspection — TC-EV-005/TC-EV-013 start runs and inspect status; resume/advance/gate progression is untested  | 🚧 progression untested |
 | StR-005-VC-1    | US-003; FR-016, FR-017 | Inspection — the default set is version-pinned; NFR-001 covers idempotent offline reconcile            | ✅ Covered      |
 | StR-006-VC-1    | US-009; FR-022         | Demonstration — `update.test.ts` covers delegation, `--check` and `--registry`                          | ✅ Covered      |
 | StR-008-VC-1    | US-021; FR-076, FR-083 | Demonstration — a variant rendered with no hand editing carries the `semantic` block, emitted schemas, typed skeletons, and a fail-not-skip suite (TC-1400..TC-1402, TC-1408, TC-1417, TC-1420, TC-1427) | ✅ Covered |

--- a/src/measurement/tool-defects.ts
+++ b/src/measurement/tool-defects.ts
@@ -130,7 +130,7 @@ export const LEDGER: readonly LedgerEntry[] = [
     covers: (p) => p.endsWith("tests.md"),
     blocks: ["status-lie"],
     summary:
-      "`traceability.status.column` names `Status` while the coverage tables assert `Coverage Status`, so the complete-but-unbacked check has never run. Any existing 'no status lies' claim is unmeasured, not clean.",
+      "`traceability.status.column` named `Status` while the coverage tables asserted `Coverage Status`, so the complete-but-unbacked check never ran. Fixed in the contract by spec-artifacts-process#87 (375fc2a), which collapsed the two names. The entry stays because the fix is per-repository: the check still does not run on any tests.md that has not renamed its header, and a 'no status lies' claim from one of those is unmeasured, not clean.",
   },
   {
     id: "artifact-module-install-refused",

--- a/templates/semantic-module/{{cookiecutter.repo_name}}/spec/matrix.md
+++ b/templates/semantic-module/{{cookiecutter.repo_name}}/spec/matrix.md
@@ -65,7 +65,7 @@ construction.
 
 ## Functional Requirement Coverage
 
-| Functional Req | Acceptance Criteria | Test Cases | Coverage Status |
+| Functional Req | Acceptance Criteria | Test Cases | Status |
 | --- | --- | --- | --- |
 | FR-001 | FR-001-AC-1..9 | TC-001..TC-009 | ✅ Covered |
 | FR-002 | FR-002-AC-1..8 | TC-010..TC-017 | ✅ Covered |
@@ -74,7 +74,7 @@ construction.
 
 ## Stakeholder Requirement Coverage
 
-| Stakeholder Req | Trace to US/FR | Test/Validation | Coverage Status |
+| Stakeholder Req | Trace to US/FR | Test/Validation | Status |
 | --- | --- | --- | --- |
 | StR-001-VC-1 | US-001; FR-001 | TC-005, TC-006, TC-007 | ✅ Covered |
 | StR-001-VC-2 | US-001; FR-003 | TC-026 | ✅ Covered |

--- a/tests/skills-vocab-drift.test.ts
+++ b/tests/skills-vocab-drift.test.ts
@@ -129,6 +129,38 @@ function skillMarkersList(): Set<string> {
   return markersIn(section?.[1] ?? "");
 }
 
+/** The status column name the manifest configures. */
+function configuredStatusColumn(): string {
+  const traceability = manifest.traceability as
+    Record<string, unknown> | undefined;
+  const status = traceability?.status as Record<string, unknown> | undefined;
+  const column = status?.column;
+  expect(
+    typeof column === "string" && column.length > 0,
+    "the manifest declares no traceability.status.column",
+  ).toBe(true);
+  return String(column);
+}
+
+/** Every markdown table header cell in `text` that names a status column. */
+function statusColumnNames(text: string): Set<string> {
+  const names = new Set<string>();
+  let inTable = false;
+  for (const line of text.split("\n")) {
+    if (!line.trimStart().startsWith("|")) {
+      inTable = false;
+      continue;
+    }
+    if (/^[-\s:|]+$/.test(line.trim())) continue; // separator
+    if (inTable) continue; // body row of a table already seen
+    inTable = true;
+    for (const cell of line.split("|").map((c) => c.trim())) {
+      if (/status/i.test(cell)) names.add(cell);
+    }
+  }
+  return names;
+}
+
 describe("TC-271 the spec-matrix vocabulary cannot drift from the module manifest", () => {
   // TC-271
   it("SKILL.md's declared Status vocabulary equals the manifest's classed set", () => {
@@ -180,6 +212,30 @@ describe("TC-271 the spec-matrix vocabulary cannot drift from the module manifes
       expect(cell, "the retired concept returned as a note word").not.toMatch(
         /partial/i,
       );
+    }
+  });
+  // TC-271
+  it("every taught status column is named exactly as the manifest configures", () => {
+    // #177 gated MARKERS only, so a stale column NAME sailed through: the
+    // contract declared `Coverage Status` on the coverage tables and
+    // `Status` on the summaries with byte-identical vocabularies, and the
+    // single global selector matched only the latter. Status classification
+    // was skipped on every table it missed, and `status_lies` came back
+    // empty because nothing ran rather than because the rows were honest.
+    // `statusCells` above cannot see that: it keys on a header cell equal to
+    // `Status`, so a differently-named column is silently not checked.
+    const configured = configuredStatusColumn();
+    for (const [label, text] of [
+      ["SKILL.md", skillMd],
+      ["the template", templateMd],
+      ["the example", exampleMd],
+    ] as const) {
+      for (const name of statusColumnNames(text)) {
+        expect(
+          name,
+          `${label} names a status column \`${name}\`, but the manifest configures \`${configured}\``,
+        ).toBe(configured);
+      }
     }
   });
 });


### PR DESCRIPTION
Closes #370.

The TestMatrix contract collapsed `Coverage Status` and `Status` into a single `Status` column (spec-artifacts-process#87, `375fc2a`). The two names carried byte-identical vocabularies and were applied inconsistently across sibling coverage tables, so the single global selector matched only some of them and **status classification was silently skipped on the rest** — after which `status_lies` was empty because nothing ran, not because the rows were honest.

quoin propagated that two ways: it **generated** the old header and it **accepted** it.

## Changes

**Root cause first** — `default-modules.yaml` pinned the module at `d605caa`, which still carries the old name. Bumped to `375fc2a`. Until this moved, validation accepted the old header and a corrected template would have failed CI.

**The generators.** No module ships a TestMatrix skeleton, so the entire authoring surface is the `spec-matrix` assets plus the cookiecutter:

| File | |
| --- | --- |
| `skills/spec-matrix/assets/test-matrix-template.md` | already inconsistent — taught `Status` on two tables, `Coverage Status` on three |
| `skills/spec-matrix/assets/test-matrix-example.md` | |
| `templates/semantic-module/{{cookiecutter.repo_name}}/spec/matrix.md` | **every new semantic-module repo was born with the defect** |

**quoin's own matrices** — `spec/matrix.md:181,1130`, `spec/evals.md:86`. Renaming makes classification run on them for the first time:

```
status-column-matches-nothing   2 → 0
status_lies                     9 → 43   (+34 newly visible)
totals / unbacked               unchanged (1029/1874, 323)
```

The 34 rows were always wrong; the check never ran. **They are not reconciled here** — no status is promoted.

**A landmine handled.** `spec/matrix.md:1135` held `⚠️ Partial` — retired by CR-031 and admitted by no vocabulary. Once the header matched it would have become a fresh validation failure. It is now `🚧` carrying the gap its own note already states ("resume/advance/gate progression is untested"), avoiding the retired concept returning as a note word per #177. The remaining ten `⚠️` cells sit in a `Coverage` column and are unaffected — verified.

## The guard that should have caught this

`tests/skills-vocab-drift.test.ts` (TC-271) already coupled the skill and assets to the installed manifest, but gated **markers only**. Its `statusCells` helper keys on a header cell equal to `Status`, so a table headed `Coverage Status` was skipped and never checked — a stale column *name* was invisible to the test written to stop vocabulary drift.

It now asserts every taught status column is named exactly as the manifest configures. **Verified red before green:**

```
AssertionError: the template names a status column `Coverage Status`,
but the manifest configures `Status`
```

## The ledger entry is updated, not removed

`src/measurement/tool-defects.ts` `status-lie-check-never-ran` (#81) stays. The contract is fixed, but the fix is **per-repository**: the check still does not run on any `tests.md` that has not renamed its header. Removing the entry would claim a measurability that does not exist for unswept repos.

## Not touched

- `corpus/` — a submodule. `corpus/cases/minting/status-column-mismatch/` is `kind: failure` with a required finding; its `Coverage Status` header is the deliberately-wrong input proving the engine reports the fault, and the collapse makes it *more* correct. Editing it would delete the regression test for quire-rs#341.
- `corpus/modules/ecosystem/` — SHA-pinned vendored manifests with a documented refresh ritual; its own reviewed event in its own repo. **Still pinned pre-collapse at `995288d`** — flagged below.
- `spec/evidence/measurements/*.json`, `bench/*.json` — re-measured, never edited.
- No consumer repos swept.

## Verification

- `make lint` clean (typecheck + eslint + prettier)
- `npx vitest run` — **105 files, 1182 tests, 0 failures**
- Cookiecutter now emits `| … | Status |` on all three tables
- `make test` (verification-stack) not run: it requires a `quire-rs` checkout at `/home/peter/dev/worktrees/quire-rs` that is absent here — an environment prerequisite, unrelated to this change

## Loose thread

`qa-corpus` still vendors `spec-artifacts-process` at `995288d`, pre-collapse, so quoin's corpus cases validate against the old two-name contract until refreshed per `VENDORED.md`. Separate repo, separate reviewed event — not done here, flagged so it is not found later as a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY