### PR TITLE
fix(spec): AP-201 had two '## Impact Scenarios' headings

### DIFF
--- a/spec/assurance/AP-201-finding-quality.md
+++ b/spec/assurance/AP-201-finding-quality.md
@@ -31,7 +31,7 @@ This profile governs Quoin's quality benchmark, measurement store, comparison
 rules, gates, and deterministic report views. It does not make `/gap-analysis`
 or any agent review a universal executable gate.
 
-## Impact Scenarios
+## Applicability
 
 Apply it across development, review, release, and maintenance, whenever code
 changes what is collected, scored, persisted, compared, or rendered. These


### PR DESCRIPTION
One heading rename. `make validate` gates `make test` (`Makefile:49`), and this has been red on `main` since `7072d65` landed on 2026-09-07.

```
spec/assurance/AP-201-finding-quality.md: line 43:
  duplicate heading 'Impact Scenarios' at level 2 [duplicate-heading]
```

## The two sections are not duplicates, and only the second is correctly named

- **`:34`** — applicability and required review: *"Apply it across development, review, release, and maintenance… Required review covers the evidence, integrity, and scope-boundary analyses."*
- **`:43`** — the real one: *"The material scenario is `concealed-measurement-gap`…"*

So the first is **renamed**, not merged or deleted.

## It also repairs a silent extraction defect

The `AssuranceProfile` archetype pulls `impacts` from `after_heading: Impact Scenarios` (engineering-assurance manifest). With two such headings the profile was yielding the **applicability prose** as its impact scenario and ignoring `concealed-measurement-gap` entirely. The duplicate-heading error is the visible half of that; this is the half nothing reported.

`## Applicability` is not one of the archetype's four extracted headings (Decision Boundary, Evidence Policy, Exceptions, Impact Scenarios), and does not need to be — the archetype admits others and this document already carries five: Assurance Concerns, Selected Practices, Measurement Ownership, Normalized Finding Envelope, Tool Reliance and Independence.

## Three more failures remain on main, and they are one problem

This unblocks one of four. `quire validate "spec/**/*.md"` on clean `origin/main` reports **three documents failing**:

| | |
|---|---|
| `spec/assurance/AP-201-finding-quality.md:43` | duplicate heading — **this PR** |
| `spec/evals.md:79` | `functional_coverage` columns are `[…, Status]`, asserted `[…, Coverage Status]` |
| `spec/matrix.md:171` | same |
| `spec/matrix.md:1123` | `stakeholder_coverage`, same shape |

The remaining three are one defect: **no table in `spec/matrix.md` uses `Coverage Status` at all** — `grep -c "| Coverage Status |"` returns zero. The installed module *and* upstream `spec-artifacts-process` both assert `Coverage Status` (`manifest.yaml:251,304`), so this is not a stale pin — the repository's matrix diverged from the column contract it declares against.

Not fixed here: renaming a column across every functional and stakeholder coverage table is a separate change with its own blast radius, and it interacts with the matrix rows [#414](https://github.com/agent-ix/quoin/pull/414) is adding.

Related: [#350](https://github.com/agent-ix/quoin/issues/350). Noted there that `7072d65` has now produced two defects consistent with its gates not having been run — this heading, and a lock digest describing bytes that never existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY