### PR TITLE
Truncate mermaid labels on a code point, not a UTF-16 code unit (#432)

### DIFF
--- a/spec/functional/FR-040-assurance-case-view.md
+++ b/spec/functional/FR-040-assurance-case-view.md
@@ -85,6 +85,14 @@ otherwise yields a diagram that **fails to draw** rather than one that draws wro
 sanitised (`FR-001-AC-1` reads as an edge fragment), labels are quoted (a `(` in a statement ends the
 node shape early), and `;` is replaced (it terminates the statement).
 
+A fourth rule governs the label's length rather than its punctuation, and it fails the other way —
+quietly. Labels are truncated on a **code-point** boundary, not on a UTF-16 code unit. Truncating by
+code unit splits a surrogate pair, and the result is a string that is not well-formed UTF-16: it
+draws, and it draws a replacement character. Measured over this repository's own 991 obligations, 835
+labels are truncated and two carry an astral character, the nearest sitting six characters short of
+the boundary — so this was a defect waiting on one spec edit rather than a hypothetical
+(`agent-ix/quoin#432`).
+
 ### Reading the bundle
 
 The upward edges live in each document's frontmatter, and no `quire` surface exposes the bundle graph
@@ -111,6 +119,7 @@ does not expose. `agent-ix/quire-rs#179` is where this stops being necessary.
 | FR-040-AC-12 | A cycle terminates without dropping a legitimately shared child. | Test (TC-238) |
 | FR-040-AC-13 | A case with no claims carries a machine-readable `reason` naming the searched claim types — present exactly when `claims` is empty — so the `--json` consumer can tell a clean case from one where nothing was argued. | Test (TC-261) |
 | FR-040-AC-14 | `--claim-type` is matched case-insensitively against the authored `type:`, and the flag REPLACES the `StR` default rather than adding to it — stated in its help. | Test (TC-262) |
+| FR-040-AC-15 | A mermaid label is truncated on a code-point boundary, so a label whose limit falls inside a surrogate pair stays well-formed rather than ending in a lone surrogate. | Test (TC-1711) |
 
 ## Constraints
 

--- a/src/assurance/render.ts
+++ b/src/assurance/render.ts
@@ -141,6 +141,14 @@ function renderNode(node: CaseNode, depth: number): string[] {
  * - **Labels are quoted**, because a statement containing `(` or `)` ends the
  *   node shape early.
  * - **No `;` in label text** — it terminates the statement.
+ *
+ * And one rule about the truncation itself (quoin#432): it counts CODE POINTS,
+ * not UTF-16 code units. `String.prototype.slice` counts units, so a label
+ * whose 80th unit fell inside a surrogate pair was cut in half and rendered as
+ * `\uFFFD` — `"x".repeat(79) + "\u{1F600}"` sliced to a lone high surrogate,
+ * `isWellFormed()` false. Measured over this repository's own 991 obligations,
+ * 835 labels are truncated and two carry an astral character; the nearest miss
+ * is `FR-082-AC-3`, whose emoji sits six characters before the boundary.
  */
 function mermaidFor(claim: CaseNode): string[] {
   const lines = ["flowchart TD"];
@@ -165,11 +173,14 @@ function nodeId(id: string): string {
   return id.replace(/[^A-Za-z0-9]/g, "_");
 }
 
+/** Label budget, in CODE POINTS. See the truncation rule in `mermaidFor`. */
+const MAX_LABEL_LENGTH = 80;
+
 function label(node: CaseNode): string {
   const text = `${node.id}: ${node.statement}`;
-  return text
-    .replace(/["`]/g, "'")
-    .replace(/;/g, ",")
-    .slice(0, 80)
-    .concat(node.status === "open" ? " ◇" : "");
+  const sanitised = text.replace(/["`]/g, "'").replace(/;/g, ",");
+  // `Array.from` iterates code points, so a surrogate pair is one element and
+  // cannot be split. `.slice(0, 80)` on the string would count code units.
+  const truncated = Array.from(sanitised).slice(0, MAX_LABEL_LENGTH).join("");
+  return truncated.concat(node.status === "open" ? " ◇" : "");
 }

--- a/tests/assurance.test.ts
+++ b/tests/assurance.test.ts
@@ -290,6 +290,60 @@ describe("rendering the case", () => {
     expect(mermaid).not.toMatch(/"[^"\n]*"[^"\n]*"/);
   });
 
+  // Trace: FR-040-AC-15
+  it("truncates a mermaid label on a code point, never inside one", () => {
+    // quoin#432. `String.prototype.slice` counts UTF-16 CODE UNITS, so a
+    // label whose 80th unit fell inside a surrogate pair was cut in half and
+    // rendered as U+FFFD.
+    //
+    // Constructed rather than taken from the corpus, and deliberately: no
+    // label in this repository's 991 obligations reaches the boundary with an
+    // astral character today. The nearest is FR-082-AC-3, whose emoji sits
+    // six characters short of it. Waiting for a real one is waiting for the
+    // bug.
+    //
+    // The label is `${id}: ${statement}`, so the id and its separator are
+    // part of the budget — the statement is padded to put the emoji exactly
+    // astride unit 80 of the whole label.
+    const id = "FR-001-AC-1";
+    const prefix = `${id}: `;
+    const statement = "x".repeat(80 - prefix.length) + "😀";
+    const result = buildCase({
+      documents: bundle(),
+      obligations: [obligation(id, statement)],
+      findings: [],
+    });
+    const mermaid = renderCase(result).split("```mermaid")[1].split("```")[0];
+
+    // The whole rendered block, not just the label: a lone surrogate anywhere
+    // in the output is the defect, wherever it came from.
+    expect(mermaid.isWellFormed()).toBe(true);
+    // The emoji is dropped whole rather than halved. Asserting its absence
+    // AND well-formedness together is what distinguishes "truncated cleanly"
+    // from "truncated into a replacement character".
+    expect(mermaid).not.toContain("😀");
+    expect(mermaid).not.toContain("\uFFFD");
+  });
+
+  // Trace: FR-040-AC-15
+  it("renders labels with no astral character byte for byte as before", () => {
+    // The fix must not move any byte that was already correct, which is 833
+    // of the 835 truncated labels in this repository. A 100-character ASCII
+    // statement exercises the truncation path; `Array.from` and `slice` agree
+    // on every input where one code point is one code unit.
+    const id = "FR-001-AC-1";
+    const statement = "y".repeat(100);
+    const result = buildCase({
+      documents: bundle(),
+      obligations: [obligation(id, statement)],
+      findings: [],
+    });
+    const mermaid = renderCase(result).split("```mermaid")[1].split("```")[0];
+    // No finding, so the node is supported and carries no ` ◇` suffix.
+    const expected = `${id}: ${statement}`.slice(0, 80);
+    expect(mermaid).toContain(`(["${expected}"])`);
+  });
+
   // Trace: FR-040-AC-10
   it("says there is no case rather than rendering an empty one", () => {
     // An empty document reads as "nothing to argue". The truth is that nothing


### PR DESCRIPTION
`String.prototype.slice` counts **UTF-16 code units**, so a mermaid label whose 80th unit fell inside a surrogate pair was cut in half and rendered as `�`.

```
"x".repeat(79) + "😀"   length 81 in JS
slice(0, 80)            length 80, ending on 0xd83d — a LONE HIGH SURROGATE
isWellFormed()          false
UTF-8 encoding          82 bytes, the tail being U+FFFD
```

`Array.from` iterates code points, so a surrogate pair is one element and cannot be split.

## Measured, not reasoned

Over this repository's own 991 obligations from `quire coverage --scope . --json`:

| | count |
|---|---:|
| labels longer than 80 units, so truncated | **835** (84%) |
| labels exactly 80 units | 9 |
| labels containing an astral character | 2 |
| labels whose `slice(0, 80)` is malformed **today** | **0** |

**This fixes no live output.** It is also not hypothetical: the truncation path fires on 84% of labels, and `FR-082-AC-3` carries `🚧` at unit 73 of a 90-unit label. Add six characters to that criterion and the slice lands inside the pair. A defect one spec edit away, in a path that runs on five labels in six.

## Why now rather than when it bites

Rust's `String` **cannot represent a lone surrogate**, so no Rust implementation can reproduce this output — not `chars().take(80)`, which keeps the character whole at 81 units, and not byte slicing, which cuts elsewhere.

Under FR-101 the retained implementation is the oracle and the differential harness compares canonical bytes. Porting `render_case` against the current behaviour would either fail permanently on that input class or, worse, write *"truncate a mermaid label to a lone high surrogate"* into the Rust side as a requirement nobody could ever justify. An oracle that emits invalid UTF-16 is not an oracle.

So this lands on its own, before the port, and `render_case` matches the fixed behaviour.

## NFR-025 checked before changing a byte

NFR-025 makes evidence and accepted-corpus bytes immutable across the port, so a rendered-output change needs clearing rather than assuming:

- **`renderCase` output is never stored.** Its only non-test caller is `src/commands/assurance.ts:215`, which passes it to `this.log`. No record, no digest.
- **No committed rendered output exists.** `flowchart TD` appears in exactly one file in the repository — `src/assurance/render.ts`, the generator.
- **No U+FFFD anywhere in the tree**, excluding `node_modules`, `dist`, `target` and the `corpus/` submodule, which NFR-025 scopes out by name as `agent-ix/qa-corpus`'s bytes.

**Clear.** No stored evidence byte and no accepted-corpus byte moves.

## FR-040-AC-15, because no criterion stated this

Which is why the defect existed. The description's *"three authoring rules"* gains a fourth, and it is the one that fails the other way round: the other three make a diagram **fail to draw**, this one makes it draw a replacement character.

Id allocation scanned across **all remote branches** rather than the working tree — `main` carries `FR-040-AC-14` and `TC-1710` as the highest, so `AC-15` and `TC-1711` are the first free. (The working tree alone would have said `AC-10`.)

## Tests

The surrogate-boundary case is **constructed**, and deliberately so: no label in this corpus reaches the boundary with an astral character today, and waiting for a real one is waiting for the bug. It asserts well-formedness *and* that the character is dropped whole — together, those distinguish "truncated cleanly" from "truncated into a replacement character".

The second test asserts non-astral labels are byte-identical to the old output, which covers 833 of the 835 truncated labels here.

Rendering all 991 obligations under one claim: **1108 mermaid labels, every one well-formed, no U+FFFD in the output.**

## Gates

`make validate` exit 0 (95 pre-existing warnings, none on FR-040) · `make lint` clean · `tests/assurance.test.ts` 16 passed · full suite **1168 passed, 5 skipped**.

The one full-suite failure is [#429](https://github.com/agent-ix/quoin/issues/429), not this change: `tests/semantic-module-template.test.ts` times out at the 5 s default under parallel load — a different test each run, three distinct ones so far — and passes 79/79 in isolation, which it did here.

Blocks `render_case` in #373 Stage 5.

Closes #432. Refs #384, #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY