### PR TITLE
quoin-assurance: render_case, and the import list lying the other way (#384)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
 name = "quoin-assurance"
 version = "0.1.0"
 dependencies = [
+ "quoin-evidence-types",
  "quoin-finding-types",
  "quoin-quire-types",
  "serde",
@@ -1216,6 +1217,14 @@ name = "quoin-difftest"
 version = "0.1.0"
 dependencies = [
  "quoin-core",
+ "serde_json",
+]
+
+[[package]]
+name = "quoin-evidence-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
  "serde_json",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,7 @@ publish = false
 [workspace.dependencies]
 quoin-assurance = { path = "crates/quoin-assurance" }
 quoin-core = { path = "crates/quoin-core" }
+quoin-evidence-types = { path = "crates/quoin-evidence-types" }
 quoin-finding-types = { path = "crates/quoin-finding-types" }
 quoin-quire-types = { path = "crates/quoin-quire-types" }
 quoin-schemas = { path = "crates/quoin-schemas" }

--- a/rust/crates/quoin-assurance/src/case.rs
+++ b/rust/crates/quoin-assurance/src/case.rs
@@ -72,7 +72,7 @@ pub enum NodeStatus {
 }
 
 /// One node of the case tree.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CaseNode {
     /// The document or obligation id.
     pub id: String,
@@ -83,7 +83,7 @@ pub struct CaseNode {
     /// Whether this part of the argument holds.
     pub status: NodeStatus,
     /// Why it is open — the auditor's finding, verbatim. Absent when supported.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub because: Option<String>,
     /// Sub-claims first, then evidence.
     pub children: Vec<CaseNode>,
@@ -107,9 +107,27 @@ pub struct Unreadable {
 /// difftest compares canonical stdout bytes, so a renamed key here is a
 /// difference. The **request** is new surface minted at this boundary, and it
 /// follows the boundary's own convention (`expect_protocol`, `obligation_id`).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+///
+/// # Why the two assessments are type parameters
+///
+/// Because the same field is opaque to one operation and read field-by-field
+/// by another, and quoin#425 is the ticket that found that out the hard way.
+///
+/// [`build_case`] never inspects producer trust or independence: it sorts each
+/// by one key and re-emits it unchanged, so for that operation they are
+/// `serde_json::Value` and must be — a struct would drop the fields it did not
+/// declare, and the difftest compares canonical bytes.
+///
+/// `render_case` interpolates fourteen of their fields into markdown, so for
+/// that operation they are [`quoin_evidence_types::TrustAssessment`] and
+/// [`quoin_evidence_types::IndependenceAssessment`].
+///
+/// Stating that as two structs would work and would drift. Stating it as two
+/// parameters means the compiler carries the distinction, and a reader asking
+/// "is this field read here?" gets the answer from the signature.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AssuranceCase {
+pub struct AssuranceCase<Trust = serde_json::Value, Independence = serde_json::Value> {
     /// Top-level claims, one tree each.
     pub claims: Vec<CaseNode>,
     /// Present exactly when `claims` is empty: why there is no case, naming
@@ -118,7 +136,7 @@ pub struct AssuranceCase {
     /// The human renderer already explained this; the JSON payload carried no
     /// equivalent, so a machine consumer could not tell "the assurance case is
     /// clean" from "nothing matched, so nothing was argued" (quoin#170).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub reason: Option<String>,
     /// Requirements reachable from no claim.
     ///
@@ -129,10 +147,25 @@ pub struct AssuranceCase {
     /// Documents whose frontmatter could not be read.
     pub unreadable: Vec<Unreadable>,
     /// Use-specific producer reliance shown as context, never claim support.
-    pub producer_trust: Vec<serde_json::Value>,
+    ///
+    /// Required on deserialization, with no default, because the retained
+    /// renderer reads `assurance.producerTrust.length` unconditionally and
+    /// throws when it is absent. The difftest found this: a default here made
+    /// `quoin-core` render a case that the retained implementation could not,
+    /// which is the port being MORE permissive than the thing it replaces —
+    /// the same class of divergence as a closed enum being less permissive,
+    /// and just as much a difference.
+    ///
+    /// `evidence_independence` below keeps its default, because there the
+    /// retained code uses `?.` and genuinely tolerates absence. The two fields
+    /// differ because the retained implementation treats them differently.
+    pub producer_trust: Vec<Trust>,
     /// Profile-selected separation results, shown as context.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub evidence_independence: Option<Vec<serde_json::Value>>,
+    // A path rather than bare `default`: the derive would otherwise demand
+    // `Independence: Default`, which is a bound on the ASSESSMENT type for the
+    // sake of an absent list. `Option::default` is `None` for any `T`.
+    #[serde(skip_serializing_if = "Option::is_none", default = "Option::default")]
+    pub evidence_independence: Option<Vec<Independence>>,
 }
 
 /// What the view is given to read.

--- a/rust/crates/quoin-assurance/src/lib.rs
+++ b/rust/crates/quoin-assurance/src/lib.rs
@@ -35,8 +35,10 @@
 //! factor of five here (quoin#425).
 
 pub mod case;
+pub mod render;
 
 pub use case::{AssuranceCase, CaseInput, CaseNode, NodeKind, NodeStatus, Unreadable, build_case};
+pub use render::{RenderableCase, render_case};
 
 /// The requirement an obligation belongs to.
 ///

--- a/rust/crates/quoin-assurance/src/render.rs
+++ b/rust/crates/quoin-assurance/src/render.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! Rendering an assurance case (quoin#384, ported from `src/assurance/render.ts`).
+//!
+//! Deterministic markdown plus a mermaid graph. **A store view, never a
+//! hand-maintained document** — every re-render over unchanged inputs produces
+//! byte-identical output, so a diff is a change in the evidence and not in
+//! somebody's prose.
+//!
+//! # The type budget, measured a second time
+//!
+//! [`crate::case`] records that sizing from the import list overstated
+//! `build_case` by a factor of five. This module is the same instrument failing
+//! the other way: `render.ts` imports one line, both of whose types already
+//! existed, and then reads fourteen fields across three types it never names.
+//! See [`quoin_evidence_types`] for the table.
+//!
+//! The lesson is in [`crate::case::AssuranceCase`]'s type parameters rather
+//! than only in a comment: producer trust is opaque to `build_case` and read by
+//! this module, and a reader asking which applies gets the answer from the
+//! signature.
+
+use quoin_evidence_types::{IndependenceAssessment, TrustAssessment};
+
+use crate::case::{AssuranceCase, CaseNode, NodeKind, NodeStatus};
+
+/// The label budget, in CODE POINTS. See [`label`].
+const MAX_LABEL_LENGTH: usize = 80;
+
+/// The case as read by this module: both assessments are real types here.
+pub type RenderableCase = AssuranceCase<TrustAssessment, IndependenceAssessment>;
+
+/// The internal view has two states and makes every unsupported branch open.
+fn mark(status: NodeStatus) -> &'static str {
+    match status {
+        NodeStatus::Supported => "✅",
+        NodeStatus::Open => "◇",
+    }
+}
+
+/// Render the case as markdown.
+#[must_use]
+pub fn render_case(assurance: &RenderableCase) -> String {
+    let mut lines: Vec<String> = vec!["# Assurance case".to_owned(), String::new()];
+
+    if assurance.claims.is_empty() {
+        // Not an empty case — no case. The distinction matters: a reader who
+        // sees an empty document concludes there is nothing to argue, and the
+        // truth is that nothing declared itself a claim.
+        lines.push(
+            "No document declares itself a top-level claim, so there is no case to".to_owned(),
+        );
+        lines.push("argue. Declare an `StR` (or pass `--claim-type`) and re-run.".to_owned());
+        lines.push(String::new());
+    }
+
+    let open = assurance
+        .claims
+        .iter()
+        .filter(|c| c.status == NodeStatus::Open)
+        .count();
+    if !assurance.claims.is_empty() {
+        lines.push(format!(
+            "{} claim(s), {open} with an open branch.",
+            assurance.claims.len()
+        ));
+        lines.push(String::new());
+    }
+
+    for claim in &assurance.claims {
+        lines.push(format!(
+            "## {} {} — {}",
+            mark(claim.status),
+            claim.id,
+            claim.statement
+        ));
+        lines.push(String::new());
+        lines.extend(render_node(claim, 0));
+        lines.push(String::new());
+        lines.push("```mermaid".to_owned());
+        lines.extend(mermaid_for(claim));
+        lines.push("```".to_owned());
+        lines.push(String::new());
+    }
+
+    if !assurance.unreachable.is_empty() {
+        lines.push("## Reachable from no claim".to_owned());
+        lines.push(String::new());
+        lines.push(
+            "These carry obligations and no claim argues over them. A case rendered".to_owned(),
+        );
+        lines.push("only over the reachable half would read as complete.".to_owned());
+        lines.push(String::new());
+        lines.extend(assurance.unreachable.iter().map(|id| format!("- {id}")));
+        lines.push(String::new());
+    }
+
+    if !assurance.unreadable.is_empty() {
+        lines.push("## Unreadable".to_owned());
+        lines.push(String::new());
+        lines.extend(
+            assurance
+                .unreadable
+                .iter()
+                .map(|u| format!("- {}: {}", u.path, u.reason)),
+        );
+        lines.push(String::new());
+    }
+
+    lines.extend(producer_trust_section(&assurance.producer_trust));
+
+    // `(x?.length ?? 0) > 0` in the retained source: an absent list and an
+    // EMPTY list both skip the section, so `Some(vec![])` must not emit a
+    // heading with nothing under it. `unwrap_or(&[])` collapses the two
+    // cases the way `?.` does, rather than branching on `is_some()`.
+    lines.extend(independence_section(
+        assurance.evidence_independence.as_deref().unwrap_or(&[]),
+    ));
+    lines.join("\n")
+}
+
+/// The producer-reliance section, or nothing when there is no reliance.
+fn producer_trust_section(decisions: &[TrustAssessment]) -> Vec<String> {
+    if decisions.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![
+        "## Evidence-producer reliance".to_owned(),
+        String::new(),
+        "These decisions are context for the case; they do not make a claim supported.".to_owned(),
+        String::new(),
+    ];
+    for decision in decisions {
+        // `join(", ")` over a list of STRINGS. `TrustTrigger` is a string
+        // union in the retained source, not an object — worth reading rather
+        // than assuming, because a list of objects would render as
+        // `[object Object]` there and the port would have had to reproduce it.
+        let triggered = if decision.triggered_by.is_empty() {
+            String::new()
+        } else {
+            format!(" — revalidate: {}", decision.triggered_by.join(", "))
+        };
+        lines.push(format!(
+            "- **{} / {}** — {}{triggered}",
+            decision.id, decision.use_id, decision.status
+        ));
+        if !decision.limitations.is_empty() {
+            lines.push(format!(
+                "  - limitations: {}",
+                decision.limitations.join("; ")
+            ));
+        }
+    }
+    lines.push(String::new());
+    lines
+}
+
+/// The independence section, or nothing when no check was selected.
+fn independence_section(assessments: &[IndependenceAssessment]) -> Vec<String> {
+    if assessments.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![
+        "## Evidence independence".to_owned(),
+        String::new(),
+        "These are profile-selected relationship checks; they do not make a claim supported by themselves.".to_owned(),
+        String::new(),
+    ];
+    for assessment in assessments {
+        lines.push(format!(
+            "- **{} / {} / {}** — {}",
+            assessment.profile, assessment.requirement, assessment.obligation, assessment.status
+        ));
+        lines.push(format!("  - {}", assessment.summary));
+        for dimension in &assessment.dimensions {
+            let values = if dimension.values.is_empty() {
+                "no stated values".to_owned()
+            } else {
+                dimension.values.join(", ")
+            };
+            let missing = if dimension.missing_suites.is_empty() {
+                String::new()
+            } else {
+                format!("; missing on {}", dimension.missing_suites.join(", "))
+            };
+            lines.push(format!("  - {}: {values}{missing}", dimension.dimension));
+        }
+    }
+    lines.push(String::new());
+    lines
+}
+
+fn render_node(node: &CaseNode, depth: usize) -> Vec<String> {
+    let indent = "  ".repeat(depth);
+    let label = if node.kind == NodeKind::Solution {
+        format!(
+            "{indent}- {} **{}** — {}",
+            mark(node.status),
+            node.id,
+            node.statement
+        )
+    } else {
+        format!(
+            "{indent}- {} {} — {}",
+            mark(node.status),
+            node.id,
+            node.statement
+        )
+    };
+    // The claim's own line is the `##` heading above, so depth 0 contributes
+    // no bullet — only its `because` and its children.
+    let mut out: Vec<String> = if depth == 0 { Vec::new() } else { vec![label] };
+    if let Some(because) = &node.because {
+        out.push(format!("{indent}  - ↳ {because}"));
+    }
+    for child in &node.children {
+        out.extend(render_node(child, depth + 1));
+    }
+    out
+}
+
+/// The claim's subtree as a mermaid flowchart.
+///
+/// Four authoring rules. The first three produce a diagram that **fails to
+/// draw** rather than one that draws wrongly:
+///
+/// - **Ids are sanitised.** `FR-001-AC-1` contains `-`, and mermaid reads a
+///   bare hyphenated token as an edge fragment.
+/// - **Labels are quoted**, because a statement containing `(` or `)` ends the
+///   node shape early.
+/// - **No `;` in label text** — it terminates the statement.
+///
+/// The fourth governs length rather than punctuation and fails the other way,
+/// quietly: labels truncate on a **code point**, never on a UTF-16 code unit
+/// (quoin#432). That one is free here — Rust has no way to express the defect,
+/// since `String` cannot hold a lone surrogate, which is precisely why the
+/// retained implementation had to be fixed before this module could match it.
+fn mermaid_for(claim: &CaseNode) -> Vec<String> {
+    let mut lines = vec!["flowchart TD".to_owned()];
+    let mut seen: Vec<String> = Vec::new();
+    walk(claim, &mut lines, &mut seen);
+    lines
+}
+
+fn walk(node: &CaseNode, lines: &mut Vec<String>, seen: &mut Vec<String>) {
+    let id = node_id(&node.id);
+    if !seen.contains(&id) {
+        seen.push(id.clone());
+        let (open, close) = if node.kind == NodeKind::Solution {
+            ("([", "])")
+        } else {
+            ("[", "]")
+        };
+        lines.push(format!("  {id}{open}\"{}\"{close}", label(node)));
+    }
+    for child in &node.children {
+        walk(child, lines, seen);
+        lines.push(format!("  {id} --> {}", node_id(&child.id)));
+    }
+}
+
+/// `id.replace(/[^A-Za-z0-9]/g, "_")`.
+///
+/// One underscore per UTF-16 CODE UNIT, not per character, and that is not
+/// pedantry. A JavaScript regex without the `u` flag matches code units, so an
+/// astral character — two units — becomes TWO underscores there and would have
+/// become one here. `chars()` was the obvious port and the wrong one.
+///
+/// Same defect family as quoin#432 one function below, from the opposite
+/// direction: there the retained code counted units where it should have
+/// counted characters, here it counts units correctly and the port must too.
+/// The unit is a fact about the retained implementation either way, never a
+/// preference.
+fn node_id(id: &str) -> String {
+    let mut out = String::with_capacity(id.len());
+    for c in id.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else {
+            for _ in 0..c.len_utf16() {
+                out.push('_');
+            }
+        }
+    }
+    out
+}
+
+fn label(node: &CaseNode) -> String {
+    let text = format!("{}: {}", node.id, node.statement);
+    let sanitised: String = text
+        .chars()
+        .map(|c| match c {
+            '"' | '`' => '\'',
+            ';' => ',',
+            other => other,
+        })
+        .collect();
+    // `Array.from(...).slice(0, 80).join("")` — code points, not code units.
+    // `chars()` is the same unit, so this is a direct correspondence rather
+    // than an approximation of one.
+    let truncated: String = sanitised.chars().take(MAX_LABEL_LENGTH).collect();
+    if node.status == NodeStatus::Open {
+        format!("{truncated} ◇")
+    } else {
+        truncated
+    }
+}

--- a/rust/crates/quoin-core/src/dispatch.rs
+++ b/rust/crates/quoin-core/src/dispatch.rs
@@ -30,6 +30,7 @@ pub fn dispatch(op: &str, request: &serde_json::Value) -> Result<Response, CoreE
     match op {
         "assurance.requirement_of" => crate::ops::assurance::requirement_of(request),
         "assurance.build_case" => crate::ops::assurance::build_case(request),
+        "assurance.render_case" => crate::ops::assurance::render_case(request),
         "core.ping" => crate::ops::core::ping(request),
         _ => Err(
             CoreError::new(CoreErrorCode::UnknownOp, "no such operation in this build")

--- a/rust/crates/quoin-core/src/ops/assurance.rs
+++ b/rust/crates/quoin-core/src/ops/assurance.rs
@@ -110,3 +110,53 @@ pub fn build_case(request: &serde_json::Value) -> Result<Response, CoreError> {
 
     Ok(Response::ok(payload))
 }
+
+/// The payload `assurance.render_case` writes to stdout.
+///
+/// The rendered document is a JSON string field rather than raw markdown on
+/// stdout, because the boundary's rule is that stdout carries a canonical JSON
+/// payload and nothing else. A consumer wanting the file writes the field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RenderCasePayload {
+    /// The rendered markdown.
+    pub rendered: String,
+}
+
+/// Answer an `assurance.render_case`.
+///
+/// # Errors
+///
+/// - [`CoreErrorCode::BadRequest`] when stdin is not a [`RenderableCase`].
+/// - [`CoreErrorCode::Refused`] when the request exceeds [`MAX_BUILD_CASE_BYTES`].
+///
+/// [`RenderableCase`]: quoin_assurance::RenderableCase
+pub fn render_case(request: &serde_json::Value) -> Result<Response, CoreError> {
+    // The same ceiling as `build_case`, and deliberately the same constant:
+    // this operation's input IS that operation's output, so a case that could
+    // be built and then could not be rendered would be a boundary that
+    // contradicts itself.
+    let size = serde_json::to_vec(request)
+        .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?
+        .len();
+    if size > MAX_BUILD_CASE_BYTES {
+        return Err(
+            CoreError::new(CoreErrorCode::Refused, "request exceeds the accepted size")
+                .with_context("op", "assurance.render_case")
+                .with_context("limit_bytes", MAX_BUILD_CASE_BYTES.to_string())
+                .with_context("observed_bytes", size.to_string()),
+        );
+    }
+
+    let assurance: quoin_assurance::RenderableCase = serde_json::from_value(request.clone())
+        .map_err(|e| {
+            CoreError::new(CoreErrorCode::BadRequest, e.to_string())
+                .with_context("op", "assurance.render_case")
+        })?;
+
+    let payload = serde_json::to_value(RenderCasePayload {
+        rendered: quoin_assurance::render_case(&assurance),
+    })
+    .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?;
+
+    Ok(Response::ok(payload))
+}

--- a/rust/crates/quoin-difftest/src/main.rs
+++ b/rust/crates/quoin-difftest/src/main.rs
@@ -400,6 +400,214 @@ const CASES: &[Case] = &[
         op: "assurance.build_case",
         request: Request::Literal("[1,2]"),
     },
+    // ── assurance.render_case (quoin#384) ──
+    //
+    // The renderer, against the retained `src/assurance/render.ts`. This
+    // operation's input is `build_case`'s OUTPUT, and the three assessment
+    // types that were opaque there are read field-by-field here — fourteen
+    // fields across three types `render.ts` never names (quoin#425).
+    Case {
+        name: "assurance/render-no-case-is-not-an-empty-case",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"no document declares itself a top-level claim (searched claim types: StR); declare one or pass --claim-type","unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-one-supported-claim",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"The system is usable","status":"supported","children":[{"id":"FR-001-AC-1","kind":"solution","statement":"It holds.","status":"supported","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // `because` renders as a nested `↳` line, and open propagates.
+        name: "assurance/render-an-open-branch-carries-its-reason",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"The system is usable","status":"open","children":[{"id":"FR-001-AC-1","kind":"solution","statement":"It holds.","status":"open","because":"undischarged: nothing binds it","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // A claim with nothing under it: `because` on the claim itself, and
+        // depth 0 contributes no bullet because the `##` heading is its line.
+        name: "assurance/render-a-bare-claim-states-why-it-is-open",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Nothing under it","status":"open","because":"no sub-claim and no obligation traces to this claim","children":[]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // Nesting depth, indentation, and the `([...])` vs `[...]` shapes.
+        name: "assurance/render-nested-goals-indent-and-change-shape",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"open","children":[{"id":"FR-001","kind":"goal","statement":"Middle","status":"open","children":[{"id":"FR-001-AC-1","kind":"solution","statement":"Leaf","status":"open","because":"stale-evidence: old","children":[]}]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // Two claims, so the `N claim(s), M with an open branch` count is not
+        // trivially 1 and 1.
+        name: "assurance/render-counts-open-branches-across-claims",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"First","status":"open","because":"no sub-claim and no obligation traces to this claim","children":[]},{"id":"StR-002","kind":"goal","statement":"Second","status":"supported","children":[{"id":"FR-002-AC-1","kind":"solution","statement":"It holds.","status":"supported","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // The three mermaid punctuation rules, all in one statement.
+        name: "assurance/render-mermaid-survives-punctuation",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"open","children":[{"id":"FR-001-AC-1","kind":"solution","statement":"Rejects (bad) input; logs \"why\" and `how`","status":"open","because":"x: y","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // quoin#432, from the Rust side. The retained renderer truncates on a
+        // CODE POINT now; before #433 it counted UTF-16 units and this input
+        // produced a lone high surrogate, which Rust's String cannot hold.
+        // The port could not have matched the old behaviour at all.
+        name: "assurance/render-truncates-on-a-code-point",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"supported","children":[{"id":"FR-001-AC-1","kind":"solution","statement":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx😀 tail","status":"supported","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // `id.replace(/[^A-Za-z0-9]/g, "_")` matches UTF-16 CODE UNITS, so an
+        // astral character in an id becomes TWO underscores. `chars()` was the
+        // obvious port and would have produced one.
+        name: "assurance/render-node-id-sanitises-per-code-unit",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"supported","children":[{"id":"FR-😀-AC-1","kind":"solution","statement":"Astral in the id","status":"supported","children":[]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // A node reached twice is declared once but gets both edges.
+        name: "assurance/render-a-shared-child-is-declared-once",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"open","children":[{"id":"FR-001","kind":"goal","statement":"A","status":"open","children":[{"id":"FR-009-AC-1","kind":"solution","statement":"Shared","status":"open","because":"x: y","children":[]}]},{"id":"FR-002","kind":"goal","statement":"B","status":"open","children":[{"id":"FR-009-AC-1","kind":"solution","statement":"Shared","status":"open","because":"x: y","children":[]}]}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-unreachable-and-unreadable-sections",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":["FR-009","FR-010"],"unreadable":[{"path":"broken.md","reason":"unterminated frontmatter"}],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // THE TYPE-SUBSET CASE. Five of TrustAssessment's eight fields are
+        // rendered; the other three are present here and must not appear in
+        // the output. `triggeredBy` is a STRING union, so `join(", ")` yields
+        // prose — had it been objects it would render `[object Object]`.
+        name: "assurance/render-producer-trust-fields",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[],"producerTrust":[{"id":"T-001","useId":"U-1","producer":"vitest","status":"accepted-with-limitations","permittedDecisions":["release"],"limitations":["linux only","x86 only"],"triggeredBy":["producer-version","configuration"],"owner":"qa"},{"id":"T-002","useId":"U-2","producer":"pytest","status":"unobserved","permittedDecisions":[],"limitations":[],"triggeredBy":[],"owner":"qa"}]}"#,
+        ),
+    },
+    Case {
+        // Six of IndependenceAssessment's seven, and all three of the nested
+        // dimension type. `satisfiedBy` is present and must not render.
+        name: "assurance/render-independence-fields",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[],"producerTrust":[],"evidenceIndependence":[{"profile":"P","requirement":"FR-001","obligation":"FR-001-AC-1","status":"satisfied","dimensions":[{"dimension":"author","values":["a","b"],"missingSuites":[]},{"dimension":"tooling","values":[],"missingSuites":["unit","e2e"]}],"satisfiedBy":["unit","integration"],"summary":"two authors"}]}"#,
+        ),
+    },
+    Case {
+        // `(x?.length ?? 0) > 0`: an EMPTY list skips the heading entirely.
+        // A naive `is_some()` would emit a section with nothing under it.
+        name: "assurance/render-empty-independence-emits-no-heading",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[],"producerTrust":[],"evidenceIndependence":[]}"#,
+        ),
+    },
+    Case {
+        // `evidenceIndependence` ABSENT rather than empty. The retained
+        // renderer reaches it through `?.`, so absence is legitimate.
+        name: "assurance/render-absent-independence",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // `producerTrust` absent, which is NOT the same case. The retained
+        // renderer reads `.length` on it directly and throws, so the boundary
+        // must refuse rather than default it to empty — a port that renders
+        // what the retained implementation cannot is as much a difference as
+        // one that refuses what it accepts. The harness found this.
+        name: "assurance/render-invalid-absent-producer-trust",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[]}"#,
+        ),
+    },
+    Case {
+        // An unknown status string. Same rule as `Finding.kind`: the renderer
+        // interpolates and does not validate, so a closed enum here would
+        // refuse input the retained implementation renders.
+        name: "assurance/render-unknown-trust-status",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"reason":"none","unreachable":[],"unreadable":[],"producerTrust":[{"id":"T","useId":"U","status":"status-invented-tomorrow","triggeredBy":["trigger-invented-tomorrow"],"limitations":[]}]}"#,
+        ),
+    },
+    Case {
+        // `kind` and `status` on a CaseNode ARE closed — build_case mints
+        // them, so an unrecognised one is a bad request on both sides.
+        name: "assurance/render-invalid-node-kind",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"premise","statement":"Top","status":"open","children":[]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-invalid-node-status",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"maybe","children":[]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        // `children` carries no serde default, so it is required at depth.
+        name: "assurance/render-invalid-nested-node-missing-children",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[{"id":"StR-001","kind":"goal","statement":"Top","status":"open","children":[{"id":"FR-001","kind":"goal","statement":"No children key","status":"open"}]}],"unreachable":[],"unreadable":[],"producerTrust":[]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-invalid-missing-unreachable",
+        op: "assurance.render_case",
+        request: Request::Literal(r#"{"claims":[],"unreadable":[],"producerTrust":[]}"#),
+    },
+    Case {
+        // A rendered field missing from an assessment. `Option` would have
+        // printed a blank row; required makes it a bad request.
+        name: "assurance/render-invalid-trust-missing-use-id",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"unreachable":[],"unreadable":[],"producerTrust":[{"id":"T","status":"accepted","triggeredBy":[],"limitations":[]}]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-invalid-dimension-missing-missing-suites",
+        op: "assurance.render_case",
+        request: Request::Literal(
+            r#"{"claims":[],"unreachable":[],"unreadable":[],"producerTrust":[],"evidenceIndependence":[{"profile":"P","requirement":"FR-001","obligation":"FR-001-AC-1","status":"satisfied","dimensions":[{"dimension":"author","values":[]}],"summary":"s"}]}"#,
+        ),
+    },
+    Case {
+        name: "assurance/render-invalid-malformed",
+        op: "assurance.render_case",
+        request: Request::Literal("{oops"),
+    },
     Case {
         name: "invalid/unknown-op",
         op: "evidence.record",

--- a/rust/crates/quoin-evidence-types/Cargo.toml
+++ b/rust/crates/quoin-evidence-types/Cargo.toml
@@ -1,26 +1,25 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Agent-IX
 [package]
-name = "quoin-assurance"
+name = "quoin-evidence-types"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "The assurance-case view: a read-only projection over evidence already collected."
+description = "Producer-reliance and independence assessments, as the assurance renderer observes them."
 publish.workspace = true
 
 [lib]
-name = "quoin_assurance"
+name = "quoin_evidence_types"
 path = "src/lib.rs"
 
 [lints]
 workspace = true
 
 [dependencies]
-quoin-evidence-types = { workspace = true }
-quoin-finding-types = { workspace = true }
-quoin-quire-types = { workspace = true }
 serde = { workspace = true }
+
+[dev-dependencies]
 serde_json = { workspace = true }

--- a/rust/crates/quoin-evidence-types/src/lib.rs
+++ b/rust/crates/quoin-evidence-types/src/lib.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! Producer-reliance and independence assessments, as the assurance renderer
+//! observes them (quoin#384).
+//!
+//! # This crate exists because an import list lied in the other direction
+//!
+//! quoin#425 found that sizing a crate from the import graph **overstates**:
+//! `build_case` names five types and reads twelve fields, and two of the five
+//! it never inspects at all — it sorts them by one key and re-emits them
+//! unchanged. Those two were correctly carried as opaque values.
+//!
+//! `render_case` is the same instrument failing the other way. It imports one
+//! line:
+//!
+//! ```ignore
+//! import type { AssuranceCase, CaseNode } from "./graph.js";
+//! ```
+//!
+//! Both of those already existed, so by the import graph `render_case` was
+//! free. It reads **fourteen fields across three types it never names**,
+//! reaching through `AssuranceCase`'s own fields:
+//!
+//! | type | `build_case` | `render_case` |
+//! |---|---|---|
+//! | [`TrustAssessment`] | one sort key | 5 of 8 fields |
+//! | [`IndependenceAssessment`] | one sort key | 6 of 7 fields |
+//! | [`IndependenceDimensionAssessment`] | never reached | 3 of 3 fields |
+//!
+//! Every one of those is interpolated into the rendered markdown, so every one
+//! is observable in a byte comparison — which is exactly the test that decides
+//! whether a type is real or opaque. The opaque-value decision that was right
+//! for `build_case` is wrong here, and the same type lands in different classes
+//! for different operations. That is the part that is easy to miss.
+//!
+//! # These are readers, restricted to what the renderer emits
+//!
+//! `src/evidence/types.ts` owns the full shapes. Only the fields the renderer
+//! puts on the page are declared here, for the reason above: a field nothing
+//! observes cannot be covered by anything, so declaring it would add surface a
+//! byte comparison could not check.
+//!
+//! There is no `deny_unknown_fields` anywhere in this crate. The caller hands
+//! the renderer whatever `build_case` emitted, which carries every field the
+//! evidence store wrote.
+
+use serde::{Deserialize, Serialize};
+
+/// Use-specific producer reliance, shown as context and never as claim support.
+///
+/// Reads 5 of the 8 fields `src/evidence/types.ts` declares. `producer`,
+/// `permittedDecisions` and `owner` are not rendered, so they are not here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustAssessment {
+    /// The assessment's own id. Also `build_case`'s sort key.
+    pub id: String,
+    /// The bounded use this reliance decision was made for.
+    pub use_id: String,
+    /// The decision, interpolated verbatim.
+    ///
+    /// A `String` and not an enum, for the reason set out on
+    /// [`quoin_finding_types::Finding::kind`]: the retained union is erased at
+    /// run time and the renderer interpolates whatever arrives, so a closed
+    /// Rust enum would refuse input the retained implementation accepts.
+    ///
+    /// The five the store writes today, as a reader's note and not a
+    /// constraint: `accepted`, `accepted-with-limitations`, `invalidated`,
+    /// `not-accepted`, `unobserved`.
+    pub status: String,
+    /// What would require this reliance to be revalidated.
+    ///
+    /// A list of strings rather than of objects: `TrustTrigger` is a string
+    /// union in the retained source, and the renderer joins it with `", "`.
+    /// Had it been an object, that join would produce `[object Object]` — a
+    /// real defect, which is why this was worth checking rather than assuming.
+    pub triggered_by: Vec<String>,
+    /// Stated limitations, joined with `"; "` when non-empty.
+    pub limitations: Vec<String>,
+}
+
+/// One dimension of a profile-selected separation check.
+///
+/// All three fields are rendered, so all three are here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndependenceDimensionAssessment {
+    /// Which dimension was checked, interpolated verbatim.
+    pub dimension: String,
+    /// The values observed. Rendered as `no stated values` when empty.
+    pub values: Vec<String>,
+    /// Suites the dimension could not be read from.
+    pub missing_suites: Vec<String>,
+}
+
+/// A profile-selected separation result for one obligation.
+///
+/// Reads 6 of the 7 fields the retained type declares; `satisfiedBy` is the one
+/// the renderer does not put on the page.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndependenceAssessment {
+    /// The profile that selected the check.
+    pub profile: String,
+    /// The requirement the obligation belongs to.
+    pub requirement: String,
+    /// The obligation assessed. Also `build_case`'s sort key.
+    pub obligation: String,
+    /// `satisfied` or `insufficient` today; a `String` for the same reason as
+    /// [`TrustAssessment::status`].
+    pub status: String,
+    /// One line explaining the result.
+    pub summary: String,
+    /// The per-dimension detail.
+    pub dimensions: Vec<IndependenceDimensionAssessment>,
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::{IndependenceAssessment, TrustAssessment};
+
+    #[test]
+    fn reads_a_trust_assessment_carrying_the_three_unrendered_fields() {
+        // The shape the evidence store actually writes. If this fails, the
+        // renderer has started refusing its own producer's output.
+        let assessment: TrustAssessment = serde_json::from_str(
+            r#"{
+                "id": "T-001",
+                "useId": "U-1",
+                "producer": "vitest",
+                "status": "accepted-with-limitations",
+                "permittedDecisions": ["release"],
+                "limitations": ["linux only"],
+                "triggeredBy": ["producer-version", "configuration"],
+                "owner": "qa"
+            }"#,
+        )
+        .expect("the store's own trust shape must deserialize");
+        assert_eq!(assessment.use_id, "U-1");
+        assert_eq!(
+            assessment.triggered_by,
+            ["producer-version", "configuration"]
+        );
+    }
+
+    #[test]
+    fn reads_an_independence_assessment_ignoring_satisfied_by() {
+        let assessment: IndependenceAssessment = serde_json::from_str(
+            r#"{
+                "profile": "P",
+                "requirement": "FR-001",
+                "obligation": "FR-001-AC-1",
+                "status": "satisfied",
+                "dimensions": [
+                    {"dimension": "author", "values": ["a", "b"], "missingSuites": []}
+                ],
+                "satisfiedBy": ["unit", "integration"],
+                "summary": "two authors"
+            }"#,
+        )
+        .expect("the store's own independence shape must deserialize");
+        assert_eq!(assessment.dimensions.len(), 1);
+        assert_eq!(assessment.dimensions[0].missing_suites, [] as [String; 0]);
+    }
+
+    #[test]
+    fn accepts_a_status_no_closed_enum_would_admit() {
+        // Same property as `Finding::kind`. The renderer interpolates; it does
+        // not validate, and neither may this.
+        let assessment: TrustAssessment = serde_json::from_str(
+            r#"{"id":"T","useId":"U","status":"status-invented-tomorrow","triggeredBy":[],"limitations":[]}"#,
+        )
+        .expect("an unknown status is not a parse error");
+        assert_eq!(assessment.status, "status-invented-tomorrow");
+    }
+
+    #[test]
+    fn a_missing_rendered_field_is_a_hard_error() {
+        // Every field here is rendered unconditionally, so absence must fail
+        // loudly rather than default to empty and print a blank row.
+        for text in [
+            r#"{"useId":"U","status":"s","triggeredBy":[],"limitations":[]}"#,
+            r#"{"id":"T","status":"s","triggeredBy":[],"limitations":[]}"#,
+            r#"{"id":"T","useId":"U","triggeredBy":[],"limitations":[]}"#,
+            r#"{"id":"T","useId":"U","status":"s","limitations":[]}"#,
+            r#"{"id":"T","useId":"U","status":"s","triggeredBy":[]}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<TrustAssessment>(text).is_err(),
+                "a trust assessment missing a rendered field must not deserialize: {text}"
+            );
+        }
+    }
+}

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -14,7 +14,7 @@
  * transliteration of one implementation would agree with itself.
  */
 
-import { buildCase, requirementOf } from "../assurance/index.js";
+import { buildCase, renderCase, requirementOf } from "../assurance/index.js";
 
 /** Mirrors `quoin_core::protocol::PROTOCOL_VERSION` — deliberately restated,
  * not imported from the generated `./types.js`: this file is the differential
@@ -149,11 +149,15 @@ export function reference(argv: string[], stdin: string): ReferenceOutcome {
   if (op === "assurance.build_case") {
     return assuranceBuildCase(parsed);
   }
+  if (op === "assurance.render_case") {
+    return assuranceRenderCase(parsed);
+  }
   if (op !== "core.ping") {
     return failure(
       3,
       diagnostic("CORE_UNKNOWN_OP", "no such operation in this build", {
-        known: "assurance.build_case, assurance.requirement_of, core.ping",
+        known:
+          "assurance.build_case, assurance.render_case, assurance.requirement_of, core.ping",
         op,
       }),
     );
@@ -420,4 +424,160 @@ function assuranceBuildCase(fields: Record<string, unknown>): ReferenceOutcome {
       : {}),
   });
   return { exitCode: 0, payload: canonicalJson(built), diagnostics: [] };
+}
+
+/**
+ * `assurance.render_case`, answered by the RETAINED implementation.
+ *
+ * The input to this operation is the OUTPUT of `assurance.build_case`, so the
+ * size ceiling is deliberately the same constant: a case that could be built
+ * and then could not be rendered would be a boundary contradicting itself.
+ *
+ * **The validation is parity, not defensiveness** — the same reason it is in
+ * `assuranceBuildCase`, and more of it here because the Rust side deserialises
+ * a deeper structure. `CaseNode.kind` and `CaseNode.status` are CLOSED enums
+ * on the Rust side and legitimately so: unlike `Finding.kind`, they are minted
+ * by `build_case` rather than supplied by a caller, so the set really is
+ * closed. serde refuses an unrecognised one, and the reference must refuse it
+ * too or the two sides disagree on exactly the inputs a malformed pipeline
+ * produces.
+ */
+function assuranceRenderCase(
+  fields: Record<string, unknown>,
+): ReferenceOutcome {
+  const op = "assurance.render_case";
+  const bad = (message: string): ReferenceOutcome =>
+    failure(3, diagnostic("CORE_BAD_REQUEST", message, { op }));
+
+  const size = Buffer.byteLength(JSON.stringify(fields), "utf8");
+  if (size > MAX_BUILD_CASE_BYTES) {
+    return failure(
+      2,
+      diagnostic("CORE_REFUSED", "request exceeds the accepted size", {
+        limit_bytes: String(MAX_BUILD_CASE_BYTES),
+        observed_bytes: String(size),
+        op,
+      }),
+    );
+  }
+
+  const isObject = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v);
+  const strings = (v: unknown): boolean =>
+    Array.isArray(v) && v.every((e) => typeof e === "string");
+
+  /** Every named key of `entry` is a string. */
+  const shaped = (
+    entry: unknown,
+    what: string,
+    keys: string[],
+  ): string | null => {
+    if (!isObject(entry)) return `each ${what} must be a JSON object`;
+    for (const key of keys) {
+      if (typeof entry[key] !== "string") return `${what}.${key} must be a string`;
+    }
+    return null;
+  };
+
+  // `CaseNode`, recursively. `children` has no serde default, so it is
+  // required at every depth — an interior node without it is a bad request on
+  // the Rust side and must be one here.
+  const NODE_KINDS = new Set(["goal", "strategy", "solution"]);
+  const NODE_STATUSES = new Set(["supported", "open"]);
+  const node = (entry: unknown, where: string): string | null => {
+    const shapeError = shaped(entry, where, ["id", "statement"]);
+    if (shapeError) return shapeError;
+    const n = entry as Record<string, unknown>;
+    if (typeof n.kind !== "string" || !NODE_KINDS.has(n.kind)) {
+      return `${where}.kind must be goal, strategy or solution`;
+    }
+    if (typeof n.status !== "string" || !NODE_STATUSES.has(n.status)) {
+      return `${where}.status must be supported or open`;
+    }
+    if (n.because !== undefined && typeof n.because !== "string") {
+      return `${where}.because must be a string when present`;
+    }
+    if (!Array.isArray(n.children)) return `${where}.children must be an array`;
+    for (const child of n.children) {
+      const error = node(child, `${where}.children[]`);
+      if (error) return error;
+    }
+    return null;
+  };
+
+  if (!Array.isArray(fields.claims)) return bad("`claims` must be an array");
+  for (const claim of fields.claims) {
+    const error = node(claim, "claim");
+    if (error) return bad(error);
+  }
+  if (fields.reason !== undefined && typeof fields.reason !== "string") {
+    return bad("`reason` must be a string when present");
+  }
+  if (!strings(fields.unreachable)) {
+    return bad("`unreachable` must be an array of strings");
+  }
+  if (!Array.isArray(fields.unreadable)) {
+    return bad("`unreadable` must be an array");
+  }
+  for (const entry of fields.unreadable) {
+    const error = shaped(entry, "unreadable", ["path", "reason"]);
+    if (error) return bad(error);
+  }
+
+  // `producerTrust` is REQUIRED, and `evidenceIndependence` is not, because
+  // the retained renderer reads `assurance.producerTrust.length` directly and
+  // reaches for `evidenceIndependence` through `?.`. The difftest found the
+  // asymmetry: defaulting the first made quoin-core render a case the retained
+  // implementation throws on, which is the port being more permissive than
+  // what it replaces.
+  const trust = fields.producerTrust;
+  {
+    if (!Array.isArray(trust)) return bad("`producerTrust` must be an array");
+    for (const entry of trust) {
+      const error = shaped(entry, "producerTrust", ["id", "useId", "status"]);
+      if (error) return bad(error);
+      const t = entry as Record<string, unknown>;
+      if (!strings(t.triggeredBy)) {
+        return bad("producerTrust.triggeredBy must be an array of strings");
+      }
+      if (!strings(t.limitations)) {
+        return bad("producerTrust.limitations must be an array of strings");
+      }
+    }
+  }
+
+  const independence = fields.evidenceIndependence;
+  if (independence !== undefined && independence !== null) {
+    if (!Array.isArray(independence)) {
+      return bad("`evidenceIndependence` must be an array");
+    }
+    for (const entry of independence) {
+      const error = shaped(entry, "evidenceIndependence", [
+        "profile",
+        "requirement",
+        "obligation",
+        "status",
+        "summary",
+      ]);
+      if (error) return bad(error);
+      const a = entry as Record<string, unknown>;
+      if (!Array.isArray(a.dimensions)) {
+        return bad("evidenceIndependence.dimensions must be an array");
+      }
+      for (const d of a.dimensions) {
+        const dimensionError = shaped(d, "dimension", ["dimension"]);
+        if (dimensionError) return bad(dimensionError);
+        const dim = d as Record<string, unknown>;
+        if (!strings(dim.values)) {
+          return bad("dimension.values must be an array of strings");
+        }
+        if (!strings(dim.missingSuites)) {
+          return bad("dimension.missingSuites must be an array of strings");
+        }
+      }
+    }
+  }
+
+  const rendered = renderCase(fields as never);
+  return { exitCode: 0, payload: canonicalJson({ rendered }), diagnostics: [] };
 }


### PR DESCRIPTION
```
72 case(s), 0 difference(s)
```

**47 of them compare the retained `src/assurance/`; 24 are the renderer.**

| cases | compared against |
|---:|---|
| 13 | `core.ping` — the Stage-0 purpose-built oracle |
| 12 | `assurance.requirement_of` vs the retained `graph.ts` |
| 23 | `assurance.build_case` vs the retained `graph.ts` |
| **24** | **`assurance.render_case` vs the retained `render.ts`** |

## The same instrument, failing the other way

[#425](https://github.com/agent-ix/quoin/issues/425) found that sizing a crate from the import list **overstates**: `build_case` names five types, reads twelve fields, and never inspects two of them at all.

`render.ts` imports one line:

```ts
import type { AssuranceCase, CaseNode } from "./graph.js";
```

Both already existed, so by the import graph `render_case` was free. It reads **fourteen fields across three types it never names**, reaching through `AssuranceCase`'s own fields:

| type | `build_case` | `render_case` |
|---|---|---|
| `TrustAssessment` | one sort key | **5 of 8** |
| `IndependenceAssessment` | one sort key | **6 of 7** |
| `IndependenceDimensionAssessment` | never reached | **3 of 3** |

All interpolated into markdown, so all observable in a byte comparison — which is the test that decides whether a type is real or opaque. The opaque-value decision that was correct for `build_case` is wrong here.

**So `AssuranceCase` is now generic over the two assessment types rather than carrying a comment about them:**

```rust
pub struct AssuranceCase<Trust = serde_json::Value, Independence = serde_json::Value>
```

`build_case` returns `AssuranceCase<Value, Value>` because it must round-trip fields it cannot see; `render_case` takes `AssuranceCase<TrustAssessment, IndependenceAssessment>` because it reads them. The compiler carries the distinction, and a reader asking "is this field read here?" gets the answer from the signature instead of from a paragraph that can rot.

## Two porting traps

**One caught by reading.** `node_id` is `id.replace(/[^A-Za-z0-9]/g, "_")`. A JavaScript regex without the `u` flag matches **UTF-16 code units**, so an astral character becomes *two* underscores. `chars()` was the obvious port and would have produced one. Case: `assurance/render-node-id-sanitises-per-code-unit`.

**One caught by the harness — the first time it has found something reading did not.** `producerTrust` had a serde default. The retained renderer reads `assurance.producerTrust.length` unconditionally and **throws** when it is absent, so the default made `quoin-core` render a case the retained implementation cannot. That is the port being *more* permissive than what it replaces, which is as much a difference as a closed enum being less permissive. Now required, with the reason in the type.

`evidenceIndependence` keeps its default, because there the retained code uses `?.` and genuinely tolerates absence. **The two fields differ because the retained implementation treats them differently**, not because one looked more optional than the other. Both cases are in the table.

## Which unions are closed, and which are not

`TrustAssessment.status` and `IndependenceAssessment.status` are `String`, per the `Finding.kind` rule: the renderer interpolates and never validates, so a closed Rust enum would refuse input the retained implementation renders.

`CaseNode.kind` and `CaseNode.status` **are** closed enums, and legitimately — `build_case` mints them, so the set really is closed, and serde refusing an unrecognised one is the correct behaviour on both sides. Both properties have cases (`render-unknown-trust-status`, `render-invalid-node-kind`, `render-invalid-node-status`).

`TrustTrigger` turned out to be a string union rather than an object, so `join(", ")` yields prose. Worth reading rather than assuming — a list of objects would render `[object Object]` and the port would have had to reproduce it. The #384 pass-through fixture fed it objects; the realistic shape is here now that the real type is in hand.

[#432](https://github.com/agent-ix/quoin/issues/432)'s truncation is free on this side: Rust's `String` cannot hold a lone surrogate, which is precisely why the oracle had to be fixed before this module could match it.

## Gates

`cargo fmt --check` clean · `clippy -D warnings` clean across the whole workspace · `cargo test --workspace` **130 tests** · **72 difftest comparisons, 0 differences** · `make lint` clean · `tsc --noEmit` clean.

**Two full-suite failures, neither this change, both the same class — a subprocess-heavy test with no deadline headroom.**

- `tests/semantic-module-template.test.ts` — [#429](https://github.com/agent-ix/quoin/issues/429), 5 s default against ~50-68 s of `cookiecutter` and `quire validate`. A different test each run; passes 79/79 alone.
- `tests/verification-relock.test.ts` — **new datum for the same ticket.** `scripts/verification-stack-selftest.mjs` measures **39.18 s unloaded against its own 60 s timeout** — 35% headroom, which full-suite parallelism eats. It passes standalone: *44 invariants verified*, exit 0. It passed in this branch's own earlier run.

That second one matters for #429's fix: reducing `cookiecutter` invocations does not help a test that is slow for its own reasons. The shared cause is a fixed deadline sized against an unloaded machine.

Refs #384, #373, #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY