### PR TITLE
OPERATIONS is every operation dispatch routes, and a guard keeps it so (#443)

### DIFF
--- a/rust/crates/quoin-core/src/dispatch.rs
+++ b/rust/crates/quoin-core/src/dispatch.rs
@@ -15,7 +15,13 @@ use crate::protocol::Response;
 ///
 /// Exposed so a caller — and `quoin-difftest` — can enumerate the surface
 /// rather than discover it by trying names.
-pub const OPERATIONS: &[&str] = &["core.ping"];
+pub const OPERATIONS: &[&str] = &[
+    "assurance.build_case",
+    "assurance.parse_argument",
+    "assurance.render_case",
+    "assurance.requirement_of",
+    "core.ping",
+];
 
 /// Route one request.
 ///
@@ -106,18 +112,86 @@ pub fn parse_operation(args: &[String]) -> Result<&str, CoreError> {
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
+    clippy::expect_used,
     clippy::indexing_slicing,
     reason = "in a test, a panic IS the failure report; the production lints stand"
 )]
 mod tests {
     use super::*;
 
+    /// Every `"…" =>` arm of `dispatch`'s match, read out of this file's own
+    /// source.
+    ///
+    /// `OPERATIONS` is a hand-written list standing beside an exhaustive
+    /// `match`, and the compiler checks neither against the other. It drifted
+    /// on four consecutive additions (#426, #431, #435, #441) and stayed green
+    /// throughout, because the test that was supposed to catch it asserted a
+    /// literal — `known == "core.ping"` — which is exactly the stale value. A
+    /// test that reads the same hand-written string it is guarding cannot
+    /// notice it going stale (#443).
+    ///
+    /// Reading the source is the only instrument available: Rust cannot
+    /// enumerate a match's arms at compile time, and enumerating them at run
+    /// time would mean the run-time registry this module's own doc comment
+    /// refuses.
+    fn routed_operations() -> Vec<String> {
+        let source = include_str!("dispatch.rs");
+        let body = source
+            .split_once("pub fn dispatch(")
+            .expect("dispatch is defined in this file")
+            .1
+            .split_once("\n}")
+            .expect("dispatch's body is brace-terminated")
+            .0;
+        let mut routed: Vec<String> = body
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix('"'))
+            .filter_map(|rest| rest.split_once("\" =>"))
+            .map(|(name, _)| name.to_owned())
+            .collect();
+        routed.sort();
+        routed
+    }
+
+    #[test]
+    fn the_operations_const_is_every_operation_dispatch_routes() {
+        let mut declared: Vec<String> = OPERATIONS.iter().map(|op| (*op).to_owned()).collect();
+        declared.sort();
+        assert_eq!(
+            declared,
+            routed_operations(),
+            "`OPERATIONS` and `dispatch`'s match disagree. Whichever was edited, \
+             edit the other: the const is what a caller and `quoin-difftest` \
+             enumerate, and the unknown-op error reports it to the user."
+        );
+    }
+
+    #[test]
+    fn the_drift_guard_can_see_the_arms_it_guards() {
+        // Without this, a refactor that changes `dispatch`'s formatting turns
+        // the guard above into a comparison of two empty lists, which passes.
+        // A check over an empty population is the failure this ticket is about.
+        assert!(
+            routed_operations().len() >= 2,
+            "the source scan found {} arm(s); it has stopped reading `dispatch`",
+            routed_operations().len()
+        );
+    }
+
     #[test]
     fn an_unknown_operation_names_the_ones_that_exist() {
         let error = dispatch("evidence.record", &serde_json::json!({})).unwrap_err();
         assert_eq!(error.code, CoreErrorCode::UnknownOp);
         assert_eq!(error.outcome().code(), 3);
-        assert_eq!(error.context["known"], "core.ping");
+        assert_eq!(error.context["known"], OPERATIONS.join(","));
+        // Not a tautology against the line above: this is the fact a user
+        // reads off a mistyped operation, and `dispatch` builds the string
+        // itself. The value is pinned by the drift guard, not by this test.
+        assert!(
+            error.context["known"].contains("assurance.build_case"),
+            "known: {}",
+            error.context["known"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
`OPERATIONS` declared `["core.ping"]` while `dispatch` routed five. Four operations were added across #426, #431, #435 and #441 and none updated the const — drift on four out of four additions.

User-visible: the unknown-op error attaches `known: OPERATIONS.join(",")`, so anyone who mistyped an operation was told the build knows only `core.ping` while standing in front of a build that answers four more.

**The gate enforced the lie.** `an_unknown_operation_names_the_ones_that_exist` asserted `known == "core.ping"` — the stale literal itself. A test that reads the same hand-written string it guards cannot notice that string going stale.

So the fix is not only the list:

- `routed_operations()` reads this file's own source and extracts every `"…" =>` arm of `dispatch`'s match. Rust cannot enumerate a match's arms at compile time, and doing it at run time would mean the run-time registry this module's doc comment explicitly refuses.
- `the_operations_const_is_every_operation_dispatch_routes` compares that set against `OPERATIONS`. Run against the unfixed const it fails and names both sides.
- `the_drift_guard_can_see_the_arms_it_guards` asserts the scan found arms at all — a formatting refactor must not quietly turn the guard into a comparison of two empty lists. A check passing over an empty population is the failure this ticket is about.
- the unknown-op test asserts the error reports `OPERATIONS` and that the string contains an assurance operation, instead of pinning a literal.

`make rust-gate` green: fmt, clippy -D warnings, cargo deny, tests, the end-to-end caller, 123 difftest cases, 0 differences.

Closes #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXzHssfDmjdPz89YBdjqqp