### PR TITLE
fix(436): an instant that names a day which does not exist is refused

### DIFF
--- a/spec/functional/FR-047-authored-assurance-arguments.md
+++ b/spec/functional/FR-047-authored-assurance-arguments.md
@@ -35,11 +35,20 @@ score or claim compatibility with an external argument notation.
 | FR-047-AC-4 | A resolved challenge requires resolution references; accepted risk additionally requires a current expiry. | Test (TC-1134) |
 | FR-047-AC-5 | The closed authored contract, decision shape, uniqueness, timestamps, and digests are validated before rendering. | Test (TC-1135) |
 | FR-047-AC-6 | Markdown and JSON preserve every open reason and render unchanged input deterministically. | Test (TC-1136) |
+| FR-047-AC-7 | An authored instant naming a day, hour, minute or second that does not exist is refused, rather than rolled forward into a different instant that then decides a reported status. | Test (TC-1712) |
 
 ## Constraints
 
 - A test result or coverage result is evidence, not a sufficiency decision.
 - The evaluator reads no wall clock; callers provide the `asOf` instant.
+
+An instant is validated in full, not merely matched for shape. `Date.parse` does
+not reject an impossible value — it rolls it, so `2026-02-30T00:00:00Z` becomes
+March 2 and `T24:00:00Z` becomes the following day. The parsed number is then
+compared against `asOf` to decide whether an assumption is due for review or an
+accepted risk has expired, which makes a date nobody can have meant into a
+reported status rather than into an error (`agent-ix/quoin#436`). The strict
+reader is shared with the measurement surfaces rather than written a third time.
 - The authored contract remains owned by the separately installed private
   engineering-assurance module.
 - No external argument notation is emitted or claimed.

--- a/src/assurance/argument.ts
+++ b/src/assurance/argument.ts
@@ -6,6 +6,8 @@
  * assumptions and challenges remain independently visible.
  */
 
+import { parseRfc3339DateTime } from "../measurement/date-time.js";
+
 import type { DischargeReport } from "./discharge.js";
 
 export interface AssuranceArgumentDefinition {
@@ -779,6 +781,23 @@ function literal<const T extends readonly string[]>(
   return value;
 }
 
+/**
+ * One authored instant, as a number for comparison.
+ *
+ * Two gates, and the split is deliberate (quoin#436). The regex is this
+ * module's own and is stricter than RFC 3339 on case: an authored `review_by`
+ * spells `T` and `Z` in upper case, and `parseRfc3339DateTime` admits `t` and
+ * `z`. Delegating the whole check would have tightened the ranges and loosened
+ * the spelling in one move.
+ *
+ * The ranges are delegated, because `Date.parse` does not reject impossible
+ * values — it ROLLS them. `2026-02-30T00:00:00Z` parsed as March 2 and
+ * `T24:00:00Z` as the following day, and the returned number is compared
+ * against `asOf` to decide whether an assumption is due for review or an
+ * accepted risk has expired. A date nobody can have meant was deciding a
+ * reported status, silently. `parseRfc3339DateTime` is the strict reader this
+ * repository already shares; a third private copy of it was the bug.
+ */
 function instant(name: string, value: string): number {
   if (
     !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
@@ -787,9 +806,8 @@ function instant(name: string, value: string): number {
   ) {
     throw new Error(`${name} must be an ISO-8601 instant`);
   }
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed))
-    throw new Error(`${name} must be an ISO-8601 instant`);
+  const parsed = parseRfc3339DateTime(value);
+  if (parsed === null) throw new Error(`${name} must be an ISO-8601 instant`);
   return parsed;
 }
 

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -474,7 +474,8 @@ function assuranceRenderCase(
   ): string | null => {
     if (!isObject(entry)) return `each ${what} must be a JSON object`;
     for (const key of keys) {
-      if (typeof entry[key] !== "string") return `${what}.${key} must be a string`;
+      if (typeof entry[key] !== "string")
+        return `${what}.${key} must be a string`;
     }
     return null;
   };

--- a/tests/authored-argument.test.ts
+++ b/tests/authored-argument.test.ts
@@ -1,4 +1,4 @@
-/** FR-047 — authored assurance arguments (TC-1131..TC-1136). */
+/** FR-047 — authored assurance arguments (TC-1131..TC-1136, TC-1712). */
 
 import { describe, expect, it } from "vitest";
 
@@ -209,5 +209,59 @@ describe("authored assurance arguments", () => {
     expect(first).toContain("OPEN");
     expect(first).toContain("no sufficiency decision");
     expect(first).toContain("Participants and authority");
+  });
+
+  // Trace: FR-047-AC-7 (TC-1712)
+  it("refuses an instant naming a day or hour that does not exist", () => {
+    // `Date.parse` rolls rather than rejects, so each of these WAS accepted and
+    // became a different instant (quoin#436).
+    for (const reviewBy of [
+      "2026-02-30T00:00:00.000Z",
+      "2026-06-31T00:00:00.000Z",
+      "2025-02-29T00:00:00.000Z",
+      "2026-08-15T24:00:00.000Z",
+    ]) {
+      expect(() =>
+        buildAuthoredArgumentView({
+          argument: {
+            ...argument,
+            assumptions: [{ ...argument.assumptions[0], review_by: reviewBy }],
+          },
+          decisions: [decision],
+          asOf: "2026-08-15T00:00:00.000Z",
+        }),
+      ).toThrow("review_by must be an ISO-8601 instant");
+    }
+
+    // The reason this is not only an acceptance question. February 30 rolls
+    // forward to March 2, which is AFTER this `asOf` — so the assumption used
+    // to read as not yet due, and the argument reported a status derived from a
+    // date nobody can have authored.
+    expect(() =>
+      buildAuthoredArgumentView({
+        argument: {
+          ...argument,
+          assumptions: [
+            {
+              ...argument.assumptions[0],
+              review_by: "2026-02-30T00:00:00.000Z",
+            },
+          ],
+        },
+        decisions: [decision],
+        asOf: "2026-03-01T00:00:00.000Z",
+      }),
+    ).toThrow("review_by must be an ISO-8601 instant");
+
+    // The leap year the other way, and a real February 29, which must stay
+    // accepted: the fix tightens impossible dates, not unusual ones.
+    expect(() =>
+      parseAssuranceArgument({
+        ...argument,
+        assumptions: [
+          { ...argument.assumptions[0], review_by: "2028-02-29T00:00:00.000Z" },
+        ],
+      }),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #436.

`instant()` in `src/assurance/argument.ts` matched the **shape** of a timestamp with a regex and left every **range** to `Date.parse`, which rolls impossible values instead of rejecting them:

```
2026-02-30T00:00:00Z  ->  2026-03-02T00:00:00.000Z   accepted
2026-01-01T24:00:00Z  ->  2026-01-02T00:00:00.000Z   accepted
```

## Why it is not only an acceptance bug

`instant()` returns the number, and the number is compared — `assumption.review_by <= asOf`, and the accepted-risk expiry in `evaluateChallenge`. An assumption dated February 30 was evaluated as **March 2**, so the argument reported a different **status**, not a different error.

The test makes exactly that case load-bearing: `review_by: 2026-02-30` against `asOf: 2026-03-01` used to read as *not yet due*, because the rolled date is after the `asOf`. FR-040's contract is that a narrowed case is indistinguishable from a complete one to a reader; this is the same failure one layer down, with a date nobody can have authored deciding whether a claim reads as supported.

## The function already existed here, twice

| | |
|---|---|
| `src/measurement/date-time.ts` — `parseRfc3339DateTime`, exported | strict |
| `src/measurement/intervention.ts:347` — private duplicate | strict |
| `src/assurance/argument.ts` — `instant()` | **loose** |

Two tests already name `2026-02-30T12:00:00Z` by hand and assert it is refused (`tests/operational.test.ts:176`, `tests/intervention.test.ts:181`). The convention was in place; assurance was the one surface outside it. `CLAUDE.md` names the rule this broke — *"two readers over the same files drift"*.

## What the change does and deliberately does not do

The regex stays as the gate and only the **ranges** are delegated. `parseRfc3339DateTime` accepts lowercase `t` and `z` where this module does not, so delegating the whole check would have tightened the ranges and loosened the spelling in one move. Leap seconds (`:60`) stay refused, as they are today.

## Measured before changing anything

```
files scanned:                 1292 (quoin) + 1034 (corpus/)
distinct instant literals:      150 + 16
accepted by the retained code:  149 + 16
accepted but NOT RFC-3339:      2
  2026-02-30T12:00:00Z  tests/intervention.test.ts
  2026-02-30T12:05:00Z  tests/operational.test.ts
```

Both are the negative fixtures above. **No authored document starts being rejected**, so this is not a user-visible acceptance change and needs no separate decision.

## Negative control

The new test was run against the unfixed `instant()` and **fails** (`expected undefined to throw`), then passes with the fix. A tightening test that passes both ways is not evidence.

## Also in this PR

One line in `src/core/reference.ts` is reformatted. It reached main unformatted in 6349ce6 (#435, mine) and `prettier --check` fails on `main` today. Separately: `make lint` cannot run here at all right now — corepack invokes pnpm 11.1.3 against a project pinned to 11.20.0 and the install aborts. `pnpm run lint` directly is clean. I have not established that the two are connected and am not claiming it.

## Provenance

Found while sizing `parseAssuranceArgument` for the Rust port (#384). A port reproduces retained behaviour, so the question was whether to reproduce this one; the measurement says there is nothing to reproduce, which is why the fix lands before the port rather than inside it.

## Gates

`tsc --noEmit` clean · import-cycle check clean · `prettier --check` clean · eslint clean · 145 tests across every file that reaches this module, all passing.

Spec: `FR-047-AC-7`, Test `TC-1712`. AC ids and the TC id were allocated by scanning all remote branches, not the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY
