### PR TITLE
feat(097): generate src/core/types.ts from the Rust boundary types, hash-asserted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,22 @@ rust-e2e: rust-build
 # The Rust gate, in the order a failure is cheapest to read: format and lint
 # first (seconds), then the supply-chain check, then the suites, then the
 # cross-language comparison that needs both trees built.
+# FR-097: `src/core/types.ts` is GENERATED from the Rust boundary types, never
+# hand-written. This target is the only thing that may write it, and it rewrites
+# the two digests in `quoin-schemas/src/lib.rs` in the same run — the artefact
+# and the assertion about it cannot be updated apart. `scripts/refresh-quire-
+# schemas.mjs` does the same for the vendored quire schemas; this is that
+# pattern with a `schemars` render in place of a pinned git object.
+#
+# The assertion is NOT in this recipe. It is in `quoin-schemas`' tests, so a
+# generated file that disagrees with the Rust types fails `make rust-gate`
+# whether or not anyone thought to run `make types` first.
+.PHONY: types
+types:
+	cd $(RUST_DIR) && cargo run --locked $(CARGO_TARGET_FLAG) \
+	  --bin quoin-schemas-gen -- --repo $(CURDIR)
+	$(PNPM) exec prettier --write $(CURDIR)/src/core/types.ts
+
 .PHONY: rust-gate
 rust-gate: rust-lint rust-deny rust-test rust-e2e rust-difftest
 	@echo "rust-gate: fmt, clippy -D warnings, cargo deny, tests, the end-to-end caller and the differential harness passed"
@@ -470,6 +486,7 @@ help:
 	@echo "Common targets:"
 	@echo "  make build              - Build TypeScript"
 	@echo "  make rust-gate          - Rust fmt, clippy, deny, tests and difftest"
+	@echo "  make types              - regenerate src/core/types.ts from the Rust types"
 	@echo "  make test               - Run the exact-source canonical verification stack"
 	@echo "  make test-with-quire QUIRE=/absolute/path - Run the explicit inner test gate"
 	@echo "  make lint               - Run linter"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,10 +3,76 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "memchr"
@@ -27,7 +93,7 @@ dependencies = [
 name = "quoin-core"
 version = "0.1.0"
 dependencies = [
- "quoin-schemas",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -44,6 +110,12 @@ dependencies = [
 [[package]]
 name = "quoin-schemas"
 version = "0.1.0"
+dependencies = [
+ "quoin-core",
+ "schemars",
+ "serde_json",
+ "sha2",
+]
 
 [[package]]
 name = "quote"
@@ -52,6 +124,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -85,6 +202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +223,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -129,10 +268,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,7 +56,25 @@ publish = false
 quoin-core = { path = "crates/quoin-core" }
 quoin-schemas = { path = "crates/quoin-schemas" }
 serde = { version = "=1.0.228", features = ["derive"] }
+# FR-097: the JSON Schema the generated TypeScript surface is derived from.
+# Exact pin for the same reason as every other line here — the generated file
+# is hash-asserted, so the generator's version is part of the contract and a
+# caret range would let a patch release silently move the digest.
+#
+# 1.2.1 AND NOT 1.2.2, and the difference is `multiple-versions = "deny"`
+# rather than taste. `schemars_derive` 1.2.2 moved to `syn` 3, while
+# `serde_derive` 1.0.228 and `thiserror-impl` 2.0.18 are on `syn` 2, so 1.2.2
+# puts two `syn` majors in the graph and `cargo deny` refuses it — correctly.
+# The lockfile holds `ref-cast` at 1.0.25 for the same reason: 1.0.26 moved
+# `ref-cast-impl` to `syn` 3 too, and `ref-cast` is not a dependency this
+# workspace declares, so the lock is the only place to state it. `cargo deny`
+# is what keeps both true: a `cargo update` that reintroduces either duplicate
+# fails `make rust-deny`, it is not quietly absorbed. Neither pin was worked
+# around by editing `deny.toml`.
+schemars = { version = "=1.2.1", features = ["derive"] }
 serde_json = "=1.0.150"
+# The digest under the FR-097 hash assertion. Exact pin like everything else.
+sha2 = "=0.10.9"
 thiserror = "=2.0.18"
 jsonschema = { version = "=0.56.0", default-features = false }
 

--- a/rust/crates/quoin-core/Cargo.toml
+++ b/rust/crates/quoin-core/Cargo.toml
@@ -24,7 +24,18 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-quoin-schemas = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+# Optional, and enabled by `quoin-schemas` rather than by this crate: the
+# derives are what let the SCHEMA be read off the canonical type, but nothing
+# on the boundary's own execution path needs them, so the shipped binary does
+# not carry the generator's dependency tree.
+schemars = { workspace = true, optional = true }
+
+[features]
+# FR-097. `quoin-schemas` turns this on to read the wire shapes off the types
+# that actually serialise them, rather than off a second declaration of the
+# same shapes. There is no `default` here on purpose: a feature that is on by
+# default is a feature nobody ever proves works when it is off.
+schema = ["dep:schemars"]

--- a/rust/crates/quoin-core/src/ops/core.rs
+++ b/rust/crates/quoin-core/src/ops/core.rs
@@ -30,6 +30,7 @@ pub const MAX_ECHO_BYTES: usize = 4 * 1024;
 /// than silently ignored — a field the boundary drops is a field the caller
 /// believes it sent.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct PingRequest {
     /// An opaque token returned unchanged, for correlating a call with its
@@ -47,6 +48,7 @@ pub struct PingRequest {
 
 /// The payload `core.ping` writes to stdout.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct PingPayload {
     /// The protocol revision this build speaks.
     pub protocol_version: u32,
@@ -80,14 +82,14 @@ pub fn ping(request: &serde_json::Value) -> Result<Response, CoreError> {
     }
 
     let payload = serde_json::to_value(PingPayload {
-        protocol_version: quoin_schemas::PROTOCOL_VERSION,
+        protocol_version: crate::protocol::PROTOCOL_VERSION,
         core_version: env!("CARGO_PKG_VERSION"),
         echo: request.echo,
     })
     .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?;
 
     match request.expect_protocol {
-        Some(expected) if expected != quoin_schemas::PROTOCOL_VERSION => Ok(Response::partial(
+        Some(expected) if expected != crate::protocol::PROTOCOL_VERSION => Ok(Response::partial(
             payload,
             &CoreError::new(
                 CoreErrorCode::ProtocolSkew,
@@ -96,7 +98,7 @@ pub fn ping(request: &serde_json::Value) -> Result<Response, CoreError> {
             )
             .with_context("op", "core.ping")
             .with_context("expected", expected.to_string())
-            .with_context("actual", quoin_schemas::PROTOCOL_VERSION.to_string()),
+            .with_context("actual", crate::protocol::PROTOCOL_VERSION.to_string()),
         )),
         _ => Ok(Response::ok(payload)),
     }

--- a/rust/crates/quoin-core/src/protocol.rs
+++ b/rust/crates/quoin-core/src/protocol.rs
@@ -23,6 +23,17 @@
 
 use std::collections::BTreeMap;
 
+/// The IPC protocol revision the boundary speaks.
+///
+/// Lives beside the wire contract it versions. It used to sit in
+/// `quoin-schemas` on the premise that the generated TypeScript side is
+/// generated from that crate — but FR-097 makes the canonical Rust type the
+/// source, so `quoin-schemas` now reads FROM here and the constant belongs
+/// with the taxonomy, the diagnostic and the payloads it revises together.
+/// The generated `src/core/types.ts` carries this number, so a bump reaches
+/// the TypeScript side only through a regeneration whose digest is asserted.
+pub const PROTOCOL_VERSION: u32 = 1;
+
 /// How the process terminated, and therefore whether stdout is worth reading.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Outcome {
@@ -83,6 +94,7 @@ impl Outcome {
 /// field list is then reviewable, and the compiler checks that every branch
 /// populated it.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Diagnostic {
     /// The stable code, from the catalogued enum — never a literal invented

--- a/rust/crates/quoin-schemas/Cargo.toml
+++ b/rust/crates/quoin-schemas/Cargo.toml
@@ -8,10 +8,18 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Placeholder for the schema-sourced type surface of quoin-core (FR-097)."
+description = "Emits the JSON Schema of the quoin-core boundary and generates src/core/types.ts from it (FR-097)."
 publish.workspace = true
 
 [lints]
 workspace = true
 
+[[bin]]
+name = "quoin-schemas-gen"
+path = "src/bin/gen.rs"
+
 [dependencies]
+quoin-core = { workspace = true, features = ["schema"] }
+schemars = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }

--- a/rust/crates/quoin-schemas/src/bin/gen.rs
+++ b/rust/crates/quoin-schemas/src/bin/gen.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! `make types`: write `src/core/types.ts` and record what it was generated
+//! from (FR-097).
+//!
+//! Modelled on `scripts/refresh-quire-schemas.mjs`, which is this repository's
+//! working precedent for a generated-or-vendored artefact under a hash
+//! assertion: the tool rewrites both the artefact and the digest recorded
+//! against it, in one act, so the two cannot be updated apart. What that script
+//! does for the vendored quire schemas, this binary does for the boundary
+//! types — the difference being only that the bytes come from a `schemars`
+//! render rather than from a pinned git object.
+//!
+//! This is the ONLY thing that may write `src/core/types.ts` or move the
+//! digests in `lib.rs`. Everything else asserts them.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+/// Where the repository root is, unless `--repo` says otherwise.
+///
+/// `crates/quoin-schemas` → `crates` → `rust` → the repository.
+fn default_repo_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for _ in 0..3 {
+        root = root
+            .parent()
+            .map_or_else(|| root.clone(), Path::to_path_buf);
+    }
+    root
+}
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let mut repo = default_repo_root();
+    let mut check_only = false;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--repo" => {
+                let Some(value) = args.next() else {
+                    eprintln!("--repo needs a path");
+                    return ExitCode::from(3);
+                };
+                repo = PathBuf::from(value);
+            }
+            // Useful by hand; the gate uses the crate's tests, which fail with
+            // the same findings and do not need a built binary.
+            "--check" => check_only = true,
+            other => {
+                eprintln!("usage: quoin-schemas-gen [--repo <path>] [--check]; got {other}");
+                return ExitCode::from(3);
+            }
+        }
+    }
+
+    let rendered = match quoin_schemas::typescript_source() {
+        Ok(rendered) => rendered,
+        Err(refusal) => {
+            eprintln!(
+                "the boundary schema carries a construct the renderer refuses: {refusal}\n\
+                 Add the case to `render.rs` with a test; do NOT widen the type."
+            );
+            return ExitCode::from(2);
+        }
+    };
+    let types_path = repo.join(quoin_schemas::GENERATED_TYPES_PATH);
+    let schema_digest = quoin_schemas::source_schema_digest();
+    let content_digest = quoin_schemas::sha256_hex(rendered.as_bytes());
+
+    if check_only {
+        let on_disk = match std::fs::read_to_string(&types_path) {
+            Ok(text) => text,
+            Err(error) => {
+                eprintln!("{}: {error}", types_path.display());
+                return ExitCode::from(4);
+            }
+        };
+        if let Err(finding) = quoin_schemas::check_generated_source(&on_disk) {
+            eprintln!("{finding}");
+            return ExitCode::from(1);
+        }
+        println!(
+            "{} is generated, current and unmodified",
+            types_path.display()
+        );
+        return ExitCode::SUCCESS;
+    }
+
+    if let Err(error) = std::fs::write(&types_path, &rendered) {
+        eprintln!("{}: {error}", types_path.display());
+        return ExitCode::from(4);
+    }
+
+    let lib_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+    let lib = match std::fs::read_to_string(&lib_path) {
+        Ok(text) => text,
+        Err(error) => {
+            eprintln!("{}: {error}", lib_path.display());
+            return ExitCode::from(4);
+        }
+    };
+    let lib = match replace_digest(&lib, "SOURCE_SCHEMA_SHA256", &schema_digest)
+        .and_then(|text| replace_digest(&text, "GENERATED_TYPES_SHA256", &content_digest))
+    {
+        Ok(text) => text,
+        Err(message) => {
+            eprintln!("{}: {message}", lib_path.display());
+            return ExitCode::from(4);
+        }
+    };
+    if let Err(error) = std::fs::write(&lib_path, lib) {
+        eprintln!("{}: {error}", lib_path.display());
+        return ExitCode::from(4);
+    }
+
+    println!("wrote {}", types_path.display());
+    println!("  source-schema sha256 {schema_digest}");
+    println!("  generated-file sha256 {content_digest}");
+    println!("  recorded in {}", lib_path.display());
+    ExitCode::SUCCESS
+}
+
+/// Replace the 64-hex literal declared for `name` in `lib.rs`.
+///
+/// Located by the declaration rather than by the old value: the two digests
+/// are indistinguishable as strings, so a value-keyed replacement would be
+/// ambiguous the moment they coincided — which they do on a fresh checkout of
+/// this file's initial state.
+fn replace_digest(text: &str, name: &str, value: &str) -> Result<String, String> {
+    let declaration = format!("pub const {name}: &str =");
+    let start = text
+        .find(&declaration)
+        .ok_or_else(|| format!("no declaration of `{name}`"))?;
+    let rest = text
+        .get(start..)
+        .ok_or_else(|| format!("no declaration of `{name}`"))?;
+    let open = rest
+        .find('"')
+        .ok_or_else(|| format!("`{name}` declares no string literal"))?;
+    let close = rest
+        .get(open + 1..)
+        .and_then(|tail| tail.find('"'))
+        .ok_or_else(|| format!("`{name}`'s string literal is unterminated"))?;
+    let absolute_open = start + open + 1;
+    let absolute_close = absolute_open + close;
+    let mut out = String::with_capacity(text.len());
+    out.push_str(text.get(..absolute_open).unwrap_or_default());
+    out.push_str(value);
+    out.push_str(text.get(absolute_close..).unwrap_or_default());
+    Ok(out)
+}

--- a/rust/crates/quoin-schemas/src/lib.rs
+++ b/rust/crates/quoin-schemas/src/lib.rs
@@ -3,26 +3,394 @@
 
 //! The schema-sourced type surface of the quoin boundary (FR-097).
 //!
-//! Deliberately empty at Stage 0 (quoin#375). It exists so the place a
-//! generated type lands is decided before the first one is generated, and so
-//! the workspace gates — `clippy -D warnings`, `cargo deny`, `rustfmt` — are
-//! already running over it when that happens.
+//! FR-097 says TypeScript never hand-writes a boundary type. This crate is the
+//! mechanism: `schemars` reads the JSON Schema off the **canonical Rust types**
+//! in `quoin-core`, [`render`] turns that schema into TypeScript, and the
+//! result — `src/core/types.ts` — carries a provenance record and a content
+//! digest that [`check_generated_source`] asserts on every `cargo test`.
 //!
-//! FR-097 says TypeScript never hand-writes a response type: `schemars` emits
-//! JSON Schema from the types declared here, a build step generates
-//! `src/core/types.ts`, and the result is hash-asserted. Nothing in this crate
-//! may be hand-written on both sides of that boundary.
+//! # Direction of truth, and why this crate depends on `quoin-core`
+//!
+//! Rust is the source; TypeScript is generated; if the two ever disagree, the
+//! Rust type wins. A crate that emits the schema of a type must therefore be
+//! able to SEE that type, which puts `quoin-schemas` **downstream** of
+//! `quoin-core`, not upstream of it.
+//!
+//! The edge used to point the other way, for one constant: `PROTOCOL_VERSION`
+//! lived here on the premise that the generated side is generated from this
+//! crate's own declarations. Honouring FR-097 literally would have meant
+//! re-declaring `Diagnostic`, `PingRequest` and `PingPayload` here — a second
+//! declaration of a type `quoin-core` already serialises, which is precisely
+//! the hand-written duplicate FR-097-CON-1 forbids, and which would drift
+//! silently because nothing compares two structurally-unrelated structs. So
+//! the derives went onto the canonical types (behind `quoin-core`'s `schema`
+//! feature, so the shipped binary carries none of the generator's tree),
+//! `PROTOCOL_VERSION` moved to `quoin_core::protocol` beside the taxonomy it
+//! versions, and this crate reads from there.
+//!
+//! # What keeps it honest
+//!
+//! Two digests, both checked in, both rewritten only by `make types`:
+//!
+//! - [`SOURCE_SCHEMA_SHA256`] — the schema the committed TypeScript was
+//!   generated from. A Rust type change moves it, and the recorded value in
+//!   the generated file is then **stale** (FR-097-AC-5).
+//! - [`GENERATED_TYPES_SHA256`] — the bytes of the committed TypeScript. It is
+//!   asserted against BOTH the file on disk (so a hand edit fails, at an
+//!   unchanged path — FR-097-AC-4) and against a fresh render (so a Rust
+//!   change that was never regenerated fails — FR-097-AC-1).
+//!
+//! A hash assertion nobody has watched fail is indistinguishable from no
+//! assertion, so `tc_1612_a_fresh_render_of_the_rust_types_matches_the`
+//! `committed_digest` exercises that branch directly rather than trusting it.
 //!
 //! # What must NOT be added here
 //!
 //! A type whose canonical definition lives in `filament-core-data`. fcd is the
 //! multi-language schema source of truth (quoin#373, gate phase B / fcd#11);
-//! re-declaring one of its types here would shadow it, which is the defect
-//! this crate exists to prevent rather than to commit.
+//! re-declaring one of its types here would shadow it. The same rule is why
+//! the boundary types are not re-declared here either — they belong to
+//! `quoin-core`.
 
-/// The IPC protocol revision the boundary speaks.
+pub mod render;
+
+use std::fmt::Write as _;
+
+use serde_json::{Value, json};
+use sha2::{Digest as _, Sha256};
+
+use crate::render::RenderRefusal;
+
+/// The generator that writes `src/core/types.ts`.
 ///
-/// Lives here rather than in `quoin-core` because both the Rust side and the
-/// generated TypeScript side must read the same number, and the generated side
-/// is generated from this crate.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// Recorded in the generated file itself so generated status is established by
+/// the provenance record, not by the directory the artefact happens to sit in
+/// (FR-097-CON-2).
+pub const GENERATOR_IDENTITY: &str = "quoin-schemas/quoin-schemas-gen";
+
+/// The generator's version, taken from this crate's manifest.
+pub const GENERATOR_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Repository-relative path of the generated TypeScript surface.
+pub const GENERATED_TYPES_PATH: &str = "src/core/types.ts";
+
+/// The `$id` of the schema the TypeScript surface is generated from.
+pub const BOUNDARY_SCHEMA_ID: &str = "https://agent-ix.dev/quoin/core-boundary-v1.schema.json";
+
+// --- The two checked-in digests. `make types` rewrites both; nothing else may.
+/// SHA-256 of the canonical JSON of [`boundary_schema`] at generation time.
+pub const SOURCE_SCHEMA_SHA256: &str =
+    "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920";
+
+/// SHA-256 of the committed `src/core/types.ts`.
+pub const GENERATED_TYPES_SHA256: &str =
+    "782c3a54e0e3d9fce94048514c61e315fb6a6bfb8c624eb05c16f047c16dda1f";
+
+/// The JSON Schema of every type that crosses the `quoin-core` boundary.
+///
+/// Read off the canonical `quoin-core` types by `schemars`. `$defs` is a
+/// `BTreeMap` in `serde_json`'s default build, so the order is the sorted type
+/// name and not the order this function happens to ask in — the digest below
+/// would otherwise depend on the order of the lines that follow.
+#[must_use]
+pub fn boundary_schema() -> Value {
+    let mut generator = schemars::SchemaGenerator::default();
+    let _ = generator.subschema_for::<quoin_core::protocol::Diagnostic>();
+    let _ = generator.subschema_for::<quoin_core::ops::core::PingRequest>();
+    let _ = generator.subschema_for::<quoin_core::ops::core::PingPayload>();
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": BOUNDARY_SCHEMA_ID,
+        "title": "quoin-core boundary types",
+        "description":
+            "Every type crossing the quoin-core subprocess boundary (FR-096), \
+             read off the canonical Rust declarations. Generated; do not edit.",
+        "x-quoin-protocol-version": quoin_core::protocol::PROTOCOL_VERSION,
+        "$defs": generator.take_definitions(true),
+    })
+}
+
+/// Canonical JSON of a value: object keys sorted at every depth, no
+/// insignificant whitespace.
+///
+/// The same discipline `quoin_core::protocol::canonical_json` applies on the
+/// wire, applied here for the same reason: a digest over a representation that
+/// can reorder is a digest that reports noise as drift.
+///
+/// # Panics
+///
+/// Never for a [`Value`], which is already a JSON document.
+#[must_use]
+pub fn canonical_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+/// Lowercase hex SHA-256 of some bytes.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().fold(String::new(), |mut acc, byte| {
+        use std::fmt::Write as _;
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}
+
+/// SHA-256 of the canonical JSON of [`boundary_schema`], as it is right now.
+#[must_use]
+pub fn source_schema_digest() -> String {
+    sha256_hex(canonical_json(&boundary_schema()).as_bytes())
+}
+
+/// Render the TypeScript surface from [`boundary_schema`].
+///
+/// # Errors
+///
+/// [`RenderRefusal`] when the schema carries a construct the renderer does not
+/// understand. It refuses rather than widening the offending type, so a
+/// boundary type that outgrows the subset stops the build instead of arriving
+/// in TypeScript as `unknown`.
+pub fn typescript_source() -> Result<String, RenderRefusal> {
+    let schema = boundary_schema();
+    let digest = sha256_hex(canonical_json(&schema).as_bytes());
+    let defs = schema
+        .get("$defs")
+        .and_then(Value::as_object)
+        .ok_or_else(|| RenderRefusal {
+            pointer: "#/$defs".to_owned(),
+            reason: "the boundary schema declared no `$defs`".to_owned(),
+        })?;
+
+    let mut out = String::new();
+    out.push_str(&header());
+    out.push_str(&provenance_record(&digest));
+    for (name, definition) in defs {
+        out.push('\n');
+        out.push_str(&render::render_interface(
+            name,
+            definition,
+            &format!("#/$defs/{name}"),
+        )?);
+    }
+    let _ = write!(
+        out,
+        "\n/** The IPC protocol revision this build of the boundary speaks. */\n\
+         export const PROTOCOL_VERSION = {};\n",
+        quoin_core::protocol::PROTOCOL_VERSION
+    );
+    Ok(out)
+}
+
+fn header() -> String {
+    format!(
+        "/**\n\
+         \x20* The quoin-core boundary types (FR-097). GENERATED — DO NOT EDIT.\n\
+         \x20*\n\
+         \x20* Written by `{GENERATOR_IDENTITY}` from the JSON Schema `schemars`\n\
+         \x20* reads off the canonical Rust declarations in\n\
+         \x20* `rust/crates/quoin-core/src/protocol.rs` and `.../src/ops/core.rs`.\n\
+         \x20* Rust is the source of truth: where this file and a Rust type\n\
+         \x20* disagree, the Rust type is right and this file is stale.\n\
+         \x20*\n\
+         \x20* Regenerate with `make types`. A hand edit does not survive review\n\
+         \x20* and does not survive the gate: `quoin-schemas` asserts the digest\n\
+         \x20* below against BOTH these bytes and a fresh render, so an edit here\n\
+         \x20* fails `make rust-test` at an unchanged path, and a Rust type change\n\
+         \x20* that was never regenerated fails it too.\n\
+         \x20*\n\
+         \x20* The machine-readable provenance is the `CORE_TYPES_PROVENANCE`\n\
+         \x20* record below, and it is the ONLY copy: a second, prose copy up\n\
+         \x20* here would be one more thing that can disagree with the artefact\n\
+         \x20* it describes.\n\
+         \x20*/\n"
+    )
+}
+
+fn provenance_record(source_schema_digest: &str) -> String {
+    format!(
+        "\n/**\n\
+         \x20* What produced this file, readable by the TypeScript side.\n\
+         \x20*\n\
+         \x20* Generated status is established by THIS record, not by the\n\
+         \x20* artefact's directory name (FR-097-CON-2): moving the file does not\n\
+         \x20* make it hand-written, and writing a file into a `generated/`\n\
+         \x20* directory does not make it generated.\n\
+         \x20*/\n\
+         export const CORE_TYPES_PROVENANCE = {{\n\
+         \x20 generator: \"{GENERATOR_IDENTITY}\",\n\
+         \x20 generatorVersion: \"{GENERATOR_VERSION}\",\n\
+         \x20 sourceSchemaSha256:\n\
+         \x20   \"{source_schema_digest}\",\n\
+         }} as const;\n"
+    )
+}
+
+/// A reason a generated artefact must not be used.
+///
+/// Distinct variants rather than one message, because the three states need
+/// three different repairs: regenerate, regenerate, or revert.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SurfaceFinding {
+    /// The file carries no complete provenance record, so nothing identifies
+    /// it as generated or says what from (FR-097-AC-2).
+    MissingProvenance {
+        /// The provenance field that could not be read.
+        field: &'static str,
+    },
+    /// The provenance names a source schema that is no longer the current one
+    /// (FR-097-AC-5). The artefact describes types that have moved on.
+    StaleSourceSchema {
+        /// The digest the artefact records.
+        recorded: String,
+        /// The digest [`boundary_schema`] produces now.
+        current: String,
+    },
+    /// The artefact's bytes are not the bytes that were generated
+    /// (FR-097-AC-1, FR-097-AC-4).
+    ContentDigest {
+        /// The checked-in digest.
+        expected: String,
+        /// The digest of what was actually read.
+        observed: String,
+    },
+}
+
+impl std::fmt::Display for SurfaceFinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingProvenance { field } => write!(
+                f,
+                "{GENERATED_TYPES_PATH} carries no `{field}` in its provenance record; \
+                 a generated artefact is identified by that record, not by its path. \
+                 Run `make types`."
+            ),
+            Self::StaleSourceSchema { recorded, current } => write!(
+                f,
+                "{GENERATED_TYPES_PATH} was generated from source schema {recorded}, \
+                 but the Rust boundary types now hash to {current}. The file is stale \
+                 and is refused rather than used. Run `make types`."
+            ),
+            Self::ContentDigest { expected, observed } => write!(
+                f,
+                "{GENERATED_TYPES_PATH} hashes to {observed}, not the committed \
+                 {expected}. Either the file was hand-edited or a Rust boundary type \
+                 changed without a regeneration. Run `make types` and review the diff."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SurfaceFinding {}
+
+/// Read one field out of the generated file's `CORE_TYPES_PROVENANCE` record.
+fn provenance_field(text: &str, key: &'static str) -> Result<String, SurfaceFinding> {
+    // The key and its value are not always on one line: prettier wraps a
+    // value that pushes past 80 columns onto the next, which the 64-hex digest
+    // does. Anchoring on the key and taking the NEXT string literal reads both
+    // layouts; anchoring on `key: "` read only the short one, and would have
+    // reported a perfectly good provenance record as missing.
+    let needle = format!("{key}:");
+    let start = text
+        .find(&needle)
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })?
+        + needle.len();
+    let rest = text
+        .get(start..)
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })?;
+    let open = rest
+        .find('"')
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })?;
+    let tail = rest
+        .get(open + 1..)
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })?;
+    let end = tail
+        .find('"')
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })?;
+    tail.get(..end)
+        .map(str::to_owned)
+        .ok_or(SurfaceFinding::MissingProvenance { field: key })
+}
+
+/// Judge a candidate `src/core/types.ts` against the Rust types it claims to
+/// describe.
+///
+/// Checks, in the order a failure is most useful to read: the provenance
+/// record is complete; the source schema it names is the current one; the
+/// bytes are the committed bytes.
+///
+/// # Errors
+///
+/// The first [`SurfaceFinding`] that holds. `Ok(())` means the artefact is
+/// generated, current, and unmodified.
+pub fn check_generated_source(text: &str) -> Result<(), SurfaceFinding> {
+    let generator = provenance_field(text, "generator")?;
+    if generator != GENERATOR_IDENTITY {
+        return Err(SurfaceFinding::MissingProvenance { field: "generator" });
+    }
+    let _version = provenance_field(text, "generatorVersion")?;
+    let recorded = provenance_field(text, "sourceSchemaSha256")?;
+    let current = source_schema_digest();
+    if recorded != current {
+        return Err(SurfaceFinding::StaleSourceSchema { recorded, current });
+    }
+    let observed = sha256_hex(text.as_bytes());
+    if observed != GENERATED_TYPES_SHA256 {
+        return Err(SurfaceFinding::ContentDigest {
+            expected: GENERATED_TYPES_SHA256.to_owned(),
+            observed,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_schema_covers_every_type_that_crosses_the_boundary() {
+        let schema = boundary_schema();
+        let defs = schema["$defs"].as_object().unwrap();
+        let mut names: Vec<&String> = defs.keys().collect();
+        names.sort();
+        assert_eq!(names, ["Diagnostic", "PingPayload", "PingRequest"]);
+    }
+
+    #[test]
+    fn the_schema_digest_does_not_depend_on_key_order() {
+        // Canonical JSON is what makes the digest a statement about the
+        // schema rather than about how serde happened to lay it out.
+        let once = source_schema_digest();
+        let twice = source_schema_digest();
+        assert_eq!(once, twice);
+        assert_eq!(once.len(), 64);
+    }
+
+    #[test]
+    fn a_file_with_no_provenance_record_is_refused() {
+        let error = check_generated_source("export interface Diagnostic {}\n").unwrap_err();
+        assert_eq!(
+            error,
+            SurfaceFinding::MissingProvenance { field: "generator" }
+        );
+    }
+
+    #[test]
+    fn a_stale_source_schema_digest_is_refused_rather_than_used() {
+        let stale = typescript_source()
+            .unwrap()
+            .replace(&source_schema_digest(), &"f".repeat(64));
+        assert_eq!(
+            check_generated_source(&stale).unwrap_err(),
+            SurfaceFinding::StaleSourceSchema {
+                recorded: "f".repeat(64),
+                current: source_schema_digest(),
+            }
+        );
+    }
+}

--- a/rust/crates/quoin-schemas/src/render.rs
+++ b/rust/crates/quoin-schemas/src/render.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! JSON Schema → TypeScript, for the subset `schemars` emits from the boundary
+//! types (FR-097).
+//!
+//! Deliberately a *small, total* renderer rather than a general one. Every
+//! construct it does not understand is a named refusal carrying the JSON
+//! Pointer of the node that produced it — never `any`, never `unknown`, never
+//! a silently dropped field. A generator that degrades to `any` on a shape it
+//! did not expect produces a file that compiles, passes its own digest check,
+//! and describes nothing; that is the failure this module is written to be
+//! incapable of.
+//!
+//! The subset is exactly what the boundary declares today: objects with named
+//! properties, string/integer/boolean/null unions, `Record<string, string>`
+//! from a `BTreeMap<String, String>`, arrays, and `$ref` into `$defs`. When a
+//! boundary type needs more, this module grows a case and a test in the same
+//! commit — which is the point of refusing rather than degrading.
+
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+/// A construct the renderer does not understand, and where it was found.
+///
+/// Carries the JSON Pointer rather than a type name because the offending node
+/// is frequently a property several levels inside a `$def`, and "unsupported
+/// schema" with no location is the error message that costs an afternoon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderRefusal {
+    /// JSON Pointer of the node that could not be rendered.
+    pub pointer: String,
+    /// What about it was not understood.
+    pub reason: String,
+}
+
+impl std::fmt::Display for RenderRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.pointer, self.reason)
+    }
+}
+
+impl std::error::Error for RenderRefusal {}
+
+fn refuse(pointer: &str, reason: impl Into<String>) -> RenderRefusal {
+    RenderRefusal {
+        pointer: pointer.to_owned(),
+        reason: reason.into(),
+    }
+}
+
+/// Render one `$defs` entry as a TypeScript `interface` declaration.
+///
+/// # Errors
+///
+/// [`RenderRefusal`] when the definition is not an object schema with named
+/// properties, or when any property uses a construct outside the supported
+/// subset.
+pub fn render_interface(
+    name: &str,
+    schema: &Value,
+    pointer: &str,
+) -> Result<String, RenderRefusal> {
+    let object = schema
+        .as_object()
+        .ok_or_else(|| refuse(pointer, "a `$defs` entry must be an object schema"))?;
+    if object.get("type").and_then(Value::as_str) != Some("object") {
+        return Err(refuse(
+            pointer,
+            "only `\"type\": \"object\"` definitions are rendered as interfaces",
+        ));
+    }
+    let properties = object
+        .get("properties")
+        .and_then(Value::as_object)
+        .ok_or_else(|| refuse(pointer, "an object definition must declare `properties`"))?;
+    let required: Vec<&str> = object
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    let mut out = String::new();
+    if let Some(description) = object.get("description").and_then(Value::as_str) {
+        out.push_str(&doc_comment(description, ""));
+    }
+    let _ = writeln!(out, "export interface {name} {{");
+    for (field, property) in properties {
+        let field_pointer = format!("{pointer}/properties/{field}");
+        if let Some(description) = property.get("description").and_then(Value::as_str) {
+            out.push_str(&doc_comment(description, "  "));
+        }
+        let optional = if required.contains(&field.as_str()) {
+            ""
+        } else {
+            "?"
+        };
+        let rendered = render_type(property, &field_pointer)?;
+        let _ = writeln!(out, "  {field}{optional}: {rendered};");
+    }
+    out.push_str("}\n");
+    Ok(out)
+}
+
+/// Render a schema node as a TypeScript type expression.
+///
+/// # Errors
+///
+/// [`RenderRefusal`] for any construct outside the supported subset.
+pub fn render_type(schema: &Value, pointer: &str) -> Result<String, RenderRefusal> {
+    let object = schema
+        .as_object()
+        .ok_or_else(|| refuse(pointer, "expected a schema object"))?;
+
+    if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+        let name = reference.strip_prefix("#/$defs/").ok_or_else(|| {
+            refuse(
+                pointer,
+                format!("only local `#/$defs/…` references are supported, got `{reference}`"),
+            )
+        })?;
+        return Ok(name.to_owned());
+    }
+
+    let Some(type_node) = object.get("type") else {
+        return Err(refuse(
+            pointer,
+            "a schema node without `type` or `$ref` is not renderable; the \
+             renderer refuses rather than emitting `unknown`",
+        ));
+    };
+
+    match type_node {
+        Value::String(single) => render_named_type(single, object, pointer),
+        Value::Array(members) => {
+            let mut parts = Vec::with_capacity(members.len());
+            for member in members {
+                let name = member
+                    .as_str()
+                    .ok_or_else(|| refuse(pointer, "a `type` array must hold strings"))?;
+                parts.push(render_named_type(name, object, pointer)?);
+            }
+            if parts.is_empty() {
+                return Err(refuse(pointer, "an empty `type` array names no type"));
+            }
+            parts.dedup();
+            Ok(parts.join(" | "))
+        }
+        _ => Err(refuse(pointer, "`type` must be a string or an array")),
+    }
+}
+
+fn render_named_type(
+    name: &str,
+    object: &serde_json::Map<String, Value>,
+    pointer: &str,
+) -> Result<String, RenderRefusal> {
+    match name {
+        "string" => Ok("string".to_owned()),
+        "integer" | "number" => Ok("number".to_owned()),
+        "boolean" => Ok("boolean".to_owned()),
+        "null" => Ok("null".to_owned()),
+        "array" => {
+            let items = object
+                .get("items")
+                .ok_or_else(|| refuse(pointer, "an array schema must declare `items`"))?;
+            let inner = render_type(items, &format!("{pointer}/items"))?;
+            Ok(format!("{inner}[]"))
+        }
+        "object" => {
+            if object.contains_key("properties") {
+                return Err(refuse(
+                    pointer,
+                    "an inline object with `properties` must be lifted into `$defs`; \
+                     the renderer does not emit anonymous nested interfaces",
+                ));
+            }
+            let additional = object.get("additionalProperties").ok_or_else(|| {
+                refuse(
+                    pointer,
+                    "an object schema with neither `properties` nor \
+                     `additionalProperties` describes nothing",
+                )
+            })?;
+            let value = render_type(additional, &format!("{pointer}/additionalProperties"))?;
+            Ok(format!("Record<string, {value}>"))
+        }
+        other => Err(refuse(pointer, format!("unsupported JSON type `{other}`"))),
+    }
+}
+
+/// A `JSDoc` block for a schema `description`, indented by `indent`.
+///
+/// Rust doc comments arrive with hard line breaks and `[`Type`]` intra-doc
+/// links. The breaks are preserved (they are the author's paragraphing) and
+/// the links are flattened to their text, because a TypeScript reader cannot
+/// follow a rustdoc path and a dangling `[`…`]` reads as a broken markdown
+/// link in every editor that renders `JSDoc`.
+fn doc_comment(description: &str, indent: &str) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "{indent}/**");
+    for line in description.lines() {
+        let line = flatten_intra_doc_links(line);
+        let line = line.trim_end();
+        if line.is_empty() {
+            let _ = writeln!(out, "{indent} *");
+        } else {
+            let _ = writeln!(out, "{indent} * {line}");
+        }
+    }
+    let _ = writeln!(out, "{indent} */");
+    out
+}
+
+fn flatten_intra_doc_links(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(open) = rest.find("[`") {
+        let Some(close_offset) = rest[open..].find("`]") else {
+            break;
+        };
+        let close = open + close_offset;
+        out.push_str(&rest[..open]);
+        out.push('`');
+        // The rustdoc path `crate::protocol::Outcome::Partial` reads as noise
+        // in TypeScript; only the final segment carries meaning there.
+        let path = &rest[open + 2..close];
+        out.push_str(path.rsplit("::").next().unwrap_or(path));
+        out.push('`');
+        rest = &rest[close + 2..];
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_nullable_string_renders_as_a_union() {
+        let rendered = render_type(&json!({ "type": ["string", "null"] }), "#").unwrap();
+        assert_eq!(rendered, "string | null");
+    }
+
+    #[test]
+    fn a_string_map_renders_as_a_record() {
+        let rendered = render_type(
+            &json!({ "type": "object", "additionalProperties": { "type": "string" } }),
+            "#",
+        )
+        .unwrap();
+        assert_eq!(rendered, "Record<string, string>");
+    }
+
+    #[test]
+    fn an_unknown_json_type_is_refused_and_names_its_location() {
+        let error =
+            render_type(&json!({ "type": "widget" }), "#/$defs/X/properties/y").unwrap_err();
+        assert_eq!(error.pointer, "#/$defs/X/properties/y");
+        assert!(error.reason.contains("widget"), "{}", error.reason);
+    }
+
+    #[test]
+    fn a_node_with_neither_type_nor_ref_is_refused_rather_than_widened() {
+        // The defect this renderer exists not to have: a shape it does not
+        // understand becoming `unknown`, compiling, and describing nothing.
+        let error = render_type(&json!({ "description": "opaque" }), "#/a").unwrap_err();
+        assert!(error.reason.contains("unknown"), "{}", error.reason);
+    }
+
+    #[test]
+    fn a_remote_reference_is_refused() {
+        let error =
+            render_type(&json!({ "$ref": "https://example.test/x.json" }), "#/a").unwrap_err();
+        assert!(error.reason.contains("$defs"), "{}", error.reason);
+    }
+
+    #[test]
+    fn an_optional_field_is_the_one_absent_from_required() {
+        let rendered = render_interface(
+            "T",
+            &json!({
+                "type": "object",
+                "properties": { "a": { "type": "string" }, "b": { "type": "string" } },
+                "required": ["a"]
+            }),
+            "#/$defs/T",
+        )
+        .unwrap();
+        assert!(rendered.contains("  a: string;"), "{rendered}");
+        assert!(rendered.contains("  b?: string;"), "{rendered}");
+    }
+
+    #[test]
+    fn an_intra_doc_link_keeps_only_its_final_segment() {
+        assert_eq!(
+            flatten_intra_doc_links("see [`crate::protocol::Outcome::Partial`] here"),
+            "see `Partial` here"
+        );
+    }
+}

--- a/rust/crates/quoin-schemas/tests/tc_type_surface.rs
+++ b/rust/crates/quoin-schemas/tests/tc_type_surface.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! The FR-097 hash assertion, exercised in both directions.
+//!
+//! A hash assertion nobody has watched fail is indistinguishable from no
+//! assertion at all, so this file does not only assert that the committed
+//! artefact matches — it constructs each way it can stop matching and asserts
+//! the named finding comes back. The three failing states are different
+//! repairs, not one "mismatch".
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+
+use std::path::PathBuf;
+
+use quoin_schemas::{
+    GENERATED_TYPES_PATH, GENERATED_TYPES_SHA256, GENERATOR_IDENTITY, GENERATOR_VERSION,
+    SOURCE_SCHEMA_SHA256, SurfaceFinding, check_generated_source, sha256_hex, source_schema_digest,
+    typescript_source,
+};
+
+/// `crates/quoin-schemas` → `crates` → `rust` → the repository.
+fn repo_root() -> PathBuf {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for _ in 0..3 {
+        root = root.parent().unwrap().to_path_buf();
+    }
+    root
+}
+
+fn committed_surface() -> String {
+    std::fs::read_to_string(repo_root().join(GENERATED_TYPES_PATH)).unwrap()
+}
+
+/// Trace: FR-097-AC-1
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest() {
+    // THE drift probe, in the direction that matters: change a Rust boundary
+    // type and do not run `make types`, and this is what fails. The committed
+    // digest is a literal in `lib.rs`, so nothing here re-derives its own
+    // expectation.
+    let rendered = typescript_source().unwrap();
+    assert_eq!(
+        sha256_hex(rendered.as_bytes()),
+        GENERATED_TYPES_SHA256,
+        "a Rust boundary type changed without `make types`. \
+         `{GENERATED_TYPES_PATH}` no longer describes the types that serialise \
+         on the wire; regenerate it and review the diff."
+    );
+}
+
+/// Trace: FR-097-AC-1
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1612_the_committed_source_schema_digest_is_the_current_one() {
+    assert_eq!(
+        source_schema_digest(),
+        SOURCE_SCHEMA_SHA256,
+        "the JSON Schema read off the Rust boundary types has moved since \
+         `make types` last ran"
+    );
+}
+
+/// Trace: FR-097-AC-1
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1612_the_generated_surface_declares_every_type_that_crosses_the_boundary() {
+    let surface = committed_surface();
+    for name in ["Diagnostic", "PingRequest", "PingPayload"] {
+        assert!(
+            surface.contains(&format!("export interface {name} {{")),
+            "`{name}` crosses the boundary but is not in the generated surface"
+        );
+    }
+    assert!(
+        surface.contains("export const PROTOCOL_VERSION = 1;"),
+        "{surface}"
+    );
+}
+
+/// Trace: FR-097-AC-1
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1612_the_diagnostic_interface_is_rendered_literally() {
+    // The expected bytes are written out rather than re-rendered. A test that
+    // calls the renderer to build its own expectation agrees with the renderer
+    // no matter what the renderer does.
+    let expected = "export interface Diagnostic {\n\
+                    \x20 /**\n\
+                    \x20  * The stable code, from the catalogued enum — never a literal invented\n\
+                    \x20  * at the call site.\n\
+                    \x20  */\n\
+                    \x20 code: string;\n";
+    assert!(
+        committed_surface().contains(expected),
+        "the committed surface does not contain the expected Diagnostic opening:\n{expected}"
+    );
+    assert!(
+        committed_surface().contains("  context: Record<string, string>;"),
+        "a BTreeMap<String, String> must render as Record<string, string>"
+    );
+}
+
+/// Trace: FR-097-AC-2
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1613_the_generated_surface_carries_a_complete_provenance_record() {
+    let surface = committed_surface();
+    assert!(
+        surface.contains(&format!("generator: \"{GENERATOR_IDENTITY}\"")),
+        "{surface}"
+    );
+    assert!(
+        surface.contains(&format!("generatorVersion: \"{GENERATOR_VERSION}\"")),
+        "{surface}"
+    );
+    assert!(surface.contains("sourceSchemaSha256:"), "{surface}");
+    assert!(
+        surface.contains(&format!("\"{SOURCE_SCHEMA_SHA256}\"")),
+        "{surface}"
+    );
+}
+
+/// Trace: FR-097-AC-2
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1613_an_artefact_missing_a_provenance_field_fails_the_gate() {
+    for (field, needle) in [
+        ("generator", "generator:"),
+        ("generatorVersion", "generatorVersion:"),
+        ("sourceSchemaSha256", "sourceSchemaSha256:"),
+    ] {
+        let stripped = committed_surface().replace(needle, "removed:");
+        let finding = check_generated_source(&stripped).unwrap_err();
+        assert_eq!(
+            finding,
+            SurfaceFinding::MissingProvenance { field },
+            "removing `{field}` must be refused by name"
+        );
+        assert!(finding.to_string().contains(field), "{finding}");
+    }
+}
+
+/// Trace: FR-097-AC-4
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1615_the_committed_file_is_generated_current_and_unmodified() {
+    check_generated_source(&committed_surface()).unwrap();
+}
+
+/// Trace: FR-097-AC-4
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path() {
+    // The artefact's path never changes; its provenance record is intact; only
+    // one character of one type moved. Generated status is not a property of
+    // where the file lives (FR-097-CON-2), so this must still fail.
+    let edited = committed_surface().replace("  code: string;", "  code: string | null;");
+    assert_ne!(
+        edited,
+        committed_surface(),
+        "the planted edit did not apply"
+    );
+    assert_eq!(
+        check_generated_source(&edited).unwrap_err(),
+        SurfaceFinding::ContentDigest {
+            expected: GENERATED_TYPES_SHA256.to_owned(),
+            observed: sha256_hex(edited.as_bytes()),
+        },
+        "a hand edit must be a content-digest finding"
+    );
+    assert_ne!(sha256_hex(edited.as_bytes()), GENERATED_TYPES_SHA256);
+}
+
+/// Trace: FR-097-AC-5
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used() {
+    let stale = committed_surface().replace(SOURCE_SCHEMA_SHA256, &"0".repeat(64));
+    assert_eq!(
+        check_generated_source(&stale).unwrap_err(),
+        SurfaceFinding::StaleSourceSchema {
+            recorded: "0".repeat(64),
+            current: SOURCE_SCHEMA_SHA256.to_owned(),
+        },
+        "a stale artefact must be named stale, not merely different"
+    );
+}
+
+/// Every `export interface` in a TypeScript source, as (name, field names).
+///
+/// A line scanner, not a parser, and deliberately so: it reads the two shapes
+/// this repository's `src/core/` actually uses, and a declaration it cannot
+/// read is reported rather than skipped — a duplicate detector that silently
+/// fails to see a declaration is the "green over a population that is not what
+/// it claims" failure this whole mechanism exists against.
+fn interfaces(text: &str) -> Vec<(String, Vec<String>)> {
+    let mut found = Vec::new();
+    let mut current: Option<(String, Vec<String>)> = None;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("export interface ")
+            && let Some(name) = rest.split_whitespace().next()
+        {
+            current = Some((name.to_owned(), Vec::new()));
+            continue;
+        }
+        let Some((_, fields)) = current.as_mut() else {
+            continue;
+        };
+        if trimmed == "}" {
+            if let Some(entry) = current.take() {
+                found.push(entry);
+            }
+            continue;
+        }
+        if trimmed.starts_with('*') || trimmed.starts_with("/*") || trimmed.starts_with("//") {
+            continue;
+        }
+        if let Some(colon) = trimmed.find(':') {
+            let name = trimmed[..colon].trim_end_matches('?');
+            if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                fields.push(name.to_owned());
+            }
+        }
+    }
+    found
+}
+
+/// Trace: FR-097-CON-1
+/// Provenance: quoin#373, quoin#375
+#[test]
+fn tc_1614_no_hand_written_declaration_shadows_a_generated_boundary_type() {
+    // FR-097-CON-1 in the form this stage can actually check: a type the
+    // generator publishes must not ALSO be declared by hand under `src/core/`.
+    // Matched on the FIELD SET, not on the name — the duplicate this found
+    // when it was first written was called `CoreDiagnostic`, and a name-keyed
+    // check would have reported clean over it. The fcd-published half of
+    // FR-097-AC-3 waits on the Phase B gate (fcd#11) and is not faked here.
+    let core_dir = repo_root().join("src/core");
+    let generated: Vec<(String, Vec<String>)> = interfaces(&committed_surface())
+        .into_iter()
+        .map(|(name, mut fields)| {
+            fields.sort();
+            (name, fields)
+        })
+        .collect();
+    assert_eq!(
+        generated.len(),
+        3,
+        "the scanner read {} interfaces out of the generated surface, not 3; \
+         it is broken and would report clean over anything",
+        generated.len()
+    );
+
+    let mut exempt_seen = Vec::new();
+    let mut duplicates = Vec::new();
+    for entry in std::fs::read_dir(&core_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.file_name().is_some_and(|n| n == "types.ts")
+            || path.extension().is_none_or(|e| e != "ts")
+        {
+            continue;
+        }
+        // ONE exemption, named here rather than skipped silently.
+        //
+        // `reference.ts` is the differential harness's TypeScript oracle
+        // (FR-101). Its whole value is that it was written against the
+        // documented contract and NOT against the Rust source: if it imported
+        // the generated types, the harness would be comparing quoin-core to a
+        // transliteration of itself, and `tc_375`'s twelve comparisons would
+        // prove that two things written the same week agree. FR-097 governs
+        // the CUTOVER surface — where quoin's own TypeScript calls the
+        // boundary — which is `exec.ts` and `index.ts`.
+        //
+        // The assertion below pins the exemption list to exactly this file, so
+        // a second file cannot join it by being added to a `continue`.
+        if path.file_name().is_some_and(|n| n == "reference.ts") {
+            exempt_seen.push("reference.ts");
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).unwrap();
+        for (name, mut fields) in interfaces(&text) {
+            fields.sort();
+            for (published, published_fields) in &generated {
+                if &fields == published_fields {
+                    duplicates.push(format!(
+                        "{} declares `{name}` with the fields of `{published}`, \
+                         which {GENERATED_TYPES_PATH} publishes",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+    assert_eq!(duplicates, Vec::<String>::new());
+    assert_eq!(
+        exempt_seen,
+        vec!["reference.ts"],
+        "the harness-oracle exemption must apply to exactly one file that exists"
+    );
+}

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -31,6 +31,8 @@ import { createHash } from "node:crypto";
 import { accessSync, constants, readFileSync, realpathSync } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
 
+import type { Diagnostic } from "./types.js";
+
 /**
  * Node's default `maxBuffer` is 1 MiB, and a real corpus already exceeds it:
  * filament-ide-rs (268 spec files, 1,107 obligations) emits 1,090,714 bytes of
@@ -84,15 +86,17 @@ export function carriesPayload(exitCode: number): boolean {
   return exitCode === CORE_EXIT.OK || exitCode === CORE_EXIT.PARTIAL;
 }
 
-/** One entry of quoin-core's stderr array. */
-export interface CoreDiagnostic {
-  /** A stable code from quoin-core's catalogue, e.g. `CORE_UNKNOWN_OP`. */
-  code: string;
-  /** A sentence for an operator. Never parsed to decide what happened. */
-  message: string;
-  /** Ordered context. */
-  context: Record<string, string>;
-}
+/**
+ * One entry of quoin-core's stderr array.
+ *
+ * An alias of the GENERATED {@link Diagnostic}, not a second declaration of
+ * it. The three fields were hand-written here and happened to match
+ * `quoin_core::protocol::Diagnostic` — which is exactly the duplicate FR-097
+ * forbids, because a type that agrees by coincidence drifts the first time the
+ * Rust struct gains a field and nothing reports it. The name is kept because
+ * it is the spelling callers import.
+ */
+export type CoreDiagnostic = Diagnostic;
 
 /** What one `quoin-core` invocation produced. */
 export interface CoreResult {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,11 +1,19 @@
 /**
  * The quoin↔quoin-core boundary (quoin#373 FR-096).
  *
- * One import site for the subprocess contract. Nothing else lives here yet:
- * Stage 0 ports no domain logic, and `src/core/types.ts` — the schema-sourced
- * response types — is generated from `rust/crates/quoin-schemas`, not written
- * by hand (FR-097).
+ * One import site for the subprocess contract. `./types.js` is GENERATED from
+ * the Rust boundary types by `make types` and re-exported here (FR-097); it is
+ * never hand-written, and `quoin-schemas` fails `make rust-gate` if the file
+ * and the Rust types disagree.
  */
+
+export {
+  CORE_TYPES_PROVENANCE,
+  PROTOCOL_VERSION,
+  type Diagnostic,
+  type PingPayload,
+  type PingRequest,
+} from "./types.js";
 
 export {
   CORE_EXIT,

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -14,7 +14,10 @@
  * transliteration of one implementation would agree with itself.
  */
 
-/** Mirrors `quoin_schemas::PROTOCOL_VERSION`. */
+/** Mirrors `quoin_core::protocol::PROTOCOL_VERSION` — deliberately restated,
+ * not imported from the generated `./types.js`: this file is the differential
+ * harness's independent oracle (FR-101) and importing the generated surface
+ * would make it a transliteration of the thing it exists to check. */
 export const PROTOCOL_VERSION = 1;
 
 /** Mirrors `quoin_core::ops::core::MAX_ECHO_BYTES`. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,102 @@
+/**
+ * The quoin-core boundary types (FR-097). GENERATED — DO NOT EDIT.
+ *
+ * Written by `quoin-schemas/quoin-schemas-gen` from the JSON Schema `schemars`
+ * reads off the canonical Rust declarations in
+ * `rust/crates/quoin-core/src/protocol.rs` and `.../src/ops/core.rs`.
+ * Rust is the source of truth: where this file and a Rust type
+ * disagree, the Rust type is right and this file is stale.
+ *
+ * Regenerate with `make types`. A hand edit does not survive review
+ * and does not survive the gate: `quoin-schemas` asserts the digest
+ * below against BOTH these bytes and a fresh render, so an edit here
+ * fails `make rust-test` at an unchanged path, and a Rust type change
+ * that was never regenerated fails it too.
+ *
+ * The machine-readable provenance is the `CORE_TYPES_PROVENANCE`
+ * record below, and it is the ONLY copy: a second, prose copy up
+ * here would be one more thing that can disagree with the artefact
+ * it describes.
+ */
+
+/**
+ * What produced this file, readable by the TypeScript side.
+ *
+ * Generated status is established by THIS record, not by the
+ * artefact's directory name (FR-097-CON-2): moving the file does not
+ * make it hand-written, and writing a file into a `generated/`
+ * directory does not make it generated.
+ */
+export const CORE_TYPES_PROVENANCE = {
+  generator: "quoin-schemas/quoin-schemas-gen",
+  generatorVersion: "0.1.0",
+  sourceSchemaSha256:
+    "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920",
+} as const;
+
+/**
+ * One entry of the stderr array.
+ *
+ * A `Serialize` struct rather than a hand-built `serde_json::Value`: the
+ * field list is then reviewable, and the compiler checks that every branch
+ * populated it.
+ */
+export interface Diagnostic {
+  /**
+   * The stable code, from the catalogued enum — never a literal invented
+   * at the call site.
+   */
+  code: string;
+  /**
+   * Ordered context. `BTreeMap` for byte-stable serialisation.
+   */
+  context: Record<string, string>;
+  /**
+   * A sentence for an operator.
+   */
+  message: string;
+}
+
+/**
+ * The payload `core.ping` writes to stdout.
+ */
+export interface PingPayload {
+  /**
+   * The `quoin-core` crate version.
+   */
+  core_version: string;
+  /**
+   * Whatever `echo` held, unchanged.
+   */
+  echo?: string | null;
+  /**
+   * The protocol revision this build speaks.
+   */
+  protocol_version: number;
+}
+
+/**
+ * The request accepted by `core.ping`.
+ *
+ * `deny_unknown_fields` so a caller that misspells a field is refused rather
+ * than silently ignored — a field the boundary drops is a field the caller
+ * believes it sent.
+ */
+export interface PingRequest {
+  /**
+   * An opaque token returned unchanged, for correlating a call with its
+   * answer across the pipe. Absent is fine.
+   */
+  echo?: string | null;
+  /**
+   * The protocol revision the caller believes it is speaking. When it
+   * disagrees with this build's, the answer is still complete — it is how
+   * the caller learns which revision it is actually talking to — so the
+   * disagreement is reported as `Partial`, not as a
+   * failure.
+   */
+  expect_protocol?: number | null;
+}
+
+/** The IPC protocol revision this build of the boundary speaks. */
+export const PROTOCOL_VERSION = 1;


### PR DESCRIPTION
## What this is

FR-097's central mechanism existed only as a docstring. `src/core/types.ts` did not exist on any branch. `rust/crates/quoin-schemas/src/lib.rs` was 28 lines — a doc comment and one constant — with an empty `[dependencies]`, and it contributed **zero** of the 30 tests `make rust-gate` ran. `schemars` appeared nowhere in `rust/` except in that doc comment. `src/core/index.ts` said so in a comment.

This builds it: `schemars` reads the JSON Schema off the canonical `quoin-core` types, a renderer turns that schema into TypeScript, `make types` writes `src/core/types.ts` and rewrites the two digests recorded against it in the same act, and Rust tests assert both digests so the assertion runs inside `make rust-gate`.

## The direction of the dependency edge, and why

**`quoin-schemas` now depends on `quoin-core`. The edge was reversed.**

It used to run the other way: `quoin-core` depended on `quoin-schemas` for the single constant `PROTOCOL_VERSION`. That is untenable for a crate whose job is to emit the schema of `quoin-core`'s types — a schema emitter that cannot see the types it describes can only describe a second copy of them.

The two alternatives, and why they lose:

- **Re-declare the wire types in `quoin-schemas` and derive there.** This is a hand-written second declaration of a type `quoin-core` already serialises. It is precisely the duplicate FR-097-CON-1 forbids, and nothing would ever compare the two: the generated TypeScript would be a faithful rendering of a Rust type that is not the one on the wire. Every property FR-097 wants would read green over the wrong source.
- **Keep the edge and put the derives on `quoin-core` anyway.** A cycle. Cargo refuses it.

So the derives go on the canonical types in `quoin-core` — `protocol::Diagnostic`, `ops::core::PingRequest`, `ops::core::PingPayload` — behind a **non-default** `schema` feature:

```toml
[features]
schema = ["dep:schemars"]
```

`quoin-schemas` enables it (`quoin-core = { workspace = true, features = ["schema"] }`). Nothing on the boundary's own execution path needs the derives, so the shipped binary carries none of the generator's tree. There is deliberately no `default` entry: a feature that is on by default is a feature nobody ever proves works when it is off.

`PROTOCOL_VERSION` moved with the edge, from `quoin-schemas` to `quoin_core::protocol`, beside the taxonomy and the payloads it versions. The generated `src/core/types.ts` carries the number, so a bump now reaches TypeScript only through a regeneration whose digest is asserted.

`Outcome` deliberately has **no** schemars derives: it is not serialised. TypeScript consumes it as the `CORE_EXIT` exit-code numbers, which the differential harness already asserts.

## The drift probe, run rather than asserted

A hash assertion nobody has watched fail is indistinguishable from no assertion at all. So: one field added to a Rust boundary type, `make types` deliberately **not** run.

```rust
 pub struct PingRequest {
     #[serde(default)]
     pub expect_protocol: Option<u32>,
+    /// DRIFT PROBE ONLY.
+    #[serde(default)]
+    pub trace_id: Option<String>,
 }
```

`cargo test -p quoin-schemas --test tc_type_surface`, verbatim:

```
   Compiling quoin-core v0.1.0 (/home/peter/dev/quoin/rust/crates/quoin-core)
   Compiling quoin-schemas v0.1.0 (/home/peter/dev/quoin/rust/crates/quoin-schemas)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.68s
     Running tests/tc_type_surface.rs (/tmp/claude-1000/-home-peter-dev/f9d5ce73-c50b-47d4-8573-24724e7a263b/scratchpad/ct/debug/deps/tc_type_surface-baf3fd8f01a40fc3)

running 10 tests
test tc_1612_the_diagnostic_interface_is_rendered_literally ... ok
test tc_1612_the_generated_surface_declares_every_type_that_crosses_the_boundary ... ok
test tc_1613_the_generated_surface_carries_a_complete_provenance_record ... ok
test tc_1613_an_artefact_missing_a_provenance_field_fails_the_gate ... ok
test tc_1614_no_hand_written_declaration_shadows_a_generated_boundary_type ... ok
test tc_1612_the_committed_source_schema_digest_is_the_current_one ... FAILED
test tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest ... FAILED
test tc_1615_the_committed_file_is_generated_current_and_unmodified ... FAILED
test tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used ... FAILED
test tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path ... FAILED

failures:

---- tc_1612_the_committed_source_schema_digest_is_the_current_one stdout ----

thread 'tc_1612_the_committed_source_schema_digest_is_the_current_one' (1953015) panicked at crates/quoin-schemas/tests/tc_type_surface.rs:61:5:
assertion `left == right` failed: the JSON Schema read off the Rust boundary types has moved since `make types` last ran
  left: "a5fcae17dc1faef8c16e5d923fa47b2ccdbfa692edb81c8f160af1056a15ae23"
 right: "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest stdout ----

thread 'tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest' (1953014) panicked at crates/quoin-schemas/tests/tc_type_surface.rs:48:5:
assertion `left == right` failed: a Rust boundary type changed without `make types`. `src/core/types.ts` no longer describes the types that serialise on the wire; regenerate it and review the diff.
  left: "c730d958ffaee6bec0835e90ee5f6ddf7f01843c59756d64397ecfada9063d30"
 right: "782c3a54e0e3d9fce94048514c61e315fb6a6bfb8c624eb05c16f047c16dda1f"

---- tc_1615_the_committed_file_is_generated_current_and_unmodified stdout ----

thread 'tc_1615_the_committed_file_is_generated_current_and_unmodified' (1953022) panicked at crates/quoin-schemas/tests/tc_type_surface.rs:153:50:
called `Result::unwrap()` on an `Err` value: StaleSourceSchema { recorded: "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920", current: "a5fcae17dc1faef8c16e5d923fa47b2ccdbfa692edb81c8f160af1056a15ae23" }

---- tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used stdout ----

thread 'tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used' (1953023) panicked at crates/quoin-schemas/tests/tc_type_surface.rs:185:5:
assertion `left == right` failed: a stale artefact must be named stale, not merely different
  left: StaleSourceSchema { recorded: "0000000000000000000000000000000000000000000000000000000000000000", current: "a5fcae17dc1faef8c16e5d923fa47b2ccdbfa692edb81c8f160af1056a15ae23" }
 right: StaleSourceSchema { recorded: "0000000000000000000000000000000000000000000000000000000000000000", current: "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920" }

---- tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path stdout ----

thread 'tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path' (1953021) panicked at crates/quoin-schemas/tests/tc_type_surface.rs:169:5:
assertion `left == right` failed: a hand edit must be a content-digest finding
  left: StaleSourceSchema { recorded: "eecd4353aa98673bdf373a274c1037dbff46a87b8caee975cf50438dc4915920", current: "a5fcae17dc1faef8c16e5d923fa47b2ccdbfa692edb81c8f160af1056a15ae23" }
 right: ContentDigest { expected: "782c3a54e0e3d9fce94048514c61e315fb6a6bfb8c624eb05c16f047c16dda1f", observed: "87265811d3ced0c1d85a5c9557d6027c190225146aefdc2c1491180eed168be2" }


failures:
    tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest
    tc_1612_the_committed_source_schema_digest_is_the_current_one
    tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path
    tc_1615_the_committed_file_is_generated_current_and_unmodified
    tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used

test result: FAILED. 5 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p quoin-schemas --test tc_type_surface`
```

Restoring `ops/core.rs` with no other change, verbatim:

```
   Compiling quoin-core v0.1.0 (/home/peter/dev/quoin/rust/crates/quoin-core)
   Compiling quoin-schemas v0.1.0 (/home/peter/dev/quoin/rust/crates/quoin-schemas)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.61s
     Running tests/tc_type_surface.rs (/tmp/claude-1000/-home-peter-dev/f9d5ce73-c50b-47d4-8573-24724e7a263b/scratchpad/ct/debug/deps/tc_type_surface-baf3fd8f01a40fc3)

running 10 tests
test tc_1612_the_diagnostic_interface_is_rendered_literally ... ok
test tc_1612_the_generated_surface_declares_every_type_that_crosses_the_boundary ... ok
test tc_1613_the_generated_surface_carries_a_complete_provenance_record ... ok
test tc_1612_the_committed_source_schema_digest_is_the_current_one ... ok
test tc_1613_an_artefact_missing_a_provenance_field_fails_the_gate ... ok
test tc_1612_a_fresh_render_of_the_rust_types_matches_the_committed_digest ... ok
test tc_1614_no_hand_written_declaration_shadows_a_generated_boundary_type ... ok
test tc_1616_an_artefact_with_a_stale_source_schema_digest_is_refused_rather_than_used ... ok
test tc_1615_the_committed_file_is_generated_current_and_unmodified ... ok
test tc_1615_a_hand_edit_fails_the_gate_at_an_unchanged_path ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

The failure is specific, not generic: both digests are named, and the message tells you the repair (`make types`, then review the diff) rather than reporting "mismatch".

## One hand-written duplicate found, and how

`tc_1614_no_hand_written_declaration_shadows_a_generated_boundary_type` matches on the **field set**, not the name. Its first run reported:

```
src/core/exec.ts declares `CoreDiagnostic` with the fields of `Diagnostic`,
which src/core/types.ts publishes
```

Three fields that happened to agree with `quoin_core::protocol::Diagnostic` — a hand-written type that matched, which is exactly what FR-097 forbids, because it drifts silently and nothing catches it. A name-keyed check would have reported clean over it. It is now `export type CoreDiagnostic = Diagnostic;`.

**One exemption, stated in the test rather than skipped:** `src/core/reference.ts`. It is the differential harness's TypeScript oracle (FR-101), and its entire value is that it was written against the documented contract and *not* against the Rust source. If it imported the generated types, the harness would compare quoin-core to a transliteration of itself and its twelve comparisons would prove only that two things written the same week agree. The test asserts the exemption list is exactly `["reference.ts"]`, so a second file cannot join it by being quietly added to a `continue`.

## Trace tags name criteria

Every `/// Trace:` tag added here is a full criterion id — `FR-097-AC-1`, `-AC-2`, `-AC-4`, `-AC-5`, `FR-097-CON-1` — because `scripts/check-trace-tags.mjs`'s criterion regex requires the `-AC-n`/`-M-n` suffix and a bare `FR-097` binds nothing. The nine existing bare tags and that script belong to another agent this session and are untouched here.

The fcd-published half of FR-097-AC-3 waits on the Phase B gate (fcd#11) and is not faked.

## Dependency pins: resolved, not conceded

`cargo deny` failed on first run with two `syn` majors in the graph. It was not worked around by editing `deny.toml`:

- `schemars` is pinned `=1.2.1` **and not 1.2.2**, because `schemars_derive` 1.2.2 moved to `syn` 3 while `serde_derive` 1.0.228 and `thiserror-impl` 2.0.18 are on `syn` 2, and `multiple-versions = "deny"` refuses the pair — correctly. The emitted schema digest is byte-identical between 1.2.1 and 1.2.2, so this costs nothing.
- The lockfile holds `ref-cast` at 1.0.25 for the same reason; 1.0.26 moved `ref-cast-impl` to `syn` 3. `ref-cast` is not a dependency this workspace declares, so the lock is the only place to state it.

`cargo deny` is what keeps both true: a `cargo update` reintroducing either duplicate fails `make rust-deny` rather than being quietly absorbed. No `deny.toml` edit, no licence added to the allow-list.

```
advisories ok
bans ok
licenses ok
sources ok
```

## Gates

`make rust-gate` green: fmt, clippy `-D warnings`, cargo deny, tests, the end-to-end caller, the differential harness.

**51 Rust tests, up from 30.** `quoin-schemas` contributed zero before this and contributes 21 now (11 unit + 10 `tc_type_surface`). The rest: 21 quoin-core unit, 6 `tc_boundary`, 3 `tc_source_conventions`. Difftest: `12 case(s), 0 difference(s)`.

TypeScript: 107 files / 1211 tests passing, `tsc --noEmit` clean, eslint clean, `prettier --check .` → "All matched files use Prettier code style!".

## Shared files, declared

`rust/Cargo.toml`, `rust/Cargo.lock` and `rust/crates/quoin-core/Cargo.toml` are shared with the agent on #384 (`feat/384-quoin-assurance`), which carried an earlier copy of these same FR-097 manifest lines into its own commit while we shared a working tree. Only the FR-097 lines are staged here; the `quoin-assurance` lines are theirs. **Expect a keep-both conflict on those three files — nothing is lost on either side.**

The `quoin-core` source changes (`protocol.rs`, `ops/core.rs`) are the derive attributes and the `PROTOCOL_VERSION` relocation, which are FR-097's mechanism and cannot live anywhere else.

Refs #373, #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXzHssfDmjdPz89YBdjqqp
