### PR TITLE
quoin-assurance: the assurance-case view across the boundary (#384)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1190,10 +1190,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoin-assurance"
+version = "0.1.0"
+dependencies = [
+ "quoin-finding-types",
+ "quoin-quire-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quoin-core"
 version = "0.1.0"
 dependencies = [
  "engineering-assurance",
+ "quoin-assurance",
  "schemars",
  "serde",
  "serde_json",
@@ -1209,6 +1220,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoin-finding-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quoin-quire"
 version = "0.1.0"
 dependencies = [
@@ -1216,6 +1235,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "quoin-quire-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,6 +53,7 @@ publish = false
 # Exact pins, matching quire-corpus. A caret range makes the gate a claim about
 # whatever resolved that morning; `=` makes it a claim about these bytes.
 [workspace.dependencies]
+quoin-assurance = { path = "crates/quoin-assurance" }
 quoin-core = { path = "crates/quoin-core" }
 quoin-finding-types = { path = "crates/quoin-finding-types" }
 quoin-quire-types = { path = "crates/quoin-quire-types" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -54,6 +54,8 @@ publish = false
 # whatever resolved that morning; `=` makes it a claim about these bytes.
 [workspace.dependencies]
 quoin-core = { path = "crates/quoin-core" }
+quoin-finding-types = { path = "crates/quoin-finding-types" }
+quoin-quire-types = { path = "crates/quoin-quire-types" }
 quoin-schemas = { path = "crates/quoin-schemas" }
 serde = { version = "=1.0.229", features = ["derive"] }
 # FR-097: the JSON Schema the generated TypeScript surface is derived from.

--- a/rust/crates/quoin-assurance/Cargo.toml
+++ b/rust/crates/quoin-assurance/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Agent-IX
+[package]
+name = "quoin-assurance"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "The assurance-case view: a read-only projection over evidence already collected."
+publish.workspace = true
+
+[lib]
+name = "quoin_assurance"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/rust/crates/quoin-assurance/src/case.rs
+++ b/rust/crates/quoin-assurance/src/case.rs
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! The assurance case as a graph (quoin#384, ported from `src/assurance/graph.ts`).
+//!
+//! A **claim** is argued by explicit reasoning over sub-claims, and the leaves
+//! are **evidence**. A pile of green obligations is not an argument; the
+//! argument is the authored reasoning and its visible gaps.
+//!
+//! **This is strictly a view.** It collects nothing, computes no coverage and
+//! writes nothing. Where the case cannot be built, that is a finding against
+//! the spec or the store — never something the view fills in.
+//!
+//! # The type budget, and why it is smaller than the import list
+//!
+//! `buildCase` imports five types from four directories, which is what
+//! quoin#425 sized four missing crates from. The **field subset** it can
+//! observe is twelve fields, and two of the five types it never reads:
+//!
+//! | type | what the view reads |
+//! |---|---|
+//! | `Finding` | 3 of 12 — `obligation`, `kind`, `summary` |
+//! | `Obligation` | 2 of 9 — `id`, `statement` |
+//! | `BundleDocument` | `frontmatter`, which is untyped at the source |
+//! | `TrustAssessment` | one sort key |
+//! | `IndependenceAssessment` | one sort key |
+//!
+//! So two get real types ([`quoin_finding_types::Finding`],
+//! [`quoin_quire_types::Obligation`]) and three do not, each for a reason
+//! stated where it applies below. Sizing from the import graph would have
+//! produced four crates, three of which could declare only shapes no
+//! behaviour here observes — and a difftest comparing canonical JSON bytes
+//! cannot tell a faithful port of an unobserved shape from a wrong one.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use quoin_finding_types::Finding;
+use quoin_quire_types::Obligation;
+use serde::{Deserialize, Serialize};
+
+use crate::requirement_of;
+
+/// Internal node kinds for the legacy derived view; not an external format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NodeKind {
+    /// A claim or sub-claim.
+    Goal,
+    /// Reserved by the retained type; this view mints none.
+    Strategy,
+    /// A leaf: one obligation.
+    Solution,
+}
+
+/// Whether a node's part of the argument holds.
+///
+/// `open` is the point of the whole view. An undischarged obligation or a
+/// suspect binding stays in the tree as an **undeveloped goal** rather than
+/// being dropped: a case that silently narrows to only what it can prove reads
+/// as complete, and that is the failure this program exists to catch.
+///
+/// A closed enum here, unlike [`Finding::kind`], and the difference is which
+/// side mints the value. This one is produced by this code, so the set is
+/// genuinely closed; `kind` arrives from a caller, so it is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NodeStatus {
+    /// Every part of this node's argument holds.
+    Supported,
+    /// Something is missing, and the reader must see it.
+    Open,
+}
+
+/// One node of the case tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CaseNode {
+    /// The document or obligation id.
+    pub id: String,
+    /// What sort of node this is.
+    pub kind: NodeKind,
+    /// What the node asserts, in the spec's own words where it has them.
+    pub statement: String,
+    /// Whether this part of the argument holds.
+    pub status: NodeStatus,
+    /// Why it is open — the auditor's finding, verbatim. Absent when supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub because: Option<String>,
+    /// Sub-claims first, then evidence.
+    pub children: Vec<CaseNode>,
+}
+
+/// A document whose frontmatter could not be read.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Unreadable {
+    /// Path, relative to the bundle root.
+    pub path: String,
+    /// Why it could not be read.
+    pub reason: String,
+}
+
+/// The built case.
+///
+/// # The payload is `camelCase`, the request is `snake_case`
+///
+/// Not an inconsistency. The **payload** is quoin's existing contract: it is
+/// what `src/assurance/graph.ts` already returns to every consumer, and the
+/// difftest compares canonical stdout bytes, so a renamed key here is a
+/// difference. The **request** is new surface minted at this boundary, and it
+/// follows the boundary's own convention (`expect_protocol`, `obligation_id`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssuranceCase {
+    /// Top-level claims, one tree each.
+    pub claims: Vec<CaseNode>,
+    /// Present exactly when `claims` is empty: why there is no case, naming
+    /// the claim types that were searched.
+    ///
+    /// The human renderer already explained this; the JSON payload carried no
+    /// equivalent, so a machine consumer could not tell "the assurance case is
+    /// clean" from "nothing matched, so nothing was argued" (quoin#170).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Requirements reachable from no claim.
+    ///
+    /// Not an error and not hidden: a bundle whose `StR`s do not reach its `FR`s
+    /// has a traceability gap, and the view's job is to make that visible
+    /// rather than to render a tidy case over the reachable half.
+    pub unreachable: Vec<String>,
+    /// Documents whose frontmatter could not be read.
+    pub unreadable: Vec<Unreadable>,
+    /// Use-specific producer reliance shown as context, never claim support.
+    pub producer_trust: Vec<serde_json::Value>,
+    /// Profile-selected separation results, shown as context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_independence: Option<Vec<serde_json::Value>>,
+}
+
+/// What the view is given to read.
+///
+/// # `documents` is `Value`, and that is the retained type
+///
+/// `BundleDocument.frontmatter` is `Record<string, unknown>` at the source,
+/// and every read of it in `buildCase` is a dynamic lookup behind a `String()`
+/// coercion and a runtime guard. `serde_json::Value` is therefore not a
+/// weakening — it is the same type. Porting it as a struct would invent a
+/// schema the TypeScript deliberately declines to assert, and the invented one
+/// would then diverge from whatever the corpus actually writes.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaseInput {
+    /// Frontmatter of every document in the bundle.
+    pub documents: Vec<serde_json::Value>,
+    /// Obligations, from `quire coverage --json`.
+    pub obligations: Vec<Obligation>,
+    /// The auditor's findings, keyed by obligation elsewhere.
+    pub findings: Vec<Finding>,
+    /// Artifact types that are top-level claims.
+    ///
+    /// Defaults to `StR`. A safety or security bundle argues from a declared
+    /// hazard or threat instead, and that vocabulary is module data — so it is
+    /// a parameter here, never a constant.
+    #[serde(default)]
+    pub claim_types: Option<Vec<String>>,
+    /// Documents whose frontmatter could not be read.
+    #[serde(default)]
+    pub unreadable: Option<Vec<Unreadable>>,
+    /// Producer trust, carried through verbatim. See [`sorted_by_key`].
+    #[serde(default)]
+    pub producer_trust: Option<Vec<serde_json::Value>>,
+    /// Independence assessments, carried through verbatim.
+    #[serde(default)]
+    pub evidence_independence: Option<Vec<serde_json::Value>>,
+}
+
+/// The edge verbs that mean "this document elaborates that one".
+const DOWNWARD_FROM_CHILD: [&str; 6] = [
+    "traces_to",
+    "refines",
+    "implements",
+    "derives_from",
+    "mitigates",
+    "satisfies",
+];
+
+/// Build the case.
+///
+/// The decomposition is read from the documents' own `relationships`, in the
+/// child→parent direction the corpus actually authors: an FR says it
+/// `traces_to` an `StR`, not the other way round.
+#[must_use]
+pub fn build_case(input: &CaseInput) -> AssuranceCase {
+    // Case-insensitive: `--claim-type str`, `STR` or `Hazard` used to match by
+    // `===` against the authored `type:` and silently produce an empty case —
+    // indistinguishable from a corpus that genuinely declares no claims
+    // (quoin#170).
+    let requested: Vec<String> = input
+        .claim_types
+        .clone()
+        .unwrap_or_else(|| vec!["StR".to_owned()]);
+    let claim_types: BTreeSet<String> = requested.iter().map(|t| t.to_lowercase()).collect();
+
+    // `BTreeMap` rather than a hash map: the retained code iterates a JS `Map`
+    // in insertion order to mint claims, then sorts them by id. Sorted
+    // iteration reaches the same set and makes the order of `unreachable`
+    // (also sorted downstream) independent of input order rather than
+    // accidentally stable.
+    let mut by_id: BTreeMap<String, &serde_json::Value> = BTreeMap::new();
+    let mut insertion: Vec<String> = Vec::new();
+    for doc in &input.documents {
+        if let Some(id) = id_of(doc) {
+            if by_id.insert(id.clone(), doc).is_none() {
+                insertion.push(id);
+            } else {
+                // Last-wins, matching `Map.set`. The id keeps its first
+                // position in `insertion`, which is also what JS does.
+            }
+        }
+    }
+
+    // parent id → child ids, inverted from the edges each child declares.
+    let mut children: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for doc in &input.documents {
+        let Some(id) = id_of(doc) else { continue };
+        for parent in parents_of(doc) {
+            if !by_id.contains_key(&parent) {
+                continue;
+            }
+            children.entry(parent).or_default().push(id.clone());
+        }
+    }
+
+    let mut finding_for: BTreeMap<&str, &Finding> = BTreeMap::new();
+    for finding in &input.findings {
+        // First wins: the auditor already orders by severity, so the first
+        // finding for an obligation is its most serious one, and that is the
+        // one a reader needs on the node.
+        finding_for.entry(&finding.obligation).or_insert(finding);
+    }
+
+    let mut obligations_for: BTreeMap<&str, Vec<&Obligation>> = BTreeMap::new();
+    for obligation in &input.obligations {
+        obligations_for
+            .entry(requirement_of(&obligation.id))
+            .or_default()
+            .push(obligation);
+    }
+
+    let mut claims: Vec<CaseNode> = Vec::new();
+    let mut reached: BTreeSet<String> = BTreeSet::new();
+    for id in &insertion {
+        let Some(doc) = by_id.get(id.as_str()) else {
+            continue;
+        };
+        let declared = doc
+            .get("frontmatter")
+            .and_then(|f| f.get("type"))
+            .map_or_else(String::new, string_of)
+            .to_lowercase();
+        if !claim_types.contains(&declared) {
+            continue;
+        }
+        // A fresh `ancestors` set per claim. Sharing one across claims made a
+        // requirement that refines TWO claims appear under only the first,
+        // while the second reported "no sub-claim traces to this claim" — a
+        // statement that was false, in an assurance case, about the very edge
+        // the author had written. Cycle prevention and "already rendered
+        // somewhere" are different questions and have different sets.
+        claims.push(node_for(
+            id,
+            &by_id,
+            &children,
+            &obligations_for,
+            &finding_for,
+            &mut reached,
+            &BTreeSet::new(),
+        ));
+    }
+    claims.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut unreachable: Vec<String> = by_id
+        .keys()
+        .filter(|id| !reached.contains(*id) && obligations_for.contains_key(id.as_str()))
+        .cloned()
+        .collect();
+    unreachable.sort();
+
+    let reason = if claims.is_empty() {
+        // The human renderer's explanation, made machine-readable. Naming the
+        // SEARCHED types (as the caller spelled them) is what lets a pipeline
+        // see that `--claim-type hazard` over a hazard-free corpus argued
+        // nothing.
+        Some(format!(
+            "no document declares itself a top-level claim (searched claim types: {}); declare one or pass --claim-type",
+            requested.join(", ")
+        ))
+    } else {
+        None
+    };
+
+    AssuranceCase {
+        claims,
+        reason,
+        unreachable,
+        unreadable: input.unreadable.clone().unwrap_or_default(),
+        producer_trust: sorted_by_key(input.producer_trust.as_deref().unwrap_or_default(), "id"),
+        evidence_independence: input
+            .evidence_independence
+            .as_deref()
+            .map(|values| sorted_by_key(values, "obligation")),
+    }
+}
+
+/// Sort opaque assessments by one string field, carrying them through unchanged.
+///
+/// # Why these two are `Value` and not ported types
+///
+/// `TrustAssessment` and `IndependenceAssessment` are the two types
+/// `buildCase` never inspects. Across all of `src/assurance/`, every mention
+/// is a type position or one of these two sorts: it reads `id` and
+/// `obligation` as sort keys and re-emits the whole value untouched. It never
+/// branches on `status`, never reads `dimensions`, never reads `triggeredBy`.
+///
+/// Declaring those shapes here would declare something no behaviour observes,
+/// in a crate whose only reason to exist is that a type name appears in an
+/// import. The difftest compares canonical JSON bytes, so it could not tell a
+/// faithful port of an unobserved field from a wrong one — a gate that cannot
+/// fail. The difftest case `assurance/build-case-assessments-pass-through`
+/// carries a non-trivial assessment through this function and proves the bytes
+/// survive, which is what converts "it cannot fail" into "here it is passing".
+///
+/// A stable sort, like `Array.prototype.sort`: entries with equal keys keep
+/// their input order rather than being reordered by an unstable algorithm.
+fn sorted_by_key(values: &[serde_json::Value], key: &str) -> Vec<serde_json::Value> {
+    let mut out = values.to_vec();
+    out.sort_by(|a, b| {
+        let left = a.get(key).map_or_else(String::new, string_of);
+        let right = b.get(key).map_or_else(String::new, string_of);
+        left.cmp(&right)
+    });
+    out
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "mirrors the retained recursion's parameter list; bundling them into a context struct would hide which of the two sets is passed by value at each call, and that distinction is the quoin#170 fix"
+)]
+fn node_for(
+    id: &str,
+    by_id: &BTreeMap<String, &serde_json::Value>,
+    children: &BTreeMap<String, Vec<String>>,
+    obligations_for: &BTreeMap<&str, Vec<&Obligation>>,
+    finding_for: &BTreeMap<&str, &Finding>,
+    reached: &mut BTreeSet<String>,
+    ancestors: &BTreeSet<String>,
+) -> CaseNode {
+    reached.insert(id.to_owned());
+    let mut ancestors = ancestors.clone();
+    ancestors.insert(id.to_owned());
+
+    // `String(doc?.frontmatter.title ?? id)`. The `??` is why an explicit
+    // `null` falls through to the id rather than stringifying: a document that
+    // writes `title:` with no value must render as its id, not as an empty
+    // statement in an assurance case.
+    let title = by_id
+        .get(id)
+        .and_then(|doc| doc.get("frontmatter"))
+        .and_then(|f| f.get("title"))
+        .filter(|title| !title.is_null())
+        .map_or_else(|| id.to_owned(), string_of);
+
+    // `ancestors`, not `reached`: a child already rendered under a DIFFERENT
+    // claim must still appear here, and only a child on this path is a cycle.
+    let mut sub_ids: Vec<&String> = children
+        .get(id)
+        .map(|ids| ids.iter().filter(|c| !ancestors.contains(*c)).collect())
+        .unwrap_or_default();
+    sub_ids.sort();
+
+    let mut parts: Vec<CaseNode> = sub_ids
+        .into_iter()
+        .map(|child| {
+            node_for(
+                child,
+                by_id,
+                children,
+                obligations_for,
+                finding_for,
+                reached,
+                &ancestors,
+            )
+        })
+        .collect();
+
+    let mut evidence: Vec<&Obligation> = obligations_for.get(id).cloned().unwrap_or_default();
+    evidence.sort_by(|a, b| a.id.cmp(&b.id));
+    parts.extend(
+        evidence
+            .into_iter()
+            .map(|obligation| solution_for(obligation, finding_for)),
+    );
+
+    // A goal with no sub-goals and no evidence is open, which a reader must
+    // see. Rendering it as supported would assure a claim on the strength of
+    // nobody having written anything.
+    let status = if parts.is_empty() || parts.iter().any(|p| p.status == NodeStatus::Open) {
+        NodeStatus::Open
+    } else {
+        NodeStatus::Supported
+    };
+    let because = if parts.is_empty() {
+        Some("no sub-claim and no obligation traces to this claim".to_owned())
+    } else {
+        None
+    };
+
+    CaseNode {
+        id: id.to_owned(),
+        kind: NodeKind::Goal,
+        statement: title,
+        status,
+        because,
+        children: parts,
+    }
+}
+
+fn solution_for(obligation: &Obligation, finding_for: &BTreeMap<&str, &Finding>) -> CaseNode {
+    let finding = finding_for.get(obligation.id.as_str());
+    CaseNode {
+        id: obligation.id.clone(),
+        kind: NodeKind::Solution,
+        statement: obligation.statement.clone(),
+        status: if finding.is_some() {
+            NodeStatus::Open
+        } else {
+            NodeStatus::Supported
+        },
+        because: finding.map(|f| format!("{}: {}", f.kind, f.summary)),
+        children: Vec::new(),
+    }
+}
+
+/// The document's own id, from frontmatter.
+///
+/// Non-string or empty ids yield `None`, matching the retained guard
+/// (`typeof id === "string" && id.length > 0`) rather than coercing — a
+/// numeric `id: 7` is not an id here, and must not become `"7"`.
+fn id_of(doc: &serde_json::Value) -> Option<String> {
+    match doc.get("frontmatter")?.get("id")? {
+        serde_json::Value::String(id) if !id.is_empty() => Some(id.clone()),
+        _ => None,
+    }
+}
+
+/// Ids this document declares itself to elaborate.
+fn parents_of(doc: &serde_json::Value) -> Vec<String> {
+    let Some(serde_json::Value::Array(rels)) =
+        doc.get("frontmatter").and_then(|f| f.get("relationships"))
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in rels {
+        if !entry.is_object() {
+            continue;
+        }
+        let edge = entry.get("type").map_or_else(String::new, string_of);
+        if !DOWNWARD_FROM_CHILD.contains(&edge.as_str()) {
+            continue;
+        }
+        let target = entry.get("target").map_or_else(String::new, string_of);
+        // `ix://org/component/ID` or a bare id — take the last segment either
+        // way. `split("/").pop()` on an empty string yields `""` in JS, which
+        // the retained code then rejects with `if (id)`.
+        if let Some(id) = target.split('/').next_back()
+            && !id.is_empty()
+        {
+            out.push(id.to_owned());
+        }
+    }
+    out
+}
+
+/// `String(value)`, for the four JSON kinds the retained coercion can meet.
+///
+/// The retained code writes `String(entry.type ?? "")` and
+/// `String(doc.frontmatter.title ?? id)`, so a non-string in those positions
+/// is stringified rather than rejected, and this must do the same or the two
+/// implementations disagree on malformed frontmatter — which is exactly the
+/// frontmatter a real corpus has.
+fn string_of(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        // JS `String([1,2])` is `"1,2"` and `String({})` is `"[object
+        // Object]"`. Neither appears in the `type`/`title` positions of any
+        // corpus document, and reproducing JS's array-join and object-tag
+        // rules here would be porting a coercion table rather than a view.
+        // `serde_json`'s rendering differs, so the difftest would catch it if
+        // one ever arrived — which is the outcome we want over a silent
+        // agreement on a value neither side should see.
+        other => other.to_string(),
+    }
+}

--- a/rust/crates/quoin-assurance/src/lib.rs
+++ b/rust/crates/quoin-assurance/src/lib.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! The assurance-case view (quoin#384, Stage 5 of the burn-down).
+//!
+//! Ported from `src/assurance/`, which its own header describes as "strictly a
+//! view": it collects nothing, computes no coverage and writes nothing to the
+//! store. That property is why this is the first real capability across the
+//! boundary — there is no IO to model, so a difference between the two
+//! implementations is a difference in the logic and nowhere else.
+//!
+//! # Why this crate has no dependencies yet
+//!
+//! The retained module's five cross-directory imports are all `import type`,
+//! which is what makes it cycle-free. It does **not** make it dependency-free
+//! here: `build_case` needs `Obligation`, `BundleDocument`, `Finding`,
+//! `TrustAssessment` and `IndependenceAssessment` to exist as Rust types
+//! before it can be written, and four of those five belong to crates that do
+//! not exist yet.
+//!
+//! So the port starts with the part of the retained surface that names no
+//! imported type at all. That is not a shortcut: it puts a real retained
+//! capability through the whole pattern — request shape, exit taxonomy,
+//! differential comparison against the retained implementation — on a surface
+//! where a failure is legible.
+
+/// The requirement an obligation belongs to.
+///
+/// `FR-001-AC-3` → `FR-001`; `NFR-010-M-2` → `NFR-010`. Derived from the id
+/// rather than from an edge because obligations are minted from a document's
+/// own tables — the ownership is not in question, and an edge for it would be
+/// a second thing to keep in agreement.
+///
+/// # The suffix is deliberately unconstrained
+///
+/// The retained implementation is `/^([A-Za-z]+-\d+)/` and matches a *prefix*:
+/// everything after the requirement id is ignored, whatever it spells. That is
+/// load-bearing. An earlier check in this repository enumerated the suffixes it
+/// expected — `AC|CON|VC|EX|SC` — and silently skipped every `-M-` obligation,
+/// which is the whole `nfr-metric` source. A suffix list is a standing bet that
+/// nobody mints a new kind, and the engine took no such bet.
+///
+/// # Non-matching input is returned unchanged
+///
+/// Not an error, and not empty. An id the pattern does not recognise is still
+/// an id the caller holds, and returning it unchanged keeps the view total —
+/// a projection that drops rows it cannot classify reads as a clean case over
+/// a narrower population, which is the failure the retained module's header
+/// names.
+#[must_use]
+pub fn requirement_of(obligation_id: &str) -> &str {
+    let mut letters = 0usize;
+    let mut digits = 0usize;
+    let mut seen_dash = false;
+    let mut end = 0usize;
+
+    // A byte scan rather than an index walk: the workspace forbids
+    // `indexing_slicing`, and an id off an untrusted stream is exactly the
+    // input that lint exists for. Every branch below reads a byte the iterator
+    // handed over, so there is no position to get wrong.
+    for (offset, byte) in obligation_id.bytes().enumerate() {
+        if seen_dash {
+            // `\d+`
+            if byte.is_ascii_digit() {
+                digits += 1;
+                end = offset + 1;
+                continue;
+            }
+            // The match is a PREFIX: a suffix of any spelling ends the scan
+            // rather than failing it.
+            break;
+        }
+        // `[A-Za-z]+`
+        if byte.is_ascii_alphabetic() {
+            letters += 1;
+            continue;
+        }
+        if byte == b'-' && letters > 0 {
+            seen_dash = true;
+            continue;
+        }
+        return obligation_id;
+    }
+
+    if letters == 0 || !seen_dash || digits == 0 {
+        return obligation_id;
+    }
+    // `get` rather than a slice expression: `end` is an ASCII boundary by
+    // construction, and saying so with a fallible call means a future edit
+    // that breaks the invariant degrades to "unchanged" instead of panicking
+    // inside a view whose whole contract is that it is total.
+    obligation_id.get(..end).unwrap_or(obligation_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::requirement_of;
+
+    #[test]
+    fn takes_the_requirement_prefix() {
+        assert_eq!(requirement_of("FR-001-AC-3"), "FR-001");
+        assert_eq!(requirement_of("NFR-010-M-2"), "NFR-010");
+        assert_eq!(requirement_of("StR-009-VC-1"), "StR-009");
+    }
+
+    #[test]
+    fn ignores_a_suffix_of_any_spelling() {
+        // The defect a suffix allow-list produces, asserted directly.
+        assert_eq!(requirement_of("NFR-013-M-1"), "NFR-013");
+        assert_eq!(requirement_of("FR-042-QQQ-9"), "FR-042");
+        assert_eq!(requirement_of("US-024-EX-5"), "US-024");
+    }
+
+    #[test]
+    fn returns_an_unrecognised_id_unchanged() {
+        assert_eq!(requirement_of("not-an-id"), "not-an-id");
+        assert_eq!(requirement_of(""), "");
+        assert_eq!(requirement_of("123-456"), "123-456");
+        assert_eq!(requirement_of("FR"), "FR");
+        assert_eq!(requirement_of("FR-"), "FR-");
+    }
+
+    #[test]
+    fn a_bare_requirement_id_is_its_own_requirement() {
+        assert_eq!(requirement_of("FR-001"), "FR-001");
+    }
+
+    #[test]
+    fn handles_non_ascii_without_slicing_inside_a_character() {
+        // The slice above is only safe because every consumed byte is ASCII.
+        // A multi-byte character before the pattern must therefore fall to the
+        // unchanged path rather than panic.
+        assert_eq!(requirement_of("é-001-AC-1"), "é-001-AC-1");
+    }
+}

--- a/rust/crates/quoin-assurance/src/lib.rs
+++ b/rust/crates/quoin-assurance/src/lib.rs
@@ -18,11 +18,25 @@
 //! before it can be written, and four of those five belong to crates that do
 //! not exist yet.
 //!
-//! So the port starts with the part of the retained surface that names no
-//! imported type at all. That is not a shortcut: it puts a real retained
+//! So the port started with the part of the retained surface that names no
+//! imported type at all. That was not a shortcut: it put a real retained
 //! capability through the whole pattern — request shape, exit taxonomy,
 //! differential comparison against the retained implementation — on a surface
 //! where a failure is legible.
+//!
+//! # What measuring the field subset changed
+//!
+//! Sizing from the import list said four missing crates. Measuring the FIELD
+//! SUBSET `build_case` can observe said two: twelve fields across five types,
+//! and two of the five never read at all. [`case`] states the budget in full
+//! and gives the reason for each type that did not get one. The general form
+//! is that an import list sizes a crate from the module boundary, while a
+//! field subset sizes it from what the code can observe, and those differ by a
+//! factor of five here (quoin#425).
+
+pub mod case;
+
+pub use case::{AssuranceCase, CaseInput, CaseNode, NodeKind, NodeStatus, Unreadable, build_case};
 
 /// The requirement an obligation belongs to.
 ///

--- a/rust/crates/quoin-core/Cargo.toml
+++ b/rust/crates/quoin-core/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+quoin-assurance = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/crates/quoin-core/Cargo.toml
+++ b/rust/crates/quoin-core/Cargo.toml
@@ -25,7 +25,6 @@ workspace = true
 
 [dependencies]
 quoin-assurance = { workspace = true }
-quoin-schemas = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/crates/quoin-core/Cargo.toml
+++ b/rust/crates/quoin-core/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 
 [dependencies]
 quoin-assurance = { workspace = true }
+quoin-schemas = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/crates/quoin-core/src/dispatch.rs
+++ b/rust/crates/quoin-core/src/dispatch.rs
@@ -28,6 +28,7 @@ pub const OPERATIONS: &[&str] = &["core.ping"];
 /// or whatever the operation itself returns.
 pub fn dispatch(op: &str, request: &serde_json::Value) -> Result<Response, CoreError> {
     match op {
+        "assurance.requirement_of" => crate::ops::assurance::requirement_of(request),
         "core.ping" => crate::ops::core::ping(request),
         _ => Err(
             CoreError::new(CoreErrorCode::UnknownOp, "no such operation in this build")

--- a/rust/crates/quoin-core/src/dispatch.rs
+++ b/rust/crates/quoin-core/src/dispatch.rs
@@ -29,6 +29,7 @@ pub const OPERATIONS: &[&str] = &["core.ping"];
 pub fn dispatch(op: &str, request: &serde_json::Value) -> Result<Response, CoreError> {
     match op {
         "assurance.requirement_of" => crate::ops::assurance::requirement_of(request),
+        "assurance.build_case" => crate::ops::assurance::build_case(request),
         "core.ping" => crate::ops::core::ping(request),
         _ => Err(
             CoreError::new(CoreErrorCode::UnknownOp, "no such operation in this build")

--- a/rust/crates/quoin-core/src/ops/assurance.rs
+++ b/rust/crates/quoin-core/src/ops/assurance.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! Domain `assurance`: the read-only assurance-case view (quoin#384).
+//!
+//! The first REAL quoin capability across the boundary. Stage 0's `core.ping`
+//! proved the mechanism against a purpose-built oracle; every operation here
+//! is compared against the retained `src/assurance/` itself, which is the
+//! whole reason that module is retained rather than deleted (FR-101).
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CoreError, CoreErrorCode};
+use crate::protocol::Response;
+
+/// The largest obligation id this domain will accept, in bytes.
+///
+/// A bound rather than "as much as arrives": stdin is an untrusted stream
+/// (rust-review §11). Real ids are under 32 bytes; 4 KiB is far past anything
+/// a corpus mints and still refuses a stream.
+pub const MAX_OBLIGATION_ID_BYTES: usize = 4 * 1024;
+
+/// The request accepted by `assurance.requirement_of`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequirementOfRequest {
+    /// The obligation id to take the requirement prefix of.
+    pub obligation_id: String,
+}
+
+/// The payload `assurance.requirement_of` writes to stdout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RequirementOfPayload {
+    /// The requirement the obligation belongs to, or the id unchanged when it
+    /// matches no requirement pattern.
+    pub requirement: String,
+}
+
+/// Answer an `assurance.requirement_of`.
+///
+/// # Errors
+///
+/// - [`CoreErrorCode::BadRequest`] when stdin is not a [`RequirementOfRequest`].
+/// - [`CoreErrorCode::Refused`] when the id exceeds [`MAX_OBLIGATION_ID_BYTES`].
+pub fn requirement_of(request: &serde_json::Value) -> Result<Response, CoreError> {
+    let request: RequirementOfRequest = serde_json::from_value(request.clone()).map_err(|e| {
+        CoreError::new(CoreErrorCode::BadRequest, e.to_string())
+            .with_context("op", "assurance.requirement_of")
+    })?;
+
+    if request.obligation_id.len() > MAX_OBLIGATION_ID_BYTES {
+        return Err(CoreError::new(
+            CoreErrorCode::Refused,
+            "obligation id exceeds the accepted size",
+        )
+        .with_context("op", "assurance.requirement_of")
+        .with_context("limit_bytes", MAX_OBLIGATION_ID_BYTES.to_string())
+        .with_context("observed_bytes", request.obligation_id.len().to_string()));
+    }
+
+    let payload = serde_json::to_value(RequirementOfPayload {
+        requirement: quoin_assurance::requirement_of(&request.obligation_id).to_owned(),
+    })
+    .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?;
+
+    Ok(Response::ok(payload))
+}

--- a/rust/crates/quoin-core/src/ops/assurance.rs
+++ b/rust/crates/quoin-core/src/ops/assurance.rs
@@ -65,3 +65,48 @@ pub fn requirement_of(request: &serde_json::Value) -> Result<Response, CoreError
 
     Ok(Response::ok(payload))
 }
+
+/// The largest `assurance.build_case` request this domain will accept, in bytes.
+///
+/// A whole bundle's frontmatter, obligations and findings arrive in one
+/// request, so the ceiling is far above `assurance.requirement_of`'s — quoin's
+/// own bundle is 991 obligations and roughly 350 documents. 16 MiB is past
+/// anything a real corpus produces and still refuses a stream, which is the
+/// property the bound exists for (rust-style §11).
+pub const MAX_BUILD_CASE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Answer an `assurance.build_case`.
+///
+/// # Errors
+///
+/// - [`CoreErrorCode::BadRequest`] when stdin is not a [`CaseInput`].
+/// - [`CoreErrorCode::Refused`] when the request exceeds [`MAX_BUILD_CASE_BYTES`].
+///
+/// [`CaseInput`]: quoin_assurance::CaseInput
+pub fn build_case(request: &serde_json::Value) -> Result<Response, CoreError> {
+    // Measured on the parsed value rather than on raw stdin: the dispatcher
+    // has already read and parsed the stream, so this is the honest place to
+    // state a size the DOMAIN refuses, distinct from any transport ceiling.
+    let size = serde_json::to_vec(request)
+        .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?
+        .len();
+    if size > MAX_BUILD_CASE_BYTES {
+        return Err(
+            CoreError::new(CoreErrorCode::Refused, "request exceeds the accepted size")
+                .with_context("op", "assurance.build_case")
+                .with_context("limit_bytes", MAX_BUILD_CASE_BYTES.to_string())
+                .with_context("observed_bytes", size.to_string()),
+        );
+    }
+
+    let input: quoin_assurance::CaseInput =
+        serde_json::from_value(request.clone()).map_err(|e| {
+            CoreError::new(CoreErrorCode::BadRequest, e.to_string())
+                .with_context("op", "assurance.build_case")
+        })?;
+
+    let payload = serde_json::to_value(quoin_assurance::build_case(&input))
+        .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?;
+
+    Ok(Response::ok(payload))
+}

--- a/rust/crates/quoin-core/src/ops/mod.rs
+++ b/rust/crates/quoin-core/src/ops/mod.rs
@@ -7,4 +7,5 @@
 //! function (quoin#373). One module per domain; one entry per operation in
 //! [`crate::dispatch`].
 
+pub mod assurance;
 pub mod core;

--- a/rust/crates/quoin-difftest/src/main.rs
+++ b/rust/crates/quoin-difftest/src/main.rs
@@ -45,13 +45,37 @@ enum Request {
     Literal(&'static str),
     /// `{"echo": "x" * n}`.
     EchoOfBytes(usize),
+    /// A well-formed `assurance.build_case` request of exactly `n` bytes.
+    ///
+    /// Generated rather than written because the bound it probes is 16 MiB,
+    /// and "too large to put in the table" is a reason to generate the input,
+    /// not a reason to leave the boundary unasserted. Same class as the 64 MiB
+    /// `maxBuffer` incident, where the failure only appeared at a real payload
+    /// size — a limit nothing ever reaches is a limit nobody has tested.
+    ///
+    /// Both sides measure the RE-SERIALISED request, and `serde_json` sorts
+    /// object keys where `JSON.stringify` preserves insertion order. The two
+    /// orderings differ; their byte counts do not, which is why this works.
+    BuildCaseOfBytes(usize),
 }
+
+/// The `assurance.build_case` request [`Request::BuildCaseOfBytes`] pads.
+///
+/// Documents are empty on purpose: the padding rides in an obligation's
+/// statement, so a 16 MiB request still produces a few-hundred-byte payload
+/// and a difference is readable rather than being a wall of `x`.
+const BUILD_CASE_ENVELOPE: &str =
+    r#"{"documents":[],"obligations":[{"id":"FR-001-AC-1","statement":""}],"findings":[]}"#;
 
 impl Request {
     fn text(&self) -> String {
         match *self {
             Self::Literal(text) => text.to_owned(),
             Self::EchoOfBytes(n) => format!(r#"{{"echo":"{}"}}"#, "x".repeat(n)),
+            Self::BuildCaseOfBytes(n) => format!(
+                r#"{{"documents":[],"obligations":[{{"id":"FR-001-AC-1","statement":"{}"}}],"findings":[]}}"#,
+                "x".repeat(n.saturating_sub(BUILD_CASE_ENVELOPE.len()))
+            ),
         }
     }
 }
@@ -351,6 +375,20 @@ const CASES: &[Case] = &[
         request: Request::Literal(
             r#"{"documents":[],"obligations":[],"findings":[{"obligation":"FR-001-AC-1","summary":"s"}]}"#,
         ),
+    },
+    Case {
+        // The 16 MiB bound, from both directions. Until these existed the two
+        // sides' agreement about refusing an oversize request was asserted by
+        // nobody: the Rust unit test proved Rust refuses, and nothing proved
+        // the reference refuses the same byte.
+        name: "assurance/build-case-at-the-limit",
+        op: "assurance.build_case",
+        request: Request::BuildCaseOfBytes(16 * 1024 * 1024),
+    },
+    Case {
+        name: "assurance/build-case-refused-over-the-limit",
+        op: "assurance.build_case",
+        request: Request::BuildCaseOfBytes(16 * 1024 * 1024 + 1),
     },
     Case {
         name: "assurance/build-case-invalid-malformed",

--- a/rust/crates/quoin-difftest/src/main.rs
+++ b/rust/crates/quoin-difftest/src/main.rs
@@ -116,6 +116,57 @@ const CASES: &[Case] = &[
         op: "core.ping",
         request: Request::Literal("[1,2]"),
     },
+    // ── assurance.requirement_of (quoin#384) ──
+    //
+    // The first cases comparing a REAL retained capability. The TypeScript
+    // side calls `src/assurance/graph.ts`'s own `requirementOf`; it does not
+    // reimplement it. Everything above this line compares two implementations
+    // of a purpose-built ping.
+    Case {
+        name: "assurance/ac-suffix",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"FR-001-AC-3"}"#),
+    },
+    Case {
+        name: "assurance/metric-suffix",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"NFR-010-M-2"}"#),
+    },
+    Case {
+        name: "assurance/unknown-suffix-is-still-a-prefix-match",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"FR-042-QQQ-9"}"#),
+    },
+    Case {
+        name: "assurance/bare-requirement-id",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"FR-001"}"#),
+    },
+    Case {
+        name: "assurance/unrecognised-returns-unchanged",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"not-an-id"}"#),
+    },
+    Case {
+        name: "assurance/empty-id",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":""}"#),
+    },
+    Case {
+        name: "assurance/non-ascii-falls-to-unchanged",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"é-001-AC-1"}"#),
+    },
+    Case {
+        name: "assurance/invalid-unknown-field",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":"FR-001","extra":1}"#),
+    },
+    Case {
+        name: "assurance/invalid-wrong-type",
+        op: "assurance.requirement_of",
+        request: Request::Literal(r#"{"obligation_id":7}"#),
+    },
     Case {
         name: "invalid/unknown-op",
         op: "evidence.record",

--- a/rust/crates/quoin-difftest/src/main.rs
+++ b/rust/crates/quoin-difftest/src/main.rs
@@ -167,6 +167,201 @@ const CASES: &[Case] = &[
         op: "assurance.requirement_of",
         request: Request::Literal(r#"{"obligation_id":7}"#),
     },
+    // These two were missing from the nine, and their absence hid a real
+    // divergence: the reference parsed stdin INSIDE each handler and answered
+    // `CORE_BAD_REQUEST`, where `quoin-core` parses in the dispatcher and
+    // answers `CORE_BAD_JSON`. Malformed input is a transport verdict for
+    // every operation, so every operation must carry the cases that say so.
+    Case {
+        name: "assurance/requirement-of-invalid-malformed",
+        op: "assurance.requirement_of",
+        request: Request::Literal("{oops"),
+    },
+    Case {
+        name: "assurance/requirement-of-invalid-non-object",
+        op: "assurance.requirement_of",
+        request: Request::Literal("[1,2]"),
+    },
+    // ── assurance.build_case (quoin#384) ──
+    //
+    // The whole view, against the retained `src/assurance/graph.ts`. The
+    // TypeScript side CALLS it; it does not reimplement it.
+    Case {
+        name: "assurance/build-case-no-claim-declares-itself",
+        op: "assurance.build_case",
+        request: Request::Literal(r#"{"documents":[],"obligations":[],"findings":[]}"#),
+    },
+    Case {
+        name: "assurance/build-case-searched-types-are-named-back",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[],"claim_types":["Hazard","Threat"]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-a-claim-with-nothing-under-it-is-open",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}}],"obligations":[],"findings":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-claim-type-is-case-insensitive",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}}],"obligations":[],"findings":[],"claim_types":["str"]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-evidence-under-a-traced-requirement",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"A requirement","relationships":[{"type":"traces_to","target":"ix://org/comp/StR-001"}]}}],"obligations":[{"id":"FR-001-AC-2","statement":"second"},{"id":"FR-001-AC-1","statement":"first"}],"findings":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-a-finding-opens-the-whole-path",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"A requirement","relationships":[{"type":"traces_to","target":"ix://org/comp/StR-001"}]}}],"obligations":[{"id":"FR-001-AC-1","statement":"first"}],"findings":[{"obligation":"FR-001-AC-1","kind":"undischarged","summary":"nothing binds it","severity":"error","path":"src/x.ts","line":7}]}"#,
+        ),
+    },
+    Case {
+        // The property `quoin_finding_types::Finding::kind` argues for: a
+        // closed 12-variant enum would refuse this, and the retained
+        // implementation renders it. A difference here is the port being
+        // stricter than the thing it replaces.
+        name: "assurance/build-case-unknown-finding-kind",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"A requirement","relationships":[{"type":"traces_to","target":"StR-001"}]}}],"obligations":[{"id":"FR-001-AC-1","statement":"first"}],"findings":[{"obligation":"FR-001-AC-1","kind":"kind-invented-tomorrow","summary":"s"}]}"#,
+        ),
+    },
+    Case {
+        // The first finding per obligation wins, because the auditor has
+        // already ordered by severity. Two findings, and only one `because`.
+        name: "assurance/build-case-first-finding-per-obligation-wins",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"A requirement","relationships":[{"type":"traces_to","target":"StR-001"}]}}],"obligations":[{"id":"FR-001-AC-1","statement":"first"}],"findings":[{"obligation":"FR-001-AC-1","kind":"undischarged","summary":"most serious"},{"obligation":"FR-001-AC-1","kind":"stale-evidence","summary":"less serious"}]}"#,
+        ),
+    },
+    Case {
+        // quoin#170: a requirement refining TWO claims must appear under both.
+        // Sharing one `ancestors` set across claims made the second report
+        // "no sub-claim traces to this claim" about an edge the author wrote.
+        name: "assurance/build-case-a-requirement-under-two-claims",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"a.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"First"}},{"path":"b.md","body":"","frontmatter":{"id":"StR-002","type":"StR","title":"Second"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"Shared","relationships":[{"type":"refines","target":"StR-001"},{"type":"refines","target":"StR-002"}]}}],"obligations":[{"id":"FR-001-AC-1","statement":"first"}],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // A cycle must terminate, and only a node on THIS path is one.
+        name: "assurance/build-case-a-cycle-terminates",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"a.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"First","relationships":[{"type":"refines","target":"FR-001"}]}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"Cyclic","relationships":[{"type":"refines","target":"StR-001"}]}}],"obligations":[],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // A requirement with obligations that no claim reaches. Visible, not
+        // dropped: the gap IS the finding.
+        name: "assurance/build-case-unreachable-requirement",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-009","type":"FR","title":"Orphan"}}],"obligations":[{"id":"FR-009-AC-1","statement":"unreached"}],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // An edge verb outside the downward set is not decomposition.
+        name: "assurance/build-case-a-non-downward-edge-is-not-a-child",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":"The claim"}},{"path":"f.md","body":"","frontmatter":{"id":"FR-001","type":"FR","title":"Merely related","relationships":[{"type":"references","target":"StR-001"}]}}],"obligations":[{"id":"FR-001-AC-1","statement":"first"}],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // `String(title ?? id)`: an explicit null falls through to the id
+        // rather than rendering an empty statement in an assurance case.
+        name: "assurance/build-case-null-title-falls-through-to-the-id",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":"StR-001","type":"StR","title":null}}],"obligations":[],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // A non-string id is not an id, and must not be coerced into one.
+        name: "assurance/build-case-a-numeric-id-is-not-an-id",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[{"path":"s.md","body":"","frontmatter":{"id":7,"type":"StR","title":"Coerced?"}},{"path":"t.md","body":"","frontmatter":{"id":"","type":"StR","title":"Empty"}}],"obligations":[],"findings":[]}"#,
+        ),
+    },
+    Case {
+        // The condition of carrying these two through as opaque values: a
+        // non-trivial assessment, sorted by one key and emitted unchanged.
+        // Without this the pass-through is a gate that cannot fail.
+        name: "assurance/build-case-assessments-pass-through",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[],"producer_trust":[{"id":"T-002","useId":"U-2","producer":"p","status":"accepted-with-limitations","permittedDecisions":["release"],"limitations":["only on linux"],"triggeredBy":[{"kind":"version-change","detail":{"from":"1","to":"2"}}],"owner":"o"},{"id":"T-001","useId":"U-1","producer":"p","status":"unobserved","permittedDecisions":[],"limitations":[],"triggeredBy":[],"owner":"o"}],"evidence_independence":[{"profile":"P","requirement":"FR-002","obligation":"FR-002-AC-1","status":"insufficient","dimensions":[{"dimension":"author","status":"insufficient"}],"summary":"same author"},{"profile":"P","requirement":"FR-001","obligation":"FR-001-AC-1","status":"satisfied","dimensions":[],"satisfiedBy":["a","b"],"summary":"ok"}]}"#,
+        ),
+    },
+    Case {
+        // Ties keep input order: a stable sort, like `Array.prototype.sort`.
+        name: "assurance/build-case-equal-sort-keys-keep-input-order",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[],"producer_trust":[{"id":"T-001","marker":"second-in"},{"id":"T-001","marker":"third-in"},{"id":"T-000","marker":"first-by-key"}]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-unreadable-documents-are-carried",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[],"unreadable":[{"path":"broken.md","reason":"unterminated frontmatter"}]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-invalid-unknown-field",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[],"claimTypes":["StR"]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-invalid-missing-findings",
+        op: "assurance.build_case",
+        request: Request::Literal(r#"{"documents":[],"obligations":[]}"#),
+    },
+    Case {
+        // Parity on malformed input, which is the half a well-formed-only
+        // gate never reaches: serde refuses a numeric obligation id, so the
+        // reference must too rather than coercing it.
+        name: "assurance/build-case-invalid-obligation-id-not-a-string",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[{"id":7,"statement":"s"}],"findings":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-invalid-finding-missing-kind",
+        op: "assurance.build_case",
+        request: Request::Literal(
+            r#"{"documents":[],"obligations":[],"findings":[{"obligation":"FR-001-AC-1","summary":"s"}]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/build-case-invalid-malformed",
+        op: "assurance.build_case",
+        request: Request::Literal("{oops"),
+    },
+    Case {
+        name: "assurance/build-case-invalid-non-object",
+        op: "assurance.build_case",
+        request: Request::Literal("[1,2]"),
+    },
     Case {
         name: "invalid/unknown-op",
         op: "evidence.record",

--- a/rust/crates/quoin-finding-types/Cargo.toml
+++ b/rust/crates/quoin-finding-types/Cargo.toml
@@ -1,25 +1,25 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Agent-IX
 [package]
-name = "quoin-assurance"
+name = "quoin-finding-types"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "The assurance-case view: a read-only projection over evidence already collected."
+description = "The auditor's Finding, as the assurance view observes it."
 publish.workspace = true
 
 [lib]
-name = "quoin_assurance"
+name = "quoin_finding_types"
 path = "src/lib.rs"
 
 [lints]
 workspace = true
 
 [dependencies]
-quoin-finding-types = { workspace = true }
-quoin-quire-types = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
 serde_json = { workspace = true }

--- a/rust/crates/quoin-finding-types/src/lib.rs
+++ b/rust/crates/quoin-finding-types/src/lib.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! The auditor's [`Finding`], as the assurance view observes it (quoin#384).
+//!
+//! # Why this crate holds one type and not the auditor's four
+//!
+//! quoin#425 sized the remaining burn-down stages from the import graph. That
+//! is the wrong instrument, and this crate is the first place it shows. The
+//! retained `src/assurance/graph.ts` imports five types across four
+//! directories, so the import graph says "four crates". The **field subset**
+//! `buildCase` can actually observe says something else: twelve fields across
+//! five types, and two of the five never read at all.
+//!
+//! `Finding` is one of the two that is genuinely read, so it gets a real type.
+//! The auditor's other three types are not on `build_case`'s path, and putting
+//! them here because they share a directory with this one would be sizing from
+//! the module boundary again — the same mistake in the opposite direction.
+
+use serde::{Deserialize, Serialize};
+
+/// One auditor finding, restricted to the fields the assurance view reads.
+///
+/// # The subset is deliberate, and it is three of twelve
+///
+/// The retained `Finding` (`src/auditor/audit.ts`) carries twelve fields.
+/// `buildCase` reads exactly three: it keys findings by `obligation`, and
+/// renders `because` as `` `{kind}: {summary}` ``. It never reads `severity`,
+/// `path`, `line`, `symbol` or any of the structured action fields — not even
+/// to order by, because the auditor has already ordered its output and the
+/// view takes the first finding per obligation on that strength.
+///
+/// Declaring the other nine here would put fields in the payload that no
+/// behaviour depends on, and a difftest comparing canonical JSON bytes could
+/// not tell a correct one from an incorrect one. A field nothing observes is
+/// not covered by anything.
+///
+/// # Unknown fields are accepted, and must be
+///
+/// There is no `deny_unknown_fields`. The real auditor emits all twelve, and
+/// the caller hands this view the auditor's own output verbatim. Refusing the
+/// nine we do not read would refuse every real input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    /// The obligation the finding is against. The view's join key.
+    pub obligation: String,
+    /// What kind of finding it is.
+    ///
+    /// # Why this is a `String` and not an enum
+    ///
+    /// The retained type declares twelve spellings in a closed union, and it
+    /// is tempting to mirror that here — the spellings *are* observable,
+    /// because `because` interpolates this value into the payload.
+    ///
+    /// But a TypeScript union is erased at run time. `buildCase` performs no
+    /// validation: it interpolates whatever string arrives. A closed Rust enum
+    /// would therefore **refuse input the retained implementation accepts**,
+    /// turning a payload into a `BadRequest` — a behavioural difference, in
+    /// the direction of the port being stricter than the thing it replaces.
+    ///
+    /// This is the same defect class as the suffix enumeration in
+    /// [`quoin_assurance::requirement_of`]: writing the type from what the
+    /// declaration *says* rather than from what the code *does*. There the
+    /// enumeration dropped every `-M-` obligation; here it would drop every
+    /// finding kind added after this file was written. The difftest case
+    /// `assurance/build-case-unknown-finding-kind` holds the property.
+    ///
+    /// The twelve the auditor mints today, for the reader's benefit and not as
+    /// a constraint: `suspect-link`, `stale-evidence`, `vacuous-evidence`,
+    /// `combinatorial-gap`, `undischarged`, `method-conformance`,
+    /// `unknown-method`, `insufficient-independence`,
+    /// `insufficient-multiplicity`, `insufficient-mutation-score`,
+    /// `unmeasured-mutation-score`, `mocked-confirmation`.
+    pub kind: String,
+    /// The finding's one-line summary, rendered verbatim into `because`.
+    pub summary: String,
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::Finding;
+
+    #[test]
+    fn reads_a_finding_carrying_the_auditor_s_other_nine_fields() {
+        // The shape the real auditor emits. If this ever fails, the view has
+        // started refusing its own producer's output.
+        let finding: Finding = serde_json::from_str(
+            r#"{
+                "kind": "undischarged",
+                "obligation": "FR-001-AC-1",
+                "severity": "error",
+                "summary": "no evidence binds this criterion",
+                "path": "src/cli.ts",
+                "line": 42,
+                "symbol": "parseArgs",
+                "subject": "the criterion",
+                "changeTarget": "tests/cli.test.ts",
+                "remedy": "bind a test",
+                "nextDiagnosticStep": "run the suite"
+            }"#,
+        )
+        .expect("the auditor's own finding shape must deserialize");
+        assert_eq!(finding.obligation, "FR-001-AC-1");
+        assert_eq!(finding.kind, "undischarged");
+        assert_eq!(finding.summary, "no evidence binds this criterion");
+    }
+
+    #[test]
+    fn accepts_a_kind_no_closed_enum_would_admit() {
+        // The property the doc comment above argues for. A thirteenth kind is
+        // not this view's business to reject; it renders it and moves on.
+        let finding: Finding = serde_json::from_str(
+            r#"{"kind":"kind-invented-tomorrow","obligation":"FR-002-AC-1","summary":"s"}"#,
+        )
+        .expect("an unknown kind is not a parse error");
+        assert_eq!(finding.kind, "kind-invented-tomorrow");
+    }
+
+    #[test]
+    fn a_missing_read_field_is_a_hard_error() {
+        // All three are read unconditionally, so absence must fail loudly
+        // rather than default to empty and render a blank `because`.
+        for text in [
+            r#"{"kind":"undischarged","summary":"s"}"#,
+            r#"{"obligation":"FR-001-AC-1","summary":"s"}"#,
+            r#"{"obligation":"FR-001-AC-1","kind":"undischarged"}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<Finding>(text).is_err(),
+                "a finding missing a field the view reads must not deserialize: {text}"
+            );
+        }
+    }
+}

--- a/rust/crates/quoin-quire-types/Cargo.toml
+++ b/rust/crates/quoin-quire-types/Cargo.toml
@@ -1,25 +1,26 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Agent-IX
 [package]
-name = "quoin-assurance"
+name = "quoin-quire-types"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "The assurance-case view: a read-only projection over evidence already collected."
+description = "Deserialize-only readers for quire's wire formats. Quire owns these formats; this crate only reads them."
 publish.workspace = true
 
 [lib]
-name = "quoin_assurance"
+name = "quoin_quire_types"
 path = "src/lib.rs"
 
 [lints]
 workspace = true
 
 [dependencies]
-quoin-finding-types = { workspace = true }
-quoin-quire-types = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
 serde_json = { workspace = true }
+sha2 = { workspace = true }

--- a/rust/crates/quoin-quire-types/src/lib.rs
+++ b/rust/crates/quoin-quire-types/src/lib.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! Deserialize-only readers for quire's wire formats (quoin#384).
+//!
+//! # This crate defines nothing
+//!
+//! **quire owns every format in this crate.** These types are projections of
+//! what `quire coverage --json` emits, restricted to the fields quoin actually
+//! reads. They are not a definition, they do not compete with quire's own
+//! types, and quoin is not entitled to change the shape by changing this file.
+//!
+//! The alternative was a dependency on quire-rs's crate. Rejected: it buys a
+//! version coupling across the whole burn-down for two fields, and the
+//! burn-down is the thing that has to stay able to move.
+//!
+//! # What that obliges of anyone editing this crate
+//!
+//! Adding a field here is adding a field to a **reader**. Check quire's
+//! emitter first, and match its spelling exactly — a reader that invents a
+//! name reads nothing and reports empty, which is the silent-drift failure
+//! this whole program exists to catch.
+//!
+//! The coupling is recorded from quire's side too, so it is visible to the
+//! owner rather than only to us.
+//!
+//! # How drift is made loud
+//!
+//! Two mechanisms, because either alone is insufficient:
+//!
+//! 1. **Fields quoin reads are required, never `Option`.** A rename or removal
+//!    upstream fails deserialization at the boundary instead of reading as an
+//!    empty string and rendering a blank row.
+//! 2. **The fixture is captured from the pinned quire binary**, never written
+//!    by hand — a hand-written fixture asserts against bytes the test itself
+//!    invented, which FR-101 names as a self-fixture tautology. See
+//!    `tests/coverage_reader.rs`.
+//!
+//! There is deliberately **no** `deny_unknown_fields`: [`Obligation`] reads
+//! two of the nine fields quire emits, so unknown fields are the normal case
+//! and not an error.
+
+use serde::Deserialize;
+
+/// One obligation, as quoin reads it off `quire coverage --json`.
+///
+/// # Two fields of nine
+///
+/// quire emits `source`, `id`, `document`, `statement`, `statement_hash`,
+/// `method`, `parameters`, `criticality` and `target_ids`. The assurance view
+/// reads `id` (to derive the owning requirement, and as the solution node's
+/// id) and `statement` (as the node's statement). It reads none of the other
+/// seven — not even `document`, which a reader might reasonably expect a view
+/// to cite, and does not.
+///
+/// Both fields here are required, for the reason in the module header: they
+/// are read unconditionally, so their absence must be an error rather than a
+/// silent empty.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Obligation {
+    /// The obligation id, e.g. `FR-001-AC-1` or `NFR-010-M-2`.
+    pub id: String,
+    /// The criterion's statement, in the spec's own words.
+    pub statement: String,
+}

--- a/rust/crates/quoin-quire-types/tests/coverage_reader.rs
+++ b/rust/crates/quoin-quire-types/tests/coverage_reader.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! The [`Obligation`] reader, against bytes a real quire produced (quoin#384).
+//!
+//! # Why the fixture is captured and not written
+//!
+//! FR-101 names the self-fixture tautology: a test asserting against bytes the
+//! test itself invented proves that the author's idea of the format agrees
+//! with the author's idea of the format. quoin does not own this format —
+//! quire does — so a hand-written fixture here would be exactly that, and the
+//! first field quire renamed would read as an empty string in a passing suite.
+//!
+//! `tests/fixtures/coverage-obligations.json` is therefore output from
+//! `quire coverage --scope . --json` run over this repository, and
+//! `tests/fixtures/provenance.json` records which quire produced it: version
+//! string, resolved path and sha256 of the bytes at that path.
+//!
+//! # Why the digest is recorded but not compared against a live quire
+//!
+//! It would be better if this test resolved quire and compared. It cannot, and
+//! the reason is worth writing down rather than rediscovering: CI's `rust` job
+//! installs no quire at all, and the job that does have one **builds it from
+//! source** (`.ci/quire-cli`), so its bytes are not the npm-installed shim's
+//! bytes and never will be. A digest assertion here would fail in CI for a
+//! reason unrelated to drift, which is the fastest way to get a gate disabled.
+//!
+//! So provenance is recorded for a human, and the two checks below are what
+//! actually run. The second is the one that carries the weight: it verifies a
+//! property of the captured bytes that a person writing a fixture by hand
+//! could not produce, which is a machine-checkable answer to "did this really
+//! come from the engine".
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+
+use std::path::Path;
+
+use quoin_quire_types::Obligation;
+use sha2::{Digest as _, Sha256};
+
+fn fixture() -> serde_json::Value {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/coverage-obligations.json");
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "the captured fixture must be readable at {}: {e}",
+            path.display()
+        )
+    });
+    serde_json::from_str(&text).expect("the captured fixture must be JSON")
+}
+
+fn obligations(value: &serde_json::Value) -> &Vec<serde_json::Value> {
+    value
+        .get("obligations")
+        .and_then(serde_json::Value::as_array)
+        .expect("the capture must carry an `obligations` array")
+}
+
+/// Trace: FR-101
+#[test]
+fn reads_every_obligation_quire_emitted() {
+    let value = fixture();
+    let raw = obligations(&value);
+    assert!(
+        !raw.is_empty(),
+        "a fixture with no obligations checks nothing"
+    );
+
+    for entry in raw {
+        let obligation: Obligation = serde_json::from_value(entry.clone()).unwrap_or_else(|e| {
+            panic!("quire emitted an obligation this reader cannot read: {e}\n{entry}")
+        });
+        // The two fields quoin reads, present and non-empty. A reader that
+        // parses but yields "" is the silent-drift outcome this exists to
+        // prevent, and `Option` would have produced exactly that.
+        assert!(
+            !obligation.id.is_empty(),
+            "an obligation with no id: {entry}"
+        );
+        assert!(
+            !obligation.statement.is_empty(),
+            "an obligation with no statement: {entry}"
+        );
+    }
+}
+
+/// Trace: FR-101
+#[test]
+fn the_fixture_carries_engine_computed_digests() {
+    // The anti-self-fixture check. `statement_hash` is sha256 of `statement`,
+    // computed by the engine. Every captured row verifies, which a fixture
+    // typed by a person would not — the author would have to have run the
+    // digest themselves, and at that point they are capturing, not inventing.
+    //
+    // It also pins the pair: editing a `statement` in the fixture to make a
+    // test convenient breaks the digest, so the bytes cannot be quietly
+    // adjusted after capture.
+    let value = fixture();
+    for entry in obligations(&value) {
+        let statement = entry
+            .get("statement")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("no statement: {entry}"));
+        let recorded = entry
+            .get("statement_hash")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("no statement_hash: {entry}"));
+        let computed = format!("{:x}", Sha256::digest(statement.as_bytes()));
+        assert_eq!(
+            computed, recorded,
+            "statement_hash does not verify, so these bytes did not come from the engine: {entry}"
+        );
+    }
+}
+
+/// Trace: FR-101
+#[test]
+fn the_capture_still_covers_every_shape_quire_mints() {
+    // The capture was selected by census: one obligation per distinct
+    // (source, key-set) pair the run emitted, all six pairs present out of 991
+    // obligations. Asserting the count here means a careless recapture that
+    // narrows the fixture to one comfortable shape fails rather than passing
+    // with less coverage than the name implies.
+    let value = fixture();
+    let mut shapes: Vec<(String, Vec<String>)> = obligations(&value)
+        .iter()
+        .map(|entry| {
+            let source = entry
+                .get("source")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| panic!("no source: {entry}"))
+                .to_owned();
+            let mut keys: Vec<String> = entry
+                .as_object()
+                .unwrap_or_else(|| panic!("not an object: {entry}"))
+                .keys()
+                .cloned()
+                .collect();
+            keys.sort();
+            (source, keys)
+        })
+        .collect();
+    shapes.sort();
+    shapes.dedup();
+    assert_eq!(
+        shapes.len(),
+        6,
+        "the capture must exhibit all six (source, key-set) pairs; it exhibits {shapes:?}"
+    );
+
+    // All three obligation sources quire minted, named rather than counted —
+    // a count of three could be one source appearing under three key sets.
+    let sources: std::collections::BTreeSet<&str> =
+        shapes.iter().map(|(source, _)| source.as_str()).collect();
+    assert_eq!(
+        sources.iter().copied().collect::<Vec<_>>(),
+        vec![
+            "acceptance-criterion",
+            "nfr-acceptance-criterion",
+            "nfr-metric"
+        ]
+    );
+}

--- a/rust/crates/quoin-quire-types/tests/fixtures/coverage-obligations.json
+++ b/rust/crates/quoin-quire-types/tests/fixtures/coverage-obligations.json
@@ -1,0 +1,63 @@
+{
+  "obligations": [
+    {
+      "document": "spec/functional/FR-028-generate-property-tests-from-criteria.md",
+      "id": "FR-028-AC-10",
+      "method": "Inspection",
+      "source": "acceptance-criterion",
+      "statement": "No specification artifact the skill writes names a test framework, harness, or generator library",
+      "statement_hash": "4a3b3292d2605f5a8eef0b99d74cc1e2fddc0bea1e2f32239928120be6c7d950"
+    },
+    {
+      "document": "spec/functional/FR-001-parse-command-line.md",
+      "id": "FR-001-AC-1",
+      "method": "Test",
+      "source": "acceptance-criterion",
+      "statement": "Both `--flag=value` and `--flag value` bind the value",
+      "statement_hash": "a8f326d89cecd5cee8741093c36f254c0b99c65a8e269359812ccf6f2ed7452f",
+      "target_ids": ["cli.test.ts"]
+    },
+    {
+      "document": "spec/non-functional/NFR-007-external-tool-invocation.md",
+      "id": "NFR-007-AC-1",
+      "method": "Demonstration",
+      "source": "nfr-acceptance-criterion",
+      "statement": "The absence of external-tool version pinning is an accepted limitation, recorded here rather than as a metric; it is revisited if pinning becomes required.",
+      "statement_hash": "7de11b22f6b43d90785f57fc5d3b64a3b3bdf0ad63605814489872a613fefaf6"
+    },
+    {
+      "document": "spec/non-functional/NFR-005-catalog-driven-workflows.md",
+      "id": "NFR-005-AC-1",
+      "method": "Test",
+      "source": "nfr-acceptance-criterion",
+      "statement": "The Status vocabulary that `skills/spec-matrix/SKILL.md` and both of its asset templates teach equals the classed status set the installed `spec-artifacts-process` manifest declares (`traceability.status`), and every taught marker is admitted by the manifest's Status column pattern; divergence in either direction fails the suite. A marker the manifest admits but classes as nothing is deliberately not required to be taught.",
+      "statement_hash": "219b6ae38de5e96e46bd1060deed180f63a13d68ed74ecc9033ee84312bba9ee",
+      "target_ids": ["TC-271"]
+    },
+    {
+      "document": "spec/non-functional/NFR-001-idempotent-offline-reconcile.md",
+      "id": "NFR-001-M-1",
+      "method": "Test",
+      "parameters": {
+        "target": "0",
+        "threshold": "0"
+      },
+      "source": "nfr-metric",
+      "statement": "Network/git operations on repeat catalog access after install",
+      "statement_hash": "050c8c68cfe526cbd4e93ab5dc81d62ac5146ce91adb646b594ed5b58a2308e7"
+    },
+    {
+      "document": "spec/non-functional/NFR-013-traceable-semantic-architecture.md",
+      "id": "NFR-013-M-1",
+      "method": "Test",
+      "parameters": {
+        "target": "100%",
+        "threshold": "100%"
+      },
+      "source": "nfr-metric",
+      "statement": "Normative architecture claims with a requirement or decision reference",
+      "statement_hash": "f60ae02c8f687f13be8b8ab49e340b057e27eaceec947008cbc89c93851b4ad2",
+      "target_ids": ["TC-1151"]
+    }
+  ]
+}

--- a/rust/crates/quoin-quire-types/tests/fixtures/provenance.json
+++ b/rust/crates/quoin-quire-types/tests/fixtures/provenance.json
@@ -1,0 +1,10 @@
+{
+  "bundle": "the quoin repository itself",
+  "captured_from": "quire coverage --scope . --json",
+  "obligations_captured": 6,
+  "obligations_in_bundle": 991,
+  "quire_executable": "/home/peter/.npm-global/lib/node_modules/@agent-ix/quire-cli/bin/quire.js",
+  "quire_sha256": "sha256:96ce25fe91ab75ee96505b343b251a3e1db16de430a524aabef1f5590dbc02b3",
+  "quire_version": "quire 0.32.0 (cli 55a1c4e2, engine 0.46.0@a874fb64)",
+  "selection": "one per distinct (source, key-set) pair the run emitted; all 6 pairs present"
+}

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -14,7 +14,7 @@
  * transliteration of one implementation would agree with itself.
  */
 
-import { requirementOf } from "../assurance/index.js";
+import { buildCase, requirementOf } from "../assurance/index.js";
 
 /** Mirrors `quoin_core::protocol::PROTOCOL_VERSION` — deliberately restated,
  * not imported from the generated `./types.js`: this file is the differential
@@ -116,40 +116,50 @@ export function reference(argv: string[], stdin: string): ReferenceOutcome {
   // rule is that the retained implementation IS the oracle. A second copy here
   // would make the difftest prove that two things written this week agree with
   // each other, which is the one thing it must not prove.
+  // Parse ONCE, before dispatch, because that is where `quoin-core` parses.
+  // The Rust dispatcher reads stdin into a `Value` and reports `CORE_BAD_JSON`
+  // itself, so malformed input is a TRANSPORT verdict for every operation and
+  // never the domain's. Handling it inside each handler produced exactly the
+  // divergence this harness exists to find: `assurance.build_case` answered
+  // `CORE_BAD_REQUEST` where the binary answered `CORE_BAD_JSON`, and
+  // `assurance.requirement_of` carried the same defect unnoticed because its
+  // nine difftest cases never sent it malformed bytes (quoin#384).
+  let parsed: Record<string, unknown> = {};
+  if (stdin.trim() !== "") {
+    let value: unknown;
+    try {
+      value = JSON.parse(stdin) as unknown;
+    } catch (cause) {
+      return failure(3, diagnostic("CORE_BAD_JSON", (cause as Error).message));
+    }
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return failure(
+        3,
+        diagnostic("CORE_BAD_JSON", "a request must be a JSON object", {
+          observed_type: Array.isArray(value) ? "array" : typeof value,
+        }),
+      );
+    }
+    parsed = value as Record<string, unknown>;
+  }
+
   if (op === "assurance.requirement_of") {
-    return assuranceRequirementOf(stdin);
+    return assuranceRequirementOf(parsed);
+  }
+  if (op === "assurance.build_case") {
+    return assuranceBuildCase(parsed);
   }
   if (op !== "core.ping") {
     return failure(
       3,
       diagnostic("CORE_UNKNOWN_OP", "no such operation in this build", {
-        known: "assurance.requirement_of, core.ping",
+        known: "assurance.build_case, assurance.requirement_of, core.ping",
         op,
       }),
     );
   }
 
-  let request: unknown = {};
-  if (stdin.trim() !== "") {
-    try {
-      request = JSON.parse(stdin) as unknown;
-    } catch (cause) {
-      return failure(3, diagnostic("CORE_BAD_JSON", (cause as Error).message));
-    }
-    if (
-      request === null ||
-      typeof request !== "object" ||
-      Array.isArray(request)
-    ) {
-      return failure(
-        3,
-        diagnostic("CORE_BAD_JSON", "a request must be a JSON object", {
-          observed_type: Array.isArray(request) ? "array" : typeof request,
-        }),
-      );
-    }
-  }
-  return ping(request as Record<string, unknown>);
+  return ping(parsed);
 }
 
 function ping(request: Record<string, unknown>): ReferenceOutcome {
@@ -251,31 +261,9 @@ export const MAX_OBLIGATION_ID_BYTES = 4 * 1024;
  * bound, shape the payload. The answer itself comes from
  * `src/assurance/graph.ts` unchanged.
  */
-function assuranceRequirementOf(stdin: string): ReferenceOutcome {
-  let request: unknown;
-  try {
-    request = stdin.trim() === "" ? undefined : JSON.parse(stdin);
-  } catch (error) {
-    return failure(
-      3,
-      diagnostic("CORE_BAD_REQUEST", String(error), {
-        op: "assurance.requirement_of",
-      }),
-    );
-  }
-  if (
-    typeof request !== "object" ||
-    request === null ||
-    Array.isArray(request)
-  ) {
-    return failure(
-      3,
-      diagnostic("CORE_BAD_REQUEST", "request must be a JSON object", {
-        op: "assurance.requirement_of",
-      }),
-    );
-  }
-  const fields = request as Record<string, unknown>;
+function assuranceRequirementOf(
+  fields: Record<string, unknown>,
+): ReferenceOutcome {
   for (const key of Object.keys(fields)) {
     if (key !== "obligation_id") {
       return failure(
@@ -310,4 +298,126 @@ function assuranceRequirementOf(stdin: string): ReferenceOutcome {
     payload: canonicalJson({ requirement: requirementOf(id) }),
     diagnostics: [],
   };
+}
+
+/** The largest `assurance.build_case` request accepted, mirroring Rust. */
+export const MAX_BUILD_CASE_BYTES = 16 * 1024 * 1024;
+
+/** The request fields `assurance.build_case` accepts, in the wire spelling. */
+const BUILD_CASE_FIELDS = new Set([
+  "documents",
+  "obligations",
+  "findings",
+  "claim_types",
+  "unreadable",
+  "producer_trust",
+  "evidence_independence",
+]);
+
+/**
+ * `assurance.build_case`, answered by the RETAINED implementation.
+ *
+ * Like `assurance.requirement_of` above, the only logic here is the
+ * boundary's: parse, bound, rename the request's snake_case keys to the
+ * camelCase `CaseInput` the retained module declares, and hand it over. The
+ * case itself is built by `src/assurance/graph.ts` unchanged.
+ *
+ * **The validation below is not defensive programming, it is parity.** Rust's
+ * `serde` refuses a request whose `obligations[].id` is a number, and returns
+ * `BadRequest`. TypeScript would coerce it and build a case. Without these
+ * checks the two sides disagree on every malformed input, and the difftest
+ * would be a gate over well-formed requests only — which is the half that
+ * never breaks.
+ */
+function assuranceBuildCase(fields: Record<string, unknown>): ReferenceOutcome {
+  const op = "assurance.build_case";
+  const bad = (message: string): ReferenceOutcome =>
+    failure(3, diagnostic("CORE_BAD_REQUEST", message, { op }));
+
+  // Measured on the re-serialised request, matching the Rust side: the bound
+  // is what the DOMAIN refuses, and measuring raw stdin would make whitespace
+  // part of the limit on one side only.
+  const size = Buffer.byteLength(JSON.stringify(fields), "utf8");
+  if (size > MAX_BUILD_CASE_BYTES) {
+    return failure(
+      2,
+      diagnostic("CORE_REFUSED", "request exceeds the accepted size", {
+        limit_bytes: String(MAX_BUILD_CASE_BYTES),
+        observed_bytes: String(size),
+        op,
+      }),
+    );
+  }
+  for (const key of Object.keys(fields)) {
+    if (!BUILD_CASE_FIELDS.has(key)) return bad(`unknown field \`${key}\``);
+  }
+
+  // The three required arrays. `serde` fails on a missing field rather than
+  // defaulting it, and a defaulted empty array here would build an empty case
+  // where Rust reports a bad request.
+  for (const key of ["documents", "obligations", "findings"]) {
+    if (!Array.isArray(fields[key])) return bad(`\`${key}\` must be an array`);
+  }
+  // The optional ones: absent is fine, present-but-wrong is not.
+  for (const key of [
+    "claim_types",
+    "unreadable",
+    "producer_trust",
+    "evidence_independence",
+  ]) {
+    const value = fields[key];
+    if (value !== undefined && value !== null && !Array.isArray(value)) {
+      return bad(`\`${key}\` must be an array`);
+    }
+  }
+
+  /** Every named field of `entry` is a string, as the Rust type requires. */
+  const requireStrings = (
+    entries: unknown[],
+    what: string,
+    keys: string[],
+  ): string | null => {
+    for (const entry of entries) {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return `each ${what} must be a JSON object`;
+      }
+      for (const key of keys) {
+        if (typeof (entry as Record<string, unknown>)[key] !== "string") {
+          return `${what}.${key} must be a string`;
+        }
+      }
+    }
+    return null;
+  };
+
+  const obligations = fields.obligations as unknown[];
+  const findings = fields.findings as unknown[];
+  const claimTypes = (fields.claim_types ?? undefined) as unknown[] | undefined;
+  const unreadable = (fields.unreadable ?? undefined) as unknown[] | undefined;
+
+  const shapeError =
+    requireStrings(obligations, "obligation", ["id", "statement"]) ??
+    requireStrings(findings, "finding", ["obligation", "kind", "summary"]) ??
+    (unreadable
+      ? requireStrings(unreadable, "unreadable", ["path", "reason"])
+      : null);
+  if (shapeError) return bad(shapeError);
+  if (claimTypes && claimTypes.some((t) => typeof t !== "string")) {
+    return bad("`claim_types` must be an array of strings");
+  }
+
+  const built = buildCase({
+    documents: fields.documents as never,
+    obligations: obligations as never,
+    findings: findings as never,
+    ...(claimTypes ? { claimTypes: claimTypes as string[] } : {}),
+    ...(unreadable ? { unreadable: unreadable as never } : {}),
+    ...(fields.producer_trust
+      ? { producerTrust: fields.producer_trust as never }
+      : {}),
+    ...(fields.evidence_independence
+      ? { evidenceIndependence: fields.evidence_independence as never }
+      : {}),
+  });
+  return { exitCode: 0, payload: canonicalJson(built), diagnostics: [] };
 }

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -14,6 +14,8 @@
  * transliteration of one implementation would agree with itself.
  */
 
+import { requirementOf } from "../assurance/index.js";
+
 /** Mirrors `quoin_core::protocol::PROTOCOL_VERSION` — deliberately restated,
  * not imported from the generated `./types.js`: this file is the differential
  * harness's independent oracle (FR-101) and importing the generated surface
@@ -107,11 +109,21 @@ export function reference(argv: string[], stdin: string): ReferenceOutcome {
       }),
     );
   }
+  // `assurance.requirement_of` is the first REAL capability on this side of
+  // the harness, and it is deliberately a CALL rather than a reimplementation.
+  // `core.ping` has two implementations because Stage 0 had no retained
+  // capability to compare against; every operation after it does, and FR-101's
+  // rule is that the retained implementation IS the oracle. A second copy here
+  // would make the difftest prove that two things written this week agree with
+  // each other, which is the one thing it must not prove.
+  if (op === "assurance.requirement_of") {
+    return assuranceRequirementOf(stdin);
+  }
   if (op !== "core.ping") {
     return failure(
       3,
       diagnostic("CORE_UNKNOWN_OP", "no such operation in this build", {
-        known: "core.ping",
+        known: "assurance.requirement_of, core.ping",
         op,
       }),
     );
@@ -227,4 +239,75 @@ function ping(request: Record<string, unknown>): ReferenceOutcome {
     };
   }
   return { payload, diagnostics: [], exitCode: 0 };
+}
+
+/** The largest obligation id accepted, mirroring `MAX_OBLIGATION_ID_BYTES`. */
+export const MAX_OBLIGATION_ID_BYTES = 4 * 1024;
+
+/**
+ * `assurance.requirement_of`, answered by the RETAINED implementation.
+ *
+ * The only logic here is the boundary's: parse the request, enforce the size
+ * bound, shape the payload. The answer itself comes from
+ * `src/assurance/graph.ts` unchanged.
+ */
+function assuranceRequirementOf(stdin: string): ReferenceOutcome {
+  let request: unknown;
+  try {
+    request = stdin.trim() === "" ? undefined : JSON.parse(stdin);
+  } catch (error) {
+    return failure(
+      3,
+      diagnostic("CORE_BAD_REQUEST", String(error), {
+        op: "assurance.requirement_of",
+      }),
+    );
+  }
+  if (
+    typeof request !== "object" ||
+    request === null ||
+    Array.isArray(request)
+  ) {
+    return failure(
+      3,
+      diagnostic("CORE_BAD_REQUEST", "request must be a JSON object", {
+        op: "assurance.requirement_of",
+      }),
+    );
+  }
+  const fields = request as Record<string, unknown>;
+  for (const key of Object.keys(fields)) {
+    if (key !== "obligation_id") {
+      return failure(
+        3,
+        diagnostic("CORE_BAD_REQUEST", `unknown field \`${key}\``, {
+          op: "assurance.requirement_of",
+        }),
+      );
+    }
+  }
+  const id = fields.obligation_id;
+  if (typeof id !== "string") {
+    return failure(
+      3,
+      diagnostic("CORE_BAD_REQUEST", "`obligation_id` must be a string", {
+        op: "assurance.requirement_of",
+      }),
+    );
+  }
+  if (id.length > MAX_OBLIGATION_ID_BYTES) {
+    return failure(
+      2,
+      diagnostic("CORE_REFUSED", "obligation id exceeds the accepted size", {
+        limit_bytes: String(MAX_OBLIGATION_ID_BYTES),
+        observed_bytes: String(id.length),
+        op: "assurance.requirement_of",
+      }),
+    );
+  }
+  return {
+    exitCode: 0,
+    payload: canonicalJson({ requirement: requirementOf(id) }),
+    diagnostics: [],
+  };
 }


### PR DESCRIPTION
```
48 case(s), 0 difference(s)
```

**35 of them compare the retained `src/assurance/graph.ts`.** That is the number that matters.

| cases | compared against |
|---:|---|
| 13 | `core.ping` — the Stage-0 purpose-built oracle |
| 12 | `assurance.requirement_of` vs **the retained implementation** |
| 23 | `assurance.build_case` vs **the retained implementation** |

> Supersedes #426, which shared a branch with unrelated #388/#390 work and so described about a tenth of its own diff. This branch is 17 files off current `main`.

## What Stage 0 proved, and what it did not

`make rust-difftest` was 12 comparisons over `core.ping`, whose TypeScript side is a purpose-built oracle written the same week for this gate. The mechanism was proven; nothing about quoin was.

So the TypeScript side here **calls** the retained implementation — `src/core/reference.ts` imports `buildCase` and `requirementOf` from `../assurance/index.js` and routes to them. FR-101's rule is that the retained implementation *is* the oracle, which is the whole reason it is retained rather than deleted. A second copy would make the harness prove that two things written this week agree with each other.

## The type budget, measured rather than assumed

[#425](https://github.com/agent-ix/quoin/issues/425) sized the remaining stages from the **import graph**: `buildCase` imports five types across four directories, so four crates were missing. Measuring the **field subset** it can observe gives a different answer — twelve fields across five types, and two of the five never read at all.

| type | import list says | field subset says |
|---|---|---|
| `Finding` | a crate | 3 of 12 — `obligation`, `kind`, `summary` |
| `Obligation` | a crate | 2 of 9 — `id`, `statement` |
| `BundleDocument` | a crate | `frontmatter`, already `Record<string, unknown>` |
| `TrustAssessment` | a crate | **one sort key** |
| `IndependenceAssessment` | a crate | **one sort key** |

So two get real types and three do not.

**The two assessments are pass-through.** `grep -rn "TrustAssessment\|IndependenceAssessment" src/assurance/` returns six lines, all type positions or `localeCompare` sort keys. Nothing branches on `status`, reads `dimensions`, or reads `triggeredBy`. Declaring those shapes would declare something no behaviour observes — and since the difftest compares canonical JSON bytes, it could not tell a faithful port of an unobserved field from a wrong one. **A gate that cannot fail.** They are carried as opaque values, and `assurance/build-case-assessments-pass-through` pushes a non-trivial assessment through the sort to prove the bytes survive, which is what converts "it cannot fail" into "here it is passing".

**`BundleDocument` is the sharper case.** Its `frontmatter` is *already* untyped, read through dynamic lookups behind `String()` coercions and runtime guards. `serde_json::Value` is not a weakening — it is the same type. A Rust struct would be inventing a schema the TypeScript deliberately declines to assert, and the invented one would then diverge from whatever the corpus writes.

An import list sizes a crate from the module boundary; a field subset sizes it from what the code can observe. Here they differ by a factor of five, and #425's sizing signal is wrong the same way for every remaining view crate.

## `Finding.kind` is a String, and that is the load-bearing decision

The retained union declares twelve spellings, and it is tempting to mirror that. **A TypeScript union is a compile-time claim, not a run-time guard.** `buildCase` validates nothing; it interpolates whatever string arrives into `because`. A closed Rust enum would therefore **refuse input the retained implementation accepts** — the port stricter than the thing it replaces.

This is the prefix-vs-enumeration defect a second time, from the same instinct: writing the type from what the declaration *says* rather than from what the code *does*. There a suffix allow-list (`AC|CON|VC|EX|SC`) silently dropped every `-M-` obligation — the entire `nfr-metric` source. Here it would drop every finding kind minted after this file was written. `assurance/build-case-unknown-finding-kind` holds the property.

The general rule, for the next port: mirror a union as a closed Rust type **only** where the retained code validates membership at run time — an `if`, a `switch` with a throwing default, a schema check. Where it interpolates, parses or passes the value through, the Rust type is the wider one. The test is what the code does with an unexpected value, not what the declaration lists.

## `Obligation` is quire's, and quoin only reads it

`quoin-quire-types` declares a **deserialize-only reader** of `quire coverage --json`, documented as a projection and not a definition. Not a dependency on quire-rs: a version coupling across the whole burn-down, bought for two fields, is worse than a reader that says what it is.

Drift is made loud from quoin's side:

- **Both fields are required, never `Option`** — a rename upstream fails at the boundary instead of reading as an empty string and rendering a blank row in an assurance case. No `deny_unknown_fields`, since it reads 2 of 9 and unknown fields are the normal case.
- **The fixture is captured, never written** — six obligations chosen by census, one per distinct `(source, key-set)` pair over a 991-obligation bundle, all six pairs present. Captured with `quire 0.32.0 (cli 55a1c4e2, engine 0.46.0@a874fb64)`.
- **The fixture proves its own provenance**: `statement_hash` verifies as `sha256(statement)` for every row. A hand-writer would have to run the digest to fake that, at which point they have captured rather than invented. It also binds statement and hash together, so the bytes cannot be quietly adjusted after capture.

A live digest comparison would have been better and cannot work: CI's `rust` job installs no quire, and the job that has one **builds it from source**, so its bytes are never the npm shim's. An assertion that fails for a reason unrelated to drift is how a gate gets disabled — same class as a check passing over an empty population, pointed the other way. The digest and version are recorded in `provenance.json`, and the reason the comparison is absent is written into the test file rather than left to be rediscovered.

Filed from the owner's side as [agent-ix/quire-rs#428](https://github.com/agent-ix/quire-rs/issues/428), so the coupling is visible to quire rather than only to us.

## Two divergences the harness found, both mine

The reference parsed stdin **inside each handler** and answered `CORE_BAD_REQUEST`, where `quoin-core` parses in the dispatcher and answers `CORE_BAD_JSON`. Malformed input is a transport verdict for every operation, never the domain's.

`assurance.requirement_of` carried the identical defect unnoticed, because its nine original cases never sent it malformed bytes — my own case set had the same shape of hole this program keeps finding elsewhere. The parse is now hoisted before dispatch, matching Rust, and two cases guard it for that op.

## The 16 MiB bound

`MAX_BUILD_CASE_BYTES` was proved by a Rust unit test and nothing else, so the two sides' *agreement* about refusing an oversize request was asserted by nobody. `Request::BuildCaseOfBytes` generates a well-formed request of exactly n bytes; cases sit at the bound and one byte past it. "Too large for the table" is a reason to generate the input, not a reason to leave the boundary unguarded — the same class as the 64 MiB `maxBuffer` incident, where the failure only appeared at a real payload size.

Both sides measure the re-serialised request. `serde_json` sorts object keys where `JSON.stringify` preserves insertion order; the orderings differ and the byte counts do not, which is what makes one number comparable across the two.

## Gates

`cargo fmt --check` clean · `clippy -D warnings` clean across the whole workspace · `cargo test --workspace` 42 tests · **48 difftest comparisons, 0 differences** · `make lint` clean · TypeScript **1167 passed, 5 skipped, 0 failed**.

Built and measured from a worktree holding nothing uncommitted but this branch.

Note for the reviewer: a fresh worktree needs `git submodule update --init corpus`, or three `bench-tier1` tests fail on a missing `corpus/`. `tests/semantic-module-template.test.ts` is separately flaky under full-suite load ([#429](https://github.com/agent-ix/quoin/issues/429)) — it passed in the run above.

Closes #384. Refs #373, #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY