### PR TITLE
feat(384): parse_argument across the boundary, and the sizing instrument as a question

### DIFF
--- a/rust/crates/quoin-assurance/src/argument.rs
+++ b/rust/crates/quoin-assurance/src/argument.rs
@@ -28,6 +28,11 @@
 //! - An instant naming a day that does not exist must be refused, which
 //!   `Date.parse` did not do until quoin#436 fixed the retained code.
 //!
+//! For the same reason the payload types are `Serialize` only. A derived
+//! `Deserialize` on [`AssuranceArgument`] would be a second, permissive door
+//! into the same struct that bypasses all seventeen predicates, and it would
+//! read as harmless because deriving both is the habit.
+//!
 //! # Permissiveness runs both ways
 //!
 //! Recorded on quoin#384 and worth repeating where the code is: a port that
@@ -35,13 +40,26 @@
 //! exactly as much as one that refuses what it accepts. Every deviation below
 //! is annotated with which direction it would have gone.
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// A rejection, carrying the retained implementation's own message.
 ///
 /// The message is reproduced because it costs nothing and helps a human, but
 /// it is deliberately **not** a contract: `quoin-difftest` compares the
 /// diagnostic's `(code, context keys)` and never its prose (quoin#373).
+///
+/// # Why one variant and not seventeen
+///
+/// rust-review §0b warns that an error whose payload is a string, built from a
+/// different literal at each site, has moved the discriminant into prose. The
+/// test it gives is whether a caller must distinguish the conditions. Here no
+/// caller can: every one of the seventeen predicates this module checks leaves
+/// the boundary as the single code `CORE_BAD_REQUEST`, because that is what
+/// the retained `parseAssuranceArgument` does — it throws one `Error` — and
+/// FR-101 parity is the whole point of the port. Seventeen typed variants
+/// would be public API that nothing branches on (§3), and the first caller
+/// that wanted one would be asking for a distinction the oracle does not make.
+/// There is one discriminant, and it is spelled `Err`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArgumentError(pub String);
 
@@ -67,7 +85,7 @@ fn reject<T>(message: impl Into<String>) -> Checked<T> {
 /// arrives. These go through `literal()`, which checks and **throws**, so
 /// refusing an unlisted value IS the retained behaviour. Same test, different
 /// answer, because the code differs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ArgumentStatus {
     /// Authored but not yet in force.
@@ -79,7 +97,7 @@ pub enum ArgumentStatus {
 }
 
 /// An assumption's declared state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AssumptionStatus {
     /// Stated and not yet decided.
@@ -91,7 +109,7 @@ pub enum AssumptionStatus {
 }
 
 /// A challenge's declared state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ChallengeStatus {
     /// Raised and unanswered.
@@ -103,7 +121,7 @@ pub enum ChallengeStatus {
 }
 
 /// How a relationship reads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RelationshipType {
     /// The target supports this argument.
@@ -115,7 +133,7 @@ pub enum RelationshipType {
 }
 
 /// The claim the whole argument exists to argue.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TopClaim {
     /// The claim's id, which every reasoning chain must reach.
     pub id: String,
@@ -126,7 +144,7 @@ pub struct TopClaim {
 }
 
 /// One step of reasoning, with the criteria that would make it sufficient.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Reasoning {
     /// This step's id.
     pub id: String,
@@ -139,7 +157,7 @@ pub struct Reasoning {
 }
 
 /// Something the argument relies on without arguing for it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Assumption {
     /// This assumption's id.
     pub id: String,
@@ -154,7 +172,7 @@ pub struct Assumption {
 }
 
 /// A named actor and the authority they hold.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Participant {
     /// This participant's id, referenced by sufficiency decisions.
     pub id: String,
@@ -186,7 +204,7 @@ pub struct Participant {
 /// places — correct for the second and **more permissive** than the retained
 /// implementation for the first. Nothing about the two declarations says which
 /// is which; only the reading mechanism does.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Challenge {
     /// This challenge's id.
     pub id: String,
@@ -207,7 +225,7 @@ pub struct Challenge {
 }
 
 /// An edge to a document outside this argument.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Relationship {
     /// An `ix://` reference.
     pub target: String,
@@ -217,7 +235,7 @@ pub struct Relationship {
 }
 
 /// A validated authored assurance argument.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AssuranceArgument {
     /// `AA-<digits>`.
     pub id: String,
@@ -248,7 +266,7 @@ pub struct AssuranceArgument {
 }
 
 /// The one-variant `type` discriminator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ArgumentKind {
     /// The only accepted value.
     AssuranceArgument,
@@ -860,7 +878,7 @@ pub fn parse_assurance_argument(value: &serde_json::Value) -> Checked<AssuranceA
 }
 
 #[cfg(test)]
-#[expect(
+#[allow(
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::unwrap_used,

--- a/rust/crates/quoin-assurance/src/argument.rs
+++ b/rust/crates/quoin-assurance/src/argument.rs
@@ -1,0 +1,1031 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Agent-IX
+
+//! Validating an authored assurance argument (quoin#384, ported from
+//! `parseAssuranceArgument` in `src/assurance/argument.ts`).
+//!
+//! # Why this one is not a `#[derive(Deserialize)]`
+//!
+//! The two slices before this were transformers, and their Rust types carried
+//! the work: [`crate::case::CaseInput`] deserialises and `build_case` runs.
+//! This is a **validator**, and a validator's types carry almost none of it.
+//!
+//! The declared shape is 37 fields and every one is read — a field subset of
+//! 100%, which is the number a validator always produces, because reading
+//! every field IS the function. What the shape does not carry is **seventeen
+//! predicates**: four format rules, three non-emptiness rules, six uniqueness
+//! rules, and two graph reachability rules. A derive with
+//! `deny_unknown_fields` reproduces none of them.
+//!
+//! So the port is written against [`serde_json::Value`] rather than against a
+//! derived type. That is not a stylistic preference. Three of the behaviours
+//! below are invisible to serde and would each have been a silent divergence:
+//!
+//! - `null` in an optional field is **asymmetric** in the retained source, and
+//!   `Option<T>` collapses both halves. See [`Challenge`].
+//! - JavaScript's `trim` and Rust's `str::trim` disagree on two code points,
+//!   **in opposite directions**. See [`js_trim_is_empty`].
+//! - An instant naming a day that does not exist must be refused, which
+//!   `Date.parse` did not do until quoin#436 fixed the retained code.
+//!
+//! # Permissiveness runs both ways
+//!
+//! Recorded on quoin#384 and worth repeating where the code is: a port that
+//! **accepts** input the retained implementation rejects is a divergence,
+//! exactly as much as one that refuses what it accepts. Every deviation below
+//! is annotated with which direction it would have gone.
+
+use serde::{Deserialize, Serialize};
+
+/// A rejection, carrying the retained implementation's own message.
+///
+/// The message is reproduced because it costs nothing and helps a human, but
+/// it is deliberately **not** a contract: `quoin-difftest` compares the
+/// diagnostic's `(code, context keys)` and never its prose (quoin#373).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArgumentError(pub String);
+
+impl std::fmt::Display for ArgumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ArgumentError {}
+
+type Checked<T> = Result<T, ArgumentError>;
+
+fn reject<T>(message: impl Into<String>) -> Checked<T> {
+    Err(ArgumentError(message.into()))
+}
+
+/// The argument's lifecycle state. Closed, because the retained code validates.
+///
+/// quoin#425 asked whether a TypeScript union ports as a closed Rust type, and
+/// answered "only where the retained code checks membership at run time".
+/// `Finding.kind` was open because the retained renderer interpolates whatever
+/// arrives. These go through `literal()`, which checks and **throws**, so
+/// refusing an unlisted value IS the retained behaviour. Same test, different
+/// answer, because the code differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArgumentStatus {
+    /// Authored but not yet in force.
+    Proposed,
+    /// In force.
+    Active,
+    /// Withdrawn.
+    Retired,
+}
+
+/// An assumption's declared state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AssumptionStatus {
+    /// Stated and not yet decided.
+    Open,
+    /// Decided and standing.
+    Accepted,
+    /// Decided and no longer true.
+    Invalidated,
+}
+
+/// A challenge's declared state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChallengeStatus {
+    /// Raised and unanswered.
+    Open,
+    /// Answered, which requires a resolution reference.
+    Resolved,
+    /// Knowingly carried, which additionally requires a current expiry.
+    AcceptedRisk,
+}
+
+/// How a relationship reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RelationshipType {
+    /// The target supports this argument.
+    Supports,
+    /// The target challenges it.
+    Challenges,
+    /// The target is context.
+    References,
+}
+
+/// The claim the whole argument exists to argue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopClaim {
+    /// The claim's id, which every reasoning chain must reach.
+    pub id: String,
+    /// What is claimed.
+    pub statement: String,
+    /// What the claim is about.
+    pub subject: String,
+}
+
+/// One step of reasoning, with the criteria that would make it sufficient.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Reasoning {
+    /// This step's id.
+    pub id: String,
+    /// The reasoning itself.
+    pub statement: String,
+    /// The id this step argues toward — another step, or the top claim.
+    pub supports: String,
+    /// Non-empty, and its entries unique.
+    pub sufficiency_criteria: Vec<String>,
+}
+
+/// Something the argument relies on without arguing for it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Assumption {
+    /// This assumption's id.
+    pub id: String,
+    /// What is assumed.
+    pub statement: String,
+    /// Who owns it.
+    pub owner: String,
+    /// Its declared state.
+    pub status: AssumptionStatus,
+    /// When it must be revisited. An instant.
+    pub review_by: String,
+}
+
+/// A named actor and the authority they hold.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Participant {
+    /// This participant's id, referenced by sufficiency decisions.
+    pub id: String,
+    /// Their role.
+    pub role: String,
+    /// What they may decide.
+    pub authority: String,
+    /// What they are independent of.
+    pub independence: String,
+}
+
+/// An objection raised against a node of the argument.
+///
+/// # The two optional fields are not optional in the same way
+///
+/// This is the asymmetry `Option<T>` erases. The retained source reads them
+/// through different mechanisms:
+///
+/// ```ignore
+/// const expiresAt = optionalStringAt(row, "expires_at");
+/// //  -> `if (!(key in object)) return undefined;` then a string check
+/// const resolutionRefs = row.resolution_refs ? nonEmptyStrings(...) : undefined;
+/// //  -> truthiness
+/// ```
+///
+/// So `{"expires_at": null}` **throws** (`expires_at must be a string`, because
+/// the key IS present), while `{"resolution_refs": null}` is silently treated
+/// as absent. A derived `Option<String>` maps JSON `null` to `None` in both
+/// places — correct for the second and **more permissive** than the retained
+/// implementation for the first. Nothing about the two declarations says which
+/// is which; only the reading mechanism does.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Challenge {
+    /// This challenge's id.
+    pub id: String,
+    /// The argument node it targets. Must resolve.
+    pub target: String,
+    /// The objection.
+    pub statement: String,
+    /// Its declared state.
+    pub status: ChallengeStatus,
+    /// Who owns it.
+    pub owner: String,
+    /// Evidence that it was answered. Emitted only when authored.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub resolution_refs: Option<Vec<String>>,
+    /// When an accepted risk stops being current. Emitted only when authored.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub expires_at: Option<String>,
+}
+
+/// An edge to a document outside this argument.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Relationship {
+    /// An `ix://` reference.
+    pub target: String,
+    /// How it reads.
+    #[serde(rename = "type")]
+    pub kind: RelationshipType,
+}
+
+/// A validated authored assurance argument.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssuranceArgument {
+    /// `AA-<digits>`.
+    pub id: String,
+    /// The argument's title.
+    pub title: String,
+    /// Always `AssuranceArgument`; re-emitted so the output is a complete
+    /// document rather than one that has to be reassembled by its reader.
+    #[serde(rename = "type")]
+    pub kind: ArgumentKind,
+    /// Its lifecycle state.
+    pub status: ArgumentStatus,
+    /// Who owns the argument.
+    pub owner: String,
+    /// An `ix://` reference to the profile that governs it.
+    pub profile: String,
+    /// The claim being argued.
+    pub top_claim: TopClaim,
+    /// Non-empty. Every entry reaches [`AssuranceArgument::top_claim`].
+    pub reasoning: Vec<Reasoning>,
+    /// May be empty.
+    pub assumptions: Vec<Assumption>,
+    /// Non-empty.
+    pub participants: Vec<Participant>,
+    /// May be empty. Every entry targets a node that exists.
+    pub challenges: Vec<Challenge>,
+    /// May be empty.
+    pub relationships: Vec<Relationship>,
+}
+
+/// The one-variant `type` discriminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ArgumentKind {
+    /// The only accepted value.
+    AssuranceArgument,
+}
+
+/// The twelve keys the retained implementation admits at the top level.
+const ALLOWED: [&str; 12] = [
+    "id",
+    "title",
+    "type",
+    "status",
+    "owner",
+    "profile",
+    "top_claim",
+    "reasoning",
+    "assumptions",
+    "participants",
+    "challenges",
+    "relationships",
+];
+
+/// Is this string empty once JavaScript's `trim` has run?
+///
+/// **Not `str::trim`.** The two disagree on exactly two code points, and they
+/// disagree in OPPOSITE directions, which is why one call to `str::trim` would
+/// have been wrong twice:
+///
+/// | code point | `String.prototype.trim` | `char::is_whitespace` | if ported naively |
+/// |---|---|---|---|
+/// | `U+FEFF` zero-width no-break space | trims | keeps | port **accepts** what the oracle refuses |
+/// | `U+0085` next line | keeps | trims | port **refuses** what the oracle accepts |
+///
+/// ECMA-262 defines the trimmed set as `WhiteSpace` (TAB, VT, FF, SP, NBSP,
+/// ZWNBSP and category `Zs`) plus `LineTerminator` (LF, CR, LS, PS). Unicode's
+/// `White_Space` property, which Rust uses, includes `U+0085` and excludes
+/// `U+FEFF`. So the set is transcribed here rather than borrowed.
+fn js_trim_is_empty(value: &str) -> bool {
+    value.chars().all(|c| {
+        matches!(c,
+            '\u{0009}'..='\u{000D}'
+                | '\u{0020}'
+                | '\u{00A0}'
+                | '\u{1680}'
+                | '\u{2000}'..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+        )
+    })
+}
+
+/// One authored instant, validated exactly as the retained `instant()` does.
+///
+/// Two gates, and the split is the retained code's (quoin#436):
+///
+/// 1. The module's own shape regex, which is **stricter than RFC 3339 on
+///    case** — an uppercase `T` and `Z` only.
+/// 2. The ranges, which the retained code delegates to the shared strict
+///    reader in `src/measurement/date-time.ts`.
+///
+/// Before quoin#436 the second gate was `Date.parse`, which does not reject an
+/// impossible value — it ROLLS it, so `2026-02-30T00:00:00Z` became March 2
+/// and the rolled number then decided whether an assumption was due for
+/// review. That was fixed in the retained tree before this port was written,
+/// precisely so this function is written against a rule rather than against a
+/// rollover.
+///
+/// A leap second (`:60`) is refused, because both sides refuse it. No date
+/// crate's default behaviour matches this combination, which is why it is
+/// written out.
+fn is_instant(value: &str) -> bool {
+    // The shape is pure ASCII, so a multi-byte character can only be a
+    // rejection — and establishing that up front makes every `get` below a
+    // character boundary by construction rather than by argument.
+    if !value.is_ascii() {
+        return false;
+    }
+    let (Some(head), Some(rest)) = (value.get(..19), value.get(19..)) else {
+        return false;
+    };
+    if head.get(4..5) != Some("-")
+        || head.get(7..8) != Some("-")
+        || head.get(10..11) != Some("T")
+        || head.get(13..14) != Some(":")
+        || head.get(16..17) != Some(":")
+    {
+        return false;
+    }
+
+    let mut fields = [0u32; 6];
+    for (slot, (from, to)) in
+        fields
+            .iter_mut()
+            .zip([(0, 4), (5, 7), (8, 10), (11, 13), (14, 16), (17, 19)])
+    {
+        let Some(text) = head.get(from..to) else {
+            return false;
+        };
+        if !text.bytes().all(|byte| byte.is_ascii_digit()) {
+            return false;
+        }
+        let Ok(parsed) = text.parse::<u32>() else {
+            return false;
+        };
+        *slot = parsed;
+    }
+    let [year, month, day, hour, minute, second] = fields;
+
+    // `(?:\.\d+)?` — a dot with no digit after it is not a fraction.
+    let mut tail = rest;
+    if let Some(fraction) = tail.strip_prefix('.') {
+        let digits = fraction.bytes().take_while(u8::is_ascii_digit).count();
+        let Some(remainder) = fraction.get(digits..) else {
+            return false;
+        };
+        if digits == 0 {
+            return false;
+        }
+        tail = remainder;
+    }
+
+    // `Z` or `±HH:MM`, and nothing else. Lowercase `z` is refused: the shared
+    // reader admits it and this module never has, so delegating the whole
+    // check would have loosened the spelling while tightening the ranges.
+    if tail != "Z" {
+        let Some(offset) = tail.strip_prefix(['+', '-']) else {
+            return false;
+        };
+        let (Some(offset_hour), Some(":"), Some(offset_minute)) =
+            (offset.get(..2), offset.get(2..3), offset.get(3..))
+        else {
+            return false;
+        };
+        let (Ok(offset_hour), Ok(offset_minute)) =
+            (offset_hour.parse::<u32>(), offset_minute.parse::<u32>())
+        else {
+            return false;
+        };
+        // `parse` admits a leading sign and whitespace; the digit check does
+        // not, and the pattern is `\d{2}:\d{2}` exactly.
+        if !offset
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b':')
+            || offset.len() != 5
+            || offset_hour > 23
+            || offset_minute > 59
+        {
+            return false;
+        }
+    }
+
+    (1..=12).contains(&month)
+        && day >= 1
+        && day <= days_in_month(year, month)
+        && hour <= 23
+        && minute <= 59
+        && second <= 59
+}
+
+/// Days in a month, with the full Gregorian leap rule.
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400)) => {
+            29
+        }
+        2 => 28,
+        _ => 0,
+    }
+}
+
+/// `record(name, value)`: an object, and not an array.
+fn record<'a>(
+    name: &str,
+    value: Option<&'a serde_json::Value>,
+) -> Checked<&'a serde_json::Map<String, serde_json::Value>> {
+    match value.and_then(serde_json::Value::as_object) {
+        Some(object) => Ok(object),
+        None => reject(format!("{name} must be an object")),
+    }
+}
+
+/// `arrayAt(object, key)`.
+fn array_at<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Checked<&'a Vec<serde_json::Value>> {
+    match object.get(key).and_then(serde_json::Value::as_array) {
+        Some(array) => Ok(array),
+        None => reject(format!("{key} must be an array")),
+    }
+}
+
+/// `stringAt(object, key)`: a string, non-empty once trimmed.
+fn string_at(object: &serde_json::Map<String, serde_json::Value>, key: &str) -> Checked<String> {
+    let Some(value) = object.get(key).and_then(serde_json::Value::as_str) else {
+        return reject(format!("{key} must be a string"));
+    };
+    if js_trim_is_empty(value) {
+        return reject(format!("{key} must not be empty"));
+    }
+    Ok(value.to_owned())
+}
+
+/// `optionalStringAt(object, key)`.
+///
+/// The distinction that matters is `key in object`, not `value != null`: an
+/// explicit `null` reaches [`string_at`] and is refused. See [`Challenge`].
+fn optional_string_at(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Checked<Option<String>> {
+    if object.contains_key(key) {
+        string_at(object, key).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+/// `exactKeys(object, name, keys)`: no unknown key, and none missing.
+fn exact_keys(
+    object: &serde_json::Map<String, serde_json::Value>,
+    name: &str,
+    keys: &[&str],
+    optional: &[&str],
+) -> Checked<()> {
+    for key in object.keys() {
+        if !keys.contains(&key.as_str()) {
+            return reject(format!("{name} has unknown field {key}"));
+        }
+    }
+    for key in keys {
+        if !optional.contains(key) && !object.contains_key(*key) {
+            return reject(format!("{name} is missing {key}"));
+        }
+    }
+    Ok(())
+}
+
+/// `stringArray(name, value, requireValue)`: strings, unique, optionally non-empty.
+fn string_array(
+    name: &str,
+    value: Option<&serde_json::Value>,
+    require_value: bool,
+) -> Checked<Vec<String>> {
+    let Some(array) = value.and_then(serde_json::Value::as_array) else {
+        return reject(format!(
+            "{name} must be {} array",
+            if require_value { "a non-empty" } else { "an" }
+        ));
+    };
+    if require_value && array.is_empty() {
+        return reject(format!("{name} must be a non-empty array"));
+    }
+    let mut strings = Vec::with_capacity(array.len());
+    for item in array {
+        let Some(text) = item.as_str() else {
+            return reject(format!("{name} must contain strings"));
+        };
+        if js_trim_is_empty(text) {
+            return reject(format!("{name} must not be empty"));
+        }
+        strings.push(text.to_owned());
+    }
+    let mut seen: Vec<&String> = Vec::with_capacity(strings.len());
+    for text in &strings {
+        if seen.contains(&text) {
+            return reject(format!("{name} must contain unique values"));
+        }
+        seen.push(text);
+    }
+    Ok(strings)
+}
+
+/// `literal(value, name, allowed)`: membership, checked at run time.
+fn literal<T: Copy>(
+    value: Option<&serde_json::Value>,
+    name: &str,
+    allowed: &[(&str, T)],
+) -> Checked<T> {
+    if let Some(text) = value.and_then(serde_json::Value::as_str) {
+        for (candidate, mapped) in allowed {
+            if *candidate == text {
+                return Ok(*mapped);
+            }
+        }
+    }
+    let names: Vec<&str> = allowed.iter().map(|(name, _)| *name).collect();
+    reject(format!("{name} must be one of {}", names.join(", ")))
+}
+
+/// `uniqueIds(name, values)`.
+fn unique_ids(name: &str, ids: &[&str]) -> Checked<()> {
+    let mut seen: Vec<&str> = Vec::with_capacity(ids.len());
+    for id in ids {
+        if seen.contains(id) {
+            return reject(format!("{name} contains duplicate id {id}"));
+        }
+        seen.push(id);
+    }
+    Ok(())
+}
+
+/// `/^AA-[0-9]+$/`, without a regex engine.
+fn is_argument_id(id: &str) -> bool {
+    let Some(digits) = id.strip_prefix("AA-") else {
+        return false;
+    };
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Validate the module-owned `AssuranceArgument` frontmatter contract.
+///
+/// # Errors
+///
+/// [`ArgumentError`] for any of the seventeen predicates in the module
+/// documentation. The message reproduces the retained implementation's;
+/// the acceptance decision is what is contractual.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the retained parseAssuranceArgument is one function and splitting \
+              it here would put the reading order somewhere other than the \
+              order the oracle validates in, which is what a reader compares"
+)]
+pub fn parse_assurance_argument(value: &serde_json::Value) -> Checked<AssuranceArgument> {
+    let object = record("argument", Some(value))?;
+    for key in object.keys() {
+        if !ALLOWED.contains(&key.as_str()) {
+            return reject(format!("argument has unknown field {key}"));
+        }
+    }
+
+    let id = string_at(object, "id")?;
+    if !is_argument_id(&id) {
+        return reject("argument id must match AA-<number>");
+    }
+    literal(
+        object.get("type"),
+        "type",
+        &[("AssuranceArgument", ArgumentKind::AssuranceArgument)],
+    )?;
+    let status = literal(
+        object.get("status"),
+        "status",
+        &[
+            ("proposed", ArgumentStatus::Proposed),
+            ("active", ArgumentStatus::Active),
+            ("retired", ArgumentStatus::Retired),
+        ],
+    )?;
+    let profile = string_at(object, "profile")?;
+    if !profile.starts_with("ix://") {
+        return reject("profile must be an ix:// reference");
+    }
+
+    let top = record("top_claim", object.get("top_claim"))?;
+    exact_keys(top, "top_claim", &["id", "statement", "subject"], &[])?;
+
+    let mut reasoning = Vec::new();
+    for (index, item) in array_at(object, "reasoning")?.iter().enumerate() {
+        let name = format!("reasoning[{index}]");
+        let row = record(&name, Some(item))?;
+        exact_keys(
+            row,
+            &name,
+            &["id", "statement", "supports", "sufficiency_criteria"],
+            &[],
+        )?;
+        reasoning.push(Reasoning {
+            id: string_at(row, "id")?,
+            statement: string_at(row, "statement")?,
+            supports: string_at(row, "supports")?,
+            sufficiency_criteria: string_array(
+                &format!("{name}.sufficiency_criteria"),
+                row.get("sufficiency_criteria"),
+                true,
+            )?,
+        });
+    }
+    if reasoning.is_empty() {
+        return reject("reasoning must not be empty");
+    }
+
+    let mut assumptions = Vec::new();
+    for (index, item) in array_at(object, "assumptions")?.iter().enumerate() {
+        let name = format!("assumptions[{index}]");
+        let row = record(&name, Some(item))?;
+        exact_keys(
+            row,
+            &name,
+            &["id", "statement", "owner", "status", "review_by"],
+            &[],
+        )?;
+        let review_by = string_at(row, "review_by")?;
+        if !is_instant(&review_by) {
+            return reject("review_by must be an ISO-8601 instant");
+        }
+        assumptions.push(Assumption {
+            id: string_at(row, "id")?,
+            statement: string_at(row, "statement")?,
+            owner: string_at(row, "owner")?,
+            status: literal(
+                row.get("status"),
+                "assumption status",
+                &[
+                    ("open", AssumptionStatus::Open),
+                    ("accepted", AssumptionStatus::Accepted),
+                    ("invalidated", AssumptionStatus::Invalidated),
+                ],
+            )?,
+            review_by,
+        });
+    }
+
+    let mut participants = Vec::new();
+    for (index, item) in array_at(object, "participants")?.iter().enumerate() {
+        let name = format!("participants[{index}]");
+        let row = record(&name, Some(item))?;
+        exact_keys(
+            row,
+            &name,
+            &["id", "role", "authority", "independence"],
+            &[],
+        )?;
+        participants.push(Participant {
+            id: string_at(row, "id")?,
+            role: string_at(row, "role")?,
+            authority: string_at(row, "authority")?,
+            independence: string_at(row, "independence")?,
+        });
+    }
+    if participants.is_empty() {
+        return reject("participants must not be empty");
+    }
+
+    let mut challenges = Vec::new();
+    for (index, item) in array_at(object, "challenges")?.iter().enumerate() {
+        let name = format!("challenges[{index}]");
+        let row = record(&name, Some(item))?;
+        exact_keys(
+            row,
+            &name,
+            &[
+                "id",
+                "target",
+                "statement",
+                "status",
+                "owner",
+                "resolution_refs",
+                "expires_at",
+            ],
+            &["resolution_refs", "expires_at"],
+        )?;
+        // `optionalStringAt` keys off PRESENCE, so an explicit null is a hard
+        // error here...
+        let expires_at = optional_string_at(row, "expires_at")?;
+        if let Some(instant) = &expires_at
+            && !is_instant(instant)
+        {
+            return reject("expires_at must be an ISO-8601 instant");
+        }
+        // ...while this one keys off TRUTHINESS, so an explicit null is
+        // silently absent. The asymmetry is the retained implementation's and
+        // is reproduced rather than tidied.
+        let resolution_refs = match row.get("resolution_refs") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(_) => Some(string_array(
+                &format!("{name}.resolution_refs"),
+                row.get("resolution_refs"),
+                true,
+            )?),
+        };
+        challenges.push(Challenge {
+            id: string_at(row, "id")?,
+            target: string_at(row, "target")?,
+            statement: string_at(row, "statement")?,
+            status: literal(
+                row.get("status"),
+                "challenge status",
+                &[
+                    ("open", ChallengeStatus::Open),
+                    ("resolved", ChallengeStatus::Resolved),
+                    ("accepted-risk", ChallengeStatus::AcceptedRisk),
+                ],
+            )?,
+            owner: string_at(row, "owner")?,
+            resolution_refs,
+            expires_at,
+        });
+    }
+
+    let mut relationships = Vec::new();
+    for (index, item) in array_at(object, "relationships")?.iter().enumerate() {
+        let name = format!("relationships[{index}]");
+        let row = record(&name, Some(item))?;
+        exact_keys(row, &name, &["target", "type"], &[])?;
+        let target = string_at(row, "target")?;
+        if !target.starts_with("ix://") {
+            return reject(format!("{name}.target must be an ix:// reference"));
+        }
+        relationships.push(Relationship {
+            target,
+            kind: literal(
+                row.get("type"),
+                "relationship type",
+                &[
+                    ("supports", RelationshipType::Supports),
+                    ("challenges", RelationshipType::Challenges),
+                    ("references", RelationshipType::References),
+                ],
+            )?,
+        });
+    }
+
+    unique_ids(
+        "reasoning",
+        &reasoning.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+    )?;
+    unique_ids(
+        "assumptions",
+        &assumptions
+            .iter()
+            .map(|a| a.id.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+    unique_ids(
+        "participants",
+        &participants
+            .iter()
+            .map(|p| p.id.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+    unique_ids(
+        "challenges",
+        &challenges.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+    )?;
+
+    let top_claim_id = string_at(top, "id")?;
+    let mut node_ids: Vec<&str> = vec![top_claim_id.as_str()];
+    node_ids.extend(reasoning.iter().map(|r| r.id.as_str()));
+    node_ids.extend(assumptions.iter().map(|a| a.id.as_str()));
+    {
+        let mut seen: Vec<&str> = Vec::with_capacity(node_ids.len());
+        for id in &node_ids {
+            if seen.contains(id) {
+                return reject("top claim, reasoning, and assumption ids must be unique");
+            }
+            seen.push(id);
+        }
+    }
+
+    // Every chain of `supports` reaches the top claim. Cycle detection is per
+    // START NODE, matching the retained `visited` set: a node reachable from
+    // two starts is walked twice, which is correct — being visited on another
+    // node's walk is not evidence that THIS node reaches the claim. Same
+    // distinction FR-040 records for shared sub-claims (SR-007 FND-001).
+    for start in &reasoning {
+        let mut cursor = start;
+        let mut visited: Vec<&str> = Vec::new();
+        while cursor.supports != top_claim_id {
+            if visited.contains(&cursor.id.as_str()) {
+                return reject(format!(
+                    "reasoning cycle does not reach top claim from {}",
+                    start.id
+                ));
+            }
+            visited.push(cursor.id.as_str());
+            let Some(parent) = reasoning.iter().find(|r| r.id == cursor.supports) else {
+                return reject(format!(
+                    "reasoning {} supports unknown target {}",
+                    start.id, cursor.supports
+                ));
+            };
+            cursor = parent;
+        }
+    }
+
+    for challenge in &challenges {
+        if !node_ids.contains(&challenge.target.as_str()) {
+            return reject(format!(
+                "challenge {} targets unknown argument node {}",
+                challenge.id, challenge.target
+            ));
+        }
+    }
+
+    Ok(AssuranceArgument {
+        id,
+        title: string_at(object, "title")?,
+        kind: ArgumentKind::AssuranceArgument,
+        status,
+        owner: string_at(object, "owner")?,
+        profile,
+        top_claim: TopClaim {
+            id: top_claim_id,
+            statement: string_at(top, "statement")?,
+            subject: string_at(top, "subject")?,
+        },
+        reasoning,
+        assumptions,
+        participants,
+        challenges,
+        relationships,
+    })
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::{is_instant, js_trim_is_empty, parse_assurance_argument};
+
+    fn base() -> serde_json::Value {
+        serde_json::json!({
+            "id": "AA-900",
+            "title": "Synthetic widget release decision",
+            "type": "AssuranceArgument",
+            "status": "active",
+            "owner": "release-owner",
+            "profile": "ix://example.invalid/widget/AP-900",
+            "top_claim": {
+                "id": "CLAIM-900",
+                "statement": "The bounded synthetic widget change is acceptable.",
+                "subject": "widget revision 0123456789abcdef"
+            },
+            "reasoning": [{
+                "id": "ARG-900",
+                "statement": "Argue from the explicitly reviewed clause disposition.",
+                "supports": "CLAIM-900",
+                "sufficiency_criteria": ["Every binding clause has a disposition."]
+            }],
+            "assumptions": [],
+            "participants": [{
+                "id": "reviewer-900",
+                "role": "decision reviewer",
+                "authority": "may accept or reject this synthetic release",
+                "independence": "did not produce the implementation evidence"
+            }],
+            "challenges": [],
+            "relationships": []
+        })
+    }
+
+    #[test]
+    fn accepts_the_minimal_authored_argument() {
+        let parsed = parse_assurance_argument(&base()).expect("the minimal argument is valid");
+        assert_eq!(parsed.id, "AA-900");
+        assert_eq!(parsed.reasoning.len(), 1);
+    }
+
+    /// The two code points where `str::trim` would have been wrong, in
+    /// opposite directions. See [`super::js_trim_is_empty`].
+    #[test]
+    fn js_trim_disagrees_with_rust_trim_in_both_directions() {
+        // U+FEFF: JavaScript trims it, Rust keeps it. A naive port ACCEPTS an
+        // owner the retained implementation refuses.
+        assert!(js_trim_is_empty("\u{FEFF}"));
+        assert!(!"\u{FEFF}".trim().is_empty());
+
+        // U+0085: JavaScript keeps it, Rust trims it. A naive port REFUSES an
+        // owner the retained implementation accepts.
+        assert!(!js_trim_is_empty("\u{0085}"));
+        assert!("\u{0085}".trim().is_empty());
+
+        // Where they agree, they agree.
+        assert!(js_trim_is_empty(" \t\n\u{00A0}\u{3000}"));
+        assert!(!js_trim_is_empty("\u{200B}"));
+    }
+
+    #[test]
+    fn an_owner_of_one_byte_order_mark_is_refused() {
+        let mut argument = base();
+        argument["owner"] = serde_json::json!("\u{FEFF}");
+        assert!(parse_assurance_argument(&argument).is_err());
+    }
+
+    #[test]
+    fn an_owner_of_one_next_line_is_accepted() {
+        let mut argument = base();
+        argument["owner"] = serde_json::json!("\u{0085}");
+        assert!(
+            parse_assurance_argument(&argument).is_ok(),
+            "U+0085 is not whitespace to JavaScript, so the oracle accepts it"
+        );
+    }
+
+    #[test]
+    fn an_explicit_null_is_asymmetric_across_the_two_optional_fields() {
+        let challenge = |extra: serde_json::Value| {
+            let mut argument = base();
+            let mut row = serde_json::json!({
+                "id": "CH-900",
+                "target": "CLAIM-900",
+                "statement": "A bounded recovery case needed review.",
+                "status": "open",
+                "owner": "release-owner"
+            });
+            for (key, value) in extra.as_object().unwrap() {
+                row[key] = value.clone();
+            }
+            argument["challenges"] = serde_json::json!([row]);
+            parse_assurance_argument(&argument)
+        };
+
+        // `optionalStringAt` keys off `key in object`, so the key IS present
+        // and reaches the string check.
+        assert!(
+            challenge(serde_json::json!({ "expires_at": null })).is_err(),
+            "an explicit null expires_at must be refused"
+        );
+        // Truthiness, so null is indistinguishable from absent.
+        let parsed = challenge(serde_json::json!({ "resolution_refs": null }))
+            .expect("an explicit null resolution_refs is silently absent");
+        assert_eq!(parsed.challenges[0].resolution_refs, None);
+    }
+
+    #[test]
+    fn instants_that_name_a_day_or_hour_that_does_not_exist_are_refused() {
+        // quoin#436: `Date.parse` rolled these rather than rejecting them.
+        assert!(!is_instant("2026-02-30T00:00:00Z"));
+        assert!(!is_instant("2026-06-31T00:00:00Z"));
+        assert!(!is_instant("2025-02-29T00:00:00Z"));
+        assert!(!is_instant("2026-08-15T24:00:00Z"));
+        // A leap second, which the retained code refuses and chrono accepts.
+        assert!(!is_instant("2026-08-15T23:59:60Z"));
+        // An offset out of range.
+        assert!(!is_instant("2026-08-15T00:00:00+99:99"));
+        // Lowercase, which this module has never accepted.
+        assert!(!is_instant("2026-08-15t00:00:00Z"));
+        assert!(!is_instant("2026-08-15T00:00:00z"));
+        // A dot with no fraction after it.
+        assert!(!is_instant("2026-08-15T00:00:00.Z"));
+
+        // Accepted: a real leap day, a fraction, and an in-range offset.
+        assert!(is_instant("2028-02-29T00:00:00Z"));
+        assert!(is_instant("2026-08-15T00:00:00.000Z"));
+        assert!(is_instant("2026-08-15T00:00:00+05:30"));
+        assert!(is_instant("2026-08-15T23:59:59-11:00"));
+    }
+
+    #[test]
+    fn a_cycle_is_detected_per_start_node_rather_than_globally() {
+        let mut argument = base();
+        argument["reasoning"] = serde_json::json!([
+            {"id": "A", "statement": "a", "supports": "B", "sufficiency_criteria": ["c"]},
+            {"id": "B", "statement": "b", "supports": "A", "sufficiency_criteria": ["c"]}
+        ]);
+        assert!(parse_assurance_argument(&argument).is_err());
+    }
+
+    #[test]
+    fn a_shared_intermediate_step_is_walked_from_both_starts() {
+        // Neither start is a cycle, and a GLOBAL visited set would have made
+        // the second walk look like one.
+        let mut argument = base();
+        argument["reasoning"] = serde_json::json!([
+            {"id": "A", "statement": "a", "supports": "M", "sufficiency_criteria": ["c"]},
+            {"id": "B", "statement": "b", "supports": "M", "sufficiency_criteria": ["c"]},
+            {"id": "M", "statement": "m", "supports": "CLAIM-900", "sufficiency_criteria": ["c"]}
+        ]);
+        assert!(parse_assurance_argument(&argument).is_ok());
+    }
+
+    #[test]
+    fn an_unlisted_status_is_refused_because_the_retained_code_checks() {
+        // The other half of quoin#425. `Finding::kind` stays a String because
+        // the renderer interpolates; this is checked, so it is closed.
+        let mut argument = base();
+        argument["status"] = serde_json::json!("archived");
+        assert!(parse_assurance_argument(&argument).is_err());
+    }
+}

--- a/rust/crates/quoin-assurance/src/lib.rs
+++ b/rust/crates/quoin-assurance/src/lib.rs
@@ -34,9 +34,15 @@
 //! field subset sizes it from what the code can observe, and those differ by a
 //! factor of five here (quoin#425).
 
+pub mod argument;
 pub mod case;
 pub mod render;
 
+pub use argument::{
+    ArgumentError, ArgumentKind, ArgumentStatus, Assumption, AssumptionStatus, AssuranceArgument,
+    Challenge, ChallengeStatus, Participant, Reasoning, Relationship, RelationshipType, TopClaim,
+    parse_assurance_argument,
+};
 pub use case::{AssuranceCase, CaseInput, CaseNode, NodeKind, NodeStatus, Unreadable, build_case};
 pub use render::{RenderableCase, render_case};
 

--- a/rust/crates/quoin-core/src/dispatch.rs
+++ b/rust/crates/quoin-core/src/dispatch.rs
@@ -31,6 +31,7 @@ pub fn dispatch(op: &str, request: &serde_json::Value) -> Result<Response, CoreE
         "assurance.requirement_of" => crate::ops::assurance::requirement_of(request),
         "assurance.build_case" => crate::ops::assurance::build_case(request),
         "assurance.render_case" => crate::ops::assurance::render_case(request),
+        "assurance.parse_argument" => crate::ops::assurance::parse_argument(request),
         "core.ping" => crate::ops::core::ping(request),
         _ => Err(
             CoreError::new(CoreErrorCode::UnknownOp, "no such operation in this build")

--- a/rust/crates/quoin-core/src/ops/assurance.rs
+++ b/rust/crates/quoin-core/src/ops/assurance.rs
@@ -160,3 +160,43 @@ pub fn render_case(request: &serde_json::Value) -> Result<Response, CoreError> {
 
     Ok(Response::ok(payload))
 }
+
+/// Answer an `assurance.parse_argument`.
+///
+/// **The request IS the argument**, with no wrapper object. Every other
+/// operation in this domain takes named fields because the retained function
+/// does; this one hands the whole request to a validator whose first act is to
+/// refuse any key outside a closed set of twelve. A wrapper would have added a
+/// thirteenth key that exists on neither side of the retained API.
+///
+/// # Errors
+///
+/// - [`CoreErrorCode::BadRequest`] when the request fails any of the retained
+///   contract's predicates.
+/// - [`CoreErrorCode::Refused`] when the request exceeds [`MAX_BUILD_CASE_BYTES`].
+pub fn parse_argument(request: &serde_json::Value) -> Result<Response, CoreError> {
+    // The same ceiling as the two operations above. An authored argument is
+    // far smaller than a built case, but a THIRD constant would be a third
+    // thing to keep in agreement with the reference for no behaviour gained.
+    let size = serde_json::to_vec(request)
+        .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?
+        .len();
+    if size > MAX_BUILD_CASE_BYTES {
+        return Err(
+            CoreError::new(CoreErrorCode::Refused, "request exceeds the accepted size")
+                .with_context("op", "assurance.parse_argument")
+                .with_context("limit_bytes", MAX_BUILD_CASE_BYTES.to_string())
+                .with_context("observed_bytes", size.to_string()),
+        );
+    }
+
+    let argument = quoin_assurance::parse_assurance_argument(request).map_err(|e| {
+        CoreError::new(CoreErrorCode::BadRequest, e.to_string())
+            .with_context("op", "assurance.parse_argument")
+    })?;
+
+    let payload = serde_json::to_value(argument)
+        .map_err(|e| CoreError::new(CoreErrorCode::Io, e.to_string()))?;
+
+    Ok(Response::ok(payload))
+}

--- a/rust/crates/quoin-difftest/src/main.rs
+++ b/rust/crates/quoin-difftest/src/main.rs
@@ -57,6 +57,82 @@ enum Request {
     /// object keys where `JSON.stringify` preserves insertion order. The two
     /// orderings differ; their byte counts do not, which is why this works.
     BuildCaseOfBytes(usize),
+    /// [`ARGUMENT`] with these top-level keys replaced by raw JSON text.
+    ///
+    /// Overrides rather than whole documents because an authored argument is
+    /// twelve required keys deep and a table of forty full copies would hide
+    /// the one field each case is about. An empty override REMOVES the key,
+    /// which a JSON merge-patch could not express: `null` is itself under
+    /// test here — the retained code treats an explicit `null` differently in
+    /// `expires_at` and in `resolution_refs`, so "set to null" and "delete"
+    /// must stay distinguishable.
+    Argument(&'static [(&'static str, &'static str)]),
+    /// [`ARGUMENT`] carrying one assumption whose `review_by` is this text.
+    ///
+    /// Its own variant because the instant grammar is the densest part of the
+    /// contract — an impossible day, a leap second, a rolled hour and two
+    /// lowercase spellings each decide acceptance — and a table of them reads
+    /// as a grammar only if the rows are one line each.
+    ArgumentReviewBy(&'static str),
+}
+
+/// The authored argument every `assurance.parse_argument` case starts from.
+///
+/// Minimal and ACCEPTED: `assumptions`, `challenges` and `relationships` are
+/// empty, so a case that overrides one of them states its whole subject.
+const ARGUMENT: &str = r#"{
+  "id": "AA-900",
+  "title": "Synthetic widget release decision",
+  "type": "AssuranceArgument",
+  "status": "active",
+  "owner": "release-owner",
+  "profile": "ix://example.invalid/widget/AP-900",
+  "top_claim": {
+    "id": "CLAIM-900",
+    "statement": "The bounded synthetic widget change is acceptable.",
+    "subject": "widget revision 0123456789abcdef"
+  },
+  "reasoning": [
+    {
+      "id": "ARG-900",
+      "statement": "Argue from the explicitly reviewed clause disposition.",
+      "supports": "CLAIM-900",
+      "sufficiency_criteria": ["Every binding clause has a disposition."]
+    }
+  ],
+  "assumptions": [],
+  "participants": [
+    {
+      "id": "reviewer-900",
+      "role": "decision reviewer",
+      "authority": "may accept or reject this synthetic release",
+      "independence": "did not produce the implementation evidence"
+    }
+  ],
+  "challenges": [],
+  "relationships": []
+}"#;
+
+/// Apply top-level overrides to [`ARGUMENT`].
+///
+/// A malformed base or override would make every case that used it a request
+/// both sides reject as bad JSON — agreeing, and proving nothing. `arguments_
+/// are_well_formed` below asserts that cannot happen, so the fallbacks here
+/// are unreachable and exist only to keep the harness panic-free.
+fn argument_with(overrides: &[(&str, &str)]) -> String {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(ARGUMENT) else {
+        return String::from("{\"unparseable base\":true}");
+    };
+    if let Some(object) = value.as_object_mut() {
+        for (key, json) in overrides {
+            if json.is_empty() {
+                object.remove(*key);
+            } else if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json) {
+                object.insert((*key).to_owned(), parsed);
+            }
+        }
+    }
+    value.to_string()
 }
 
 /// The `assurance.build_case` request [`Request::BuildCaseOfBytes`] pads.
@@ -76,6 +152,13 @@ impl Request {
                 r#"{{"documents":[],"obligations":[{{"id":"FR-001-AC-1","statement":"{}"}}],"findings":[]}}"#,
                 "x".repeat(n.saturating_sub(BUILD_CASE_ENVELOPE.len()))
             ),
+            Self::Argument(overrides) => argument_with(overrides),
+            Self::ArgumentReviewBy(review_by) => argument_with(&[(
+                "assumptions",
+                &format!(
+                    r#"[{{"id":"ASM-900","statement":"The reviewed clause set is stable.","owner":"release-owner","status":"accepted","review_by":"{review_by}"}}]"#
+                ),
+            )]),
         }
     }
 }
@@ -608,6 +691,370 @@ const CASES: &[Case] = &[
         op: "assurance.render_case",
         request: Request::Literal("{oops"),
     },
+    // ---------------------------------------------------------------------
+    // `assurance.parse_argument` (quoin#384).
+    //
+    // These cases were written BEFORE the Rust type, and that ordering found
+    // things review would not have. Three of them - the U+0085 owner, the
+    // U+FEFF owner, and the explicit `null` in `resolution_refs` - are inputs
+    // a reader of either implementation has no reason to think to ask about,
+    // because on both sides the divergence reads as SAFETY: `Option<T>` and
+    // `str::trim` are the obvious spellings, and each is wrong here in the
+    // direction that ACCEPTS what the retained code refuses.
+    // ---------------------------------------------------------------------
+    Case {
+        name: "assurance/argument-ok-minimal",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[]),
+    },
+    Case {
+        name: "assurance/argument-ok-full",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[
+            (
+                "assumptions",
+                r#"[{"id":"ASM-900","statement":"The reviewed clause set is stable.","owner":"release-owner","status":"accepted","review_by":"2028-02-29T00:00:00Z"}]"#,
+            ),
+            (
+                "challenges",
+                r#"[{"id":"CH-900","target":"ASM-900","statement":"The clause set moved once before.","status":"accepted-risk","owner":"release-owner","resolution_refs":["ix://example.invalid/e/EV-1"],"expires_at":"2029-01-01T00:00:00+05:30"}]"#,
+            ),
+            (
+                "relationships",
+                r#"[{"target":"ix://example.invalid/w/AA-800","type":"supports"}]"#,
+            ),
+        ]),
+    },
+    // --- the instant grammar ---------------------------------------------
+    Case {
+        // quoin#436: `Date.parse` ROLLED this to March 2, and the rolled
+        // number then decided whether the assumption was due for review.
+        name: "assurance/argument-review-by-impossible-day",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-02-30T00:00:00Z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-june-31",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-06-31T00:00:00Z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-non-leap-february-29",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2025-02-29T00:00:00Z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-hour-24",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T24:00:00Z"),
+    },
+    Case {
+        // Refused by both. Named because a date crate would have accepted it.
+        name: "assurance/argument-review-by-leap-second",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T23:59:60Z"),
+    },
+    Case {
+        // The module's own regex is stricter than RFC 3339 on case, and the
+        // shared strict reader it delegates ranges to is not. Delegating the
+        // WHOLE check would have loosened this while tightening the ranges.
+        name: "assurance/argument-review-by-lowercase-t",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15t00:00:00Z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-lowercase-z",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T00:00:00z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-offset-out-of-range",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T00:00:00+99:99"),
+    },
+    Case {
+        name: "assurance/argument-review-by-empty-fraction",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T00:00:00.Z"),
+    },
+    Case {
+        // Accepted, and the reason the tightening is a rule and not a ban.
+        name: "assurance/argument-review-by-real-leap-day",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2028-02-29T00:00:00Z"),
+    },
+    Case {
+        name: "assurance/argument-review-by-offset-and-fraction",
+        op: "assurance.parse_argument",
+        request: Request::ArgumentReviewBy("2026-08-15T23:59:59.250-11:00"),
+    },
+    // --- the two optional fields are not optional in the same way ---------
+    Case {
+        // `optionalStringAt` keys off `key in object`, so an explicit null
+        // reaches the string check and THROWS.
+        name: "assurance/argument-challenge-expires-at-null",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"open","owner":"release-owner","expires_at":null}]"#,
+        )]),
+    },
+    Case {
+        // The sibling field is read through TRUTHINESS, so the identical
+        // explicit null is silently absent. `Option<String>` collapses the
+        // two, which is why this port is written against `Value`.
+        name: "assurance/argument-challenge-resolution-refs-null",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"open","owner":"release-owner","resolution_refs":null}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-challenge-resolution-refs-empty",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"open","owner":"release-owner","resolution_refs":[]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-challenge-resolution-refs-duplicated",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"open","owner":"release-owner","resolution_refs":["ix://e/1","ix://e/1"]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-challenge-missing-owner",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"open"}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-challenge-unknown-target",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"NOPE-1","statement":"A bounded recovery case needed review.","status":"open","owner":"release-owner"}]"#,
+        )]),
+    },
+    // --- JavaScript's trim set is not Rust's ------------------------------
+    Case {
+        // U+FEFF: JavaScript trims it, `char::is_whitespace` does not. A port
+        // that reached for `str::trim` ACCEPTS this owner; the oracle refuses
+        // it.
+        name: "assurance/argument-owner-byte-order-mark",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("owner", r#""\ufeff""#)]),
+    },
+    Case {
+        // U+0085: the same two disagree in the OPPOSITE direction, so the one
+        // wrong call would have been wrong twice. Accepted by the oracle.
+        name: "assurance/argument-owner-next-line",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("owner", r#""\u0085""#)]),
+    },
+    Case {
+        // Where the two agree, they agree: refused by both.
+        name: "assurance/argument-owner-no-break-space",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("owner", r#""\u00a0""#)]),
+    },
+    Case {
+        // Accepted by both: not whitespace to either.
+        name: "assurance/argument-owner-zero-width-space",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("owner", r#""\u200b""#)]),
+    },
+    Case {
+        name: "assurance/argument-owner-empty",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("owner", r#""""#)]),
+    },
+    // --- five enumerations, closed because the retained code checks -------
+    Case {
+        name: "assurance/argument-status-unlisted",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("status", r#""archived""#)]),
+    },
+    Case {
+        name: "assurance/argument-type-unlisted",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("type", r#""AssuranceCase""#)]),
+    },
+    Case {
+        name: "assurance/argument-assumption-status-unlisted",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "assumptions",
+            r#"[{"id":"ASM-900","statement":"The reviewed clause set is stable.","owner":"release-owner","status":"withdrawn","review_by":"2028-02-29T00:00:00Z"}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-challenge-status-unlisted",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "challenges",
+            r#"[{"id":"CH-900","target":"CLAIM-900","statement":"A bounded recovery case needed review.","status":"accepted_risk","owner":"release-owner"}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-relationship-type-unlisted",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "relationships",
+            r#"[{"target":"ix://example.invalid/w/AA-800","type":"refutes"}]"#,
+        )]),
+    },
+    // --- closed key sets, at the top level and nested ---------------------
+    Case {
+        name: "assurance/argument-unknown-top-level-key",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("schemaVersion", r#""v1""#)]),
+    },
+    Case {
+        name: "assurance/argument-top-claim-unknown-key",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "top_claim",
+            r#"{"id":"CLAIM-900","statement":"S","subject":"widget","confidence":"high"}"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-top-claim-missing-subject",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("top_claim", r#"{"id":"CLAIM-900","statement":"S"}"#)]),
+    },
+    Case {
+        name: "assurance/argument-top-claim-not-an-object",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("top_claim", r#"["CLAIM-900"]"#)]),
+    },
+    Case {
+        name: "assurance/argument-missing-relationships",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("relationships", "")]),
+    },
+    Case {
+        name: "assurance/argument-reasoning-not-an-array",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("reasoning", r#"{"id":"ARG-900"}"#)]),
+    },
+    Case {
+        name: "assurance/argument-reasoning-empty",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("reasoning", "[]")]),
+    },
+    Case {
+        name: "assurance/argument-participants-empty",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("participants", "[]")]),
+    },
+    // --- format, uniqueness and the graph ---------------------------------
+    Case {
+        name: "assurance/argument-id-not-numbered",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("id", r#""AA-nine-hundred""#)]),
+    },
+    Case {
+        name: "assurance/argument-id-not-a-string",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("id", "900")]),
+    },
+    Case {
+        name: "assurance/argument-profile-not-a-reference",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[("profile", r#""https://example.invalid/AP-900""#)]),
+    },
+    Case {
+        name: "assurance/argument-relationship-target-not-a-reference",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "relationships",
+            r#"[{"target":"AA-800","type":"supports"}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-criteria-not-strings",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"ARG-900","statement":"R","supports":"CLAIM-900","sufficiency_criteria":[1]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-criteria-empty",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"ARG-900","statement":"R","supports":"CLAIM-900","sufficiency_criteria":[]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-criteria-duplicated",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"ARG-900","statement":"R","supports":"CLAIM-900","sufficiency_criteria":["c","c"]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-duplicate-reasoning-id",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"ARG-900","statement":"R","supports":"CLAIM-900","sufficiency_criteria":["c"]},{"id":"ARG-900","statement":"R2","supports":"CLAIM-900","sufficiency_criteria":["d"]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-assumption-collides-with-top-claim",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "assumptions",
+            r#"[{"id":"CLAIM-900","statement":"The reviewed clause set is stable.","owner":"release-owner","status":"accepted","review_by":"2028-02-29T00:00:00Z"}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-supports-unknown-target",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"ARG-900","statement":"R","supports":"NOPE-1","sufficiency_criteria":["c"]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-reasoning-cycle",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"A","statement":"a","supports":"B","sufficiency_criteria":["c"]},{"id":"B","statement":"b","supports":"A","sufficiency_criteria":["d"]}]"#,
+        )]),
+    },
+    Case {
+        // Neither start is a cycle. A GLOBAL visited set would have made the
+        // second walk look like one, which is why the retained code resets it
+        // per start node and this port does too.
+        name: "assurance/argument-shared-intermediate-step",
+        op: "assurance.parse_argument",
+        request: Request::Argument(&[(
+            "reasoning",
+            r#"[{"id":"A","statement":"a","supports":"M","sufficiency_criteria":["c"]},{"id":"B","statement":"b","supports":"M","sufficiency_criteria":["d"]},{"id":"M","statement":"m","supports":"CLAIM-900","sufficiency_criteria":["e"]}]"#,
+        )]),
+    },
+    Case {
+        name: "assurance/argument-malformed",
+        op: "assurance.parse_argument",
+        request: Request::Literal("{oops"),
+    },
+    Case {
+        name: "assurance/argument-not-an-object",
+        op: "assurance.parse_argument",
+        request: Request::Literal("[]"),
+    },
     Case {
         name: "invalid/unknown-op",
         op: "evidence.record",
@@ -791,4 +1238,63 @@ fn usage(missing: &str) -> std::process::ExitCode {
     eprintln!("quoin-difftest: missing {missing}");
     eprintln!("usage: quoin-difftest --core <path> --ts <path> [--node <node>]");
     std::process::ExitCode::from(2)
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "in a test, a panic IS the failure report; the production lints stand"
+)]
+mod tests {
+    use super::{ARGUMENT, CASES, Request};
+
+    /// Every `assurance.parse_argument` request is well-formed JSON.
+    ///
+    /// Without this, a typo in an override would produce a request BOTH sides
+    /// reject as bad JSON — a case that passes, proves nothing, and looks
+    /// exactly like one that works. The same vacuity `argument_with`'s
+    /// fallbacks would otherwise hide.
+    #[test]
+    fn argument_requests_are_well_formed() {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(ARGUMENT).is_ok(),
+            "the base argument must parse"
+        );
+        for case in CASES {
+            let (Request::Argument(_) | Request::ArgumentReviewBy(_)) = case.request else {
+                continue;
+            };
+            let text = case.request.text();
+            let parsed = serde_json::from_str::<serde_json::Value>(&text);
+            assert!(
+                parsed.is_ok_and(|value| value.is_object()),
+                "case {} produced a request that is not a JSON object: {text}",
+                case.name
+            );
+        }
+    }
+
+    /// Every override names a key the base argument already carries.
+    ///
+    /// An override spelled `resolution_ref` would silently ADD a thirteenth
+    /// top-level key, and the case would then be testing the closed key set
+    /// rather than the field it is named for. `schemaVersion` is the one case
+    /// that means to do that, so it is listed.
+    #[test]
+    fn argument_overrides_name_existing_keys() {
+        let base = serde_json::from_str::<serde_json::Value>(ARGUMENT).unwrap();
+        let base = base.as_object().unwrap();
+        for case in CASES {
+            let Request::Argument(overrides) = case.request else {
+                continue;
+            };
+            for (key, _) in overrides {
+                assert!(
+                    base.contains_key(*key) || *key == "schemaVersion",
+                    "case {} overrides `{key}`, which the base argument does not carry",
+                    case.name
+                );
+            }
+        }
+    }
 }

--- a/src/core/reference.ts
+++ b/src/core/reference.ts
@@ -14,7 +14,12 @@
  * transliteration of one implementation would agree with itself.
  */
 
-import { buildCase, renderCase, requirementOf } from "../assurance/index.js";
+import {
+  buildCase,
+  parseAssuranceArgument,
+  renderCase,
+  requirementOf,
+} from "../assurance/index.js";
 
 /** Mirrors `quoin_core::protocol::PROTOCOL_VERSION` — deliberately restated,
  * not imported from the generated `./types.js`: this file is the differential
@@ -152,12 +157,15 @@ export function reference(argv: string[], stdin: string): ReferenceOutcome {
   if (op === "assurance.render_case") {
     return assuranceRenderCase(parsed);
   }
+  if (op === "assurance.parse_argument") {
+    return assuranceParseArgument(parsed);
+  }
   if (op !== "core.ping") {
     return failure(
       3,
       diagnostic("CORE_UNKNOWN_OP", "no such operation in this build", {
         known:
-          "assurance.build_case, assurance.render_case, assurance.requirement_of, core.ping",
+          "assurance.build_case, assurance.parse_argument, assurance.render_case, assurance.requirement_of, core.ping",
         op,
       }),
     );
@@ -424,6 +432,57 @@ function assuranceBuildCase(fields: Record<string, unknown>): ReferenceOutcome {
       : {}),
   });
   return { exitCode: 0, payload: canonicalJson(built), diagnostics: [] };
+}
+
+/**
+ * `assurance.parse_argument`, answered by the RETAINED implementation.
+ *
+ * **The request IS the argument**, with no wrapper object. Every other
+ * operation here takes named fields because the retained function does; this
+ * one takes a single `unknown` and its first act is to refuse any key outside
+ * a closed set of twelve. A wrapper would have introduced a thirteenth key
+ * that exists on neither side of the retained API, and the closed set already
+ * gives the boundary the "unknown field" verdict a wrapper would have added.
+ *
+ * **There is no parity validation here, and that is the difference from
+ * `assuranceBuildCase`.** The two operations above lean on serde to reject a
+ * malformed request, so the reference had to grow a hand-written copy of what
+ * serde refuses or the sides would disagree on every bad input. This operation
+ * has no derive: the Rust port reads `serde_json::Value` directly and
+ * reimplements all seventeen of the retained predicates, because three of them
+ * — the asymmetric `null`, JavaScript's trim set, and the impossible-date
+ * check — are ones no derive can express. So the validation this function
+ * would otherwise duplicate is already the thing under comparison.
+ */
+function assuranceParseArgument(
+  fields: Record<string, unknown>,
+): ReferenceOutcome {
+  const op = "assurance.parse_argument";
+
+  const size = Buffer.byteLength(JSON.stringify(fields), "utf8");
+  if (size > MAX_BUILD_CASE_BYTES) {
+    return failure(
+      2,
+      diagnostic("CORE_REFUSED", "request exceeds the accepted size", {
+        limit_bytes: String(MAX_BUILD_CASE_BYTES),
+        observed_bytes: String(size),
+        op,
+      }),
+    );
+  }
+
+  try {
+    return {
+      exitCode: 0,
+      payload: canonicalJson(parseAssuranceArgument(fields)),
+      diagnostics: [],
+    };
+  } catch (cause) {
+    return failure(
+      3,
+      diagnostic("CORE_BAD_REQUEST", (cause as Error).message, { op }),
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Fourth slice of the `src/assurance/` port (#384, EPIC #373), and the first **validator**.

## What the sizing instrument said this time

The three slices before this sized by measuring the field subset the operation can observe. `build_case`'s import list overstated the work 5x; `render_case`'s understated it — one line of imports, 14 fields across 3 types the imports never name.

`parseAssuranceArgument` measures **37 fields out of 37**. 100%, and the number carries no information, because reading every field IS what a validator does. The work is in **seventeen predicates the shape does not state**: 4 format rules, 3 non-emptiness rules, 6 uniqueness rules, 2 graph reachability rules, 1 instant grammar.

So #425's rule generalises rather than repeats:

> The sizing instrument is not a measurement. It is a question — what does this operation actually do, and what is the unit of that? Transformers size by reachable field subset. Renderers size by the fields of types the imports never name. Validators size by predicate count.

## Why there is no `#[derive(Deserialize)]`

A derive with `deny_unknown_fields` reproduces the twelve-key closed set and none of the seventeen predicates. Worse, it is wrong in the direction nobody reviews.

**Permissiveness runs both ways.** A port that ACCEPTS input the retained implementation refuses is exactly as much a divergence as one that refuses what it accepts — and serde's two over-permission mechanisms, `Option<T>` and `#[serde(default)]`, are invisible in review *because they read as safety*. Three hazards here are of that kind:

**1. The null is asymmetric.** The retained code reads the two optional challenge fields through different mechanisms:

```ts
const expiresAt = optionalStringAt(row, "expires_at");   // `key in object`
const resolutionRefs = row.resolution_refs ? ... : undefined;   // truthiness
```

`{"expires_at": null}` **throws**. `{"resolution_refs": null}` is **silently absent**. `Option<String>` collapses both, and nothing in the two declarations says which is which.

**2. JavaScript's trim set is not Rust's, in both directions.** Measured over every relevant code point — exactly two disagreements, opposed:

| code point | `String.prototype.trim` | `char::is_whitespace` | a naive `str::trim` port |
|---|---|---|---|
| `U+FEFF` | trims | keeps | **accepts** what the oracle refuses |
| `U+0085` | keeps | trims | **refuses** what the oracle accepts |

One call would have been wrong twice. The ECMA-262 set is transcribed with the reason in a comment so the next reader does not "fix" it.

**3. The instant grammar is hand-written, no date crate.** Uppercase `T`/`Z` only, leap seconds refused, impossible days refused. No crate's defaults are that combination — and #436 had just fixed the retained half.

## Closed enums, and why the answer differs from #425

Five TypeScript unions become closed Rust enums. #425 answered the opposite for `Finding.kind` and `CaseNode.kind` — open, because the retained renderer interpolates whatever arrives. The test is not "is it a union", it is **"does the retained code check membership at run time"**. These five go through `literal()`, which checks and throws.

## Cases before the type

51 difftest cases written **before** the Rust type. Hazards 1 and 2 are inputs no reviewer would think to ask for; each was caught by a case that existed before the code it constrains.

Every tightening run **unfixed-first**, as standing discipline:

| naive implementation | cases that fail |
|---|---|
| `str::trim().is_empty()` | 2 — in opposite directions |
| `Option`-shaped null | 1 |
| shape-only instant (no ranges) | 5 |

Two guard tests assert every generated request parses as a JSON object and every override names a key the base carries — without them a typo produces a request both sides reject as bad JSON: a case that passes and proves nothing.

## The boundary

The request **IS** the argument, with no wrapper. The closed twelve-key set already produces the unknown-field verdict a wrapper would have added, and a wrapper would have introduced a thirteenth key existing on neither side of the retained API.

## Verification

- `make rust-gate` — fmt, clippy `-D warnings`, cargo deny, tests, e2e, difftest: green
- **123 difftest cases, 0 differences** (72 before this branch)
- `pnpm run lint` clean; TS suite 1169 passed. `tests/verification-relock.test.ts` timed out under full-suite parallel load (48s of a 60s budget) and passes alone — environmental, untouched by this branch.

Refs #384, #373, #425, #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4qKWaqT3xCXMbbtDqdDRY